### PR TITLE
Boolean literal support.

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -12,8 +12,9 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+
+      - name: Install rustfmt
+        run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
       - name: Install Taplo
         run: cargo install taplo-cli


### PR DESCRIPTION
Adds support for queries like:

```SQL
enabled = TRUE
```