### PR TITLE
Bugfix for EntityId filtering

### DIFF
--- a/core/src/entity.rs
+++ b/core/src/entity.rs
@@ -272,7 +272,7 @@ impl Filterable for Entity {
     /// to the requested type. (need to think about the rust type system here more)
     fn value(&self, name: &str) -> Option<String> {
         if name == "id" {
-            Some(self.id.to_string())
+            Some(self.id.to_base64())
         } else {
             // Iterate through backends to find one that has this property
             let backends = self.backends.backends.lock().unwrap();
@@ -305,7 +305,7 @@ impl Filterable for TemporaryEntity {
 
     fn value(&self, name: &str) -> Option<String> {
         if name == "id" {
-            Some(self.0.id.to_string())
+            Some(self.0.id.to_base64())
         } else {
             // Iterate through backends to find one that has this property
             let backends = self.0.backends.backends.lock().unwrap();

--- a/proto/src/clock.rs
+++ b/proto/src/clock.rs
@@ -19,7 +19,7 @@ impl Clock {
 
     pub fn as_slice(&self) -> &[EventId] { &self.0 }
 
-    pub fn to_strings(&self) -> Vec<String> { self.0.iter().map(|id| id.to_string()).collect() }
+    pub fn to_strings(&self) -> Vec<String> { self.0.iter().map(|id| id.to_base64()).collect() }
 
     pub fn from_strings(strings: Vec<String>) -> Result<Self, DecodeError> {
         let mut ids = strings.into_iter().map(|s| s.try_into()).collect::<Result<Vec<_>, _>>()?;

--- a/proto/src/data.rs
+++ b/proto/src/data.rs
@@ -26,6 +26,11 @@ impl EventId {
         use base64::{engine::general_purpose, Engine as _};
         general_purpose::URL_SAFE_NO_PAD.encode(self.0)
     }
+    pub fn to_base64_short(&self) -> String {
+        // take the last 6 characters of the base64 encoded string
+        let value = self.to_base64();
+        value[value.len() - 6..].to_string()
+    }
     pub fn from_base64<T: AsRef<[u8]>>(input: T) -> Result<Self, DecodeError> {
         use base64::{engine::general_purpose, Engine as _};
         let decoded = general_purpose::URL_SAFE_NO_PAD.decode(input)?;

--- a/proto/src/id.rs
+++ b/proto/src/id.rs
@@ -47,7 +47,7 @@ impl EntityId {
 }
 
 impl fmt::Display for EntityId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> { write!(f, "{}", self.to_base64_short()) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> { write!(f, "{}", self.to_base64()) }
 }
 
 impl TryFrom<&str> for EntityId {

--- a/proto/src/request.rs
+++ b/proto/src/request.rs
@@ -82,10 +82,10 @@ impl std::fmt::Display for NodeRequestBody {
                 write!(f, "CommitTransaction {id} [{}]", events.iter().map(|e| format!("{}", e)).collect::<Vec<_>>().join(", "))
             }
             NodeRequestBody::Get { collection, ids } => {
-                write!(f, "Get {collection} {}", ids.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", "))
+                write!(f, "Get {collection} {}", ids.iter().map(|id| id.to_base64_short()).collect::<Vec<_>>().join(", "))
             }
             NodeRequestBody::GetEvents { collection, event_ids } => {
-                write!(f, "GetEvents {collection} {}", event_ids.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", "))
+                write!(f, "GetEvents {collection} {}", event_ids.iter().map(|id| id.to_base64_short()).collect::<Vec<_>>().join(", "))
             }
             NodeRequestBody::Fetch { collection, predicate } => {
                 write!(f, "Fetch {collection} {predicate}")

--- a/storage/indexeddb-wasm/src/indexeddb.rs
+++ b/storage/indexeddb-wasm/src/indexeddb.rs
@@ -390,7 +390,7 @@ impl StorageCollection for IndexedDBBucket {
             // TODO - do we want to use a cursor? The id space is pretty sparse, so we would probably need benchmarks to see if it's worth it
             let mut events = Vec::new();
             for event_id in event_ids {
-                let request = step(store.get(&event_id.to_string().into()), "get event")?;
+                let request = step(store.get(&event_id.to_base64().into()), "get event")?;
                 step(CBFuture::new(&request, "success", "error").await, "await event request")?;
                 let result = step(request.result(), "get result")?;
 

--- a/tests/tests/policy_angent.rs
+++ b/tests/tests/policy_angent.rs
@@ -315,7 +315,7 @@
 //     ) -> Result<Option<proto::Attestation>, AccessDenied> {
 //         self.check_write(cdata, entity, Some(event))?;
 //         Ok(Some(proto::Attestation(
-//             serde_json::to_vec(&MyAttestation { node_id: node.id.to_string(), signature: "shibboleet".to_string() }).unwrap(),
+//             serde_json::to_vec(&MyAttestation { node_id: node.id.to_base64(), signature: "shibboleet".to_string() }).unwrap(),
 //         )))
 //     }
 


### PR DESCRIPTION
Entity filtering was using the to_base64_short by accident. Decided to make it much more explicit when you get the short version