### PR TITLE
Subscription bugfix / ensuring entity uniqueness

### DIFF
--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -14,7 +14,9 @@ pub trait Model {
     type View: View;
     type Mutable<'trx>: Mutable<'trx>;
     fn collection() -> CollectionId;
-    fn create_entity(&self, id: ID) -> Entity;
+    // TODO - this seems to be necessary, but I don't understand why
+    // Backend fields should be getting initialized on demand when the values are set
+    fn initialize_new_entity(&self, entity: &Entity);
 }
 
 /// A read only view of an Entity which offers typed accessors

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -54,9 +54,9 @@ impl Transaction {
     }
 
     pub async fn create<'rec, 'trx: 'rec, M: Model>(&'trx self, model: &M) -> M::Mutable<'rec> {
-        let id = self.dyncontext.next_entity_id();
-        let new_entity = model.create_entity(id);
-        let entity_ref = self.add_entity(new_entity);
+        let entity = self.dyncontext.create_entity(M::collection());
+        model.initialize_new_entity(&entity);
+        let entity_ref = self.add_entity(entity);
         <M::Mutable<'rec> as Mutable<'rec>>::new(entity_ref)
     }
     // TODO - get rid of this in favor of directly cloning the entity of the ModelView struct
@@ -85,7 +85,7 @@ impl Transaction {
                 if let Some(upstream) = &entity.upstream {
                     upstream.apply_event(&entity_event)?;
                 } else {
-                    self.dyncontext.insert_entity(entity.clone()).await?;
+                    // Entitity is already updated
                 }
                 entity_events.push(entity_event);
             }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -149,7 +149,9 @@ pub fn derive_model_impl(stream: TokenStream) -> TokenStream {
                 #[wasm_bindgen]
                 impl #resultset_name {
                     #[wasm_bindgen(getter)]
-                    pub fn items(&self) -> Vec<#view_name> { self.0.items.to_vec() }
+                    pub fn items(&self) -> Vec<#view_name> {
+                        self.0.items.to_vec()
+                    }
                     pub fn by_id(&self, id: ::ankurah::derive_deps::ankurah_proto::ID) -> Option<#view_name> {
                         self.0.items.iter().find(|item| item.id() == id).map(|item| item.clone())
                         // todo generate a map on demand if there are more than a certain number of items (benchmark this)
@@ -189,19 +191,11 @@ pub fn derive_model_impl(stream: TokenStream) -> TokenStream {
             fn collection() -> ankurah::derive_deps::ankurah_proto::CollectionId {
                 #collection_str.into()
             }
-            fn create_entity(&self, id: ::ankurah::derive_deps::ankurah_proto::ID) -> ::ankurah::entity::Entity {
-                use ankurah::property::InitializeWith;
-
-                let backends = ankurah::property::Backends::new();
-                let entity = ankurah::entity::Entity::create(
-                    id,
-                    Self::collection(),
-                    backends
-                );
+            fn initialize_new_entity(&self, entity: &::ankurah::entity::Entity) {
+                use ::ankurah::property::InitializeWith;
                 #(
                     #active_field_types_turbofish::initialize_with(&entity, #active_field_name_strs.into(), &self.#active_field_names);
                 )*
-                entity
             }
         }
 

--- a/storage/indexeddb-wasm/src/indexeddb.rs
+++ b/storage/indexeddb-wasm/src/indexeddb.rs
@@ -1,5 +1,5 @@
 use ankql::selection::filter::evaluate_predicate;
-use ankurah_core::entity::Entity;
+use ankurah_core::entity::TemporaryEntity;
 use ankurah_core::error::RetrievalError;
 use ankurah_core::storage::{StorageCollection, StorageEngine};
 use ankurah_proto as proto;
@@ -323,7 +323,7 @@ impl StorageCollection for IndexedDBBucket {
                 let entity_state = proto::State { state_buffers, head };
 
                 // Create entity to evaluate predicate
-                let entity = Entity::from_state(id, collection_id.clone(), &entity_state)?;
+                let entity = TemporaryEntity::new(id, collection_id.clone(), &entity_state)?;
 
                 // Apply predicate filter
                 if evaluate_predicate(&entity, predicate)? {

--- a/storage/sled/src/sled.rs
+++ b/storage/sled/src/sled.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use tracing::warn;
 
 use ankurah_core::{
-    entity::Entity,
+    entity::TemporaryEntity,
     error::RetrievalError,
     storage::{StorageCollection, StorageEngine},
 };
@@ -126,7 +126,7 @@ impl StorageCollection for SledStorageCollection {
                 let entity_state: State = bincode::deserialize(&value_bytes)?;
 
                 // Create entity to evaluate predicate
-                let entity = Entity::from_state(id, collection_id.clone(), &entity_state)?;
+                let entity = TemporaryEntity::new(id, collection_id.clone(), &entity_state)?;
 
                 // Apply predicate filter
                 if evaluate_predicate(&entity, &predicate)? {


### PR DESCRIPTION
Addresses an issue where multiple instances of the same entity were getting created.  This was allowing consumers to get a reference to an entity that would then no longer get updates to that entity, and would become stale.  This PR attempts to ensure that all requests to create / update an entity go through the new `EntitySet` so that we can more easily maintain the uniqueness of entities, essentially treating each entity as a singleton.