### PR TITLE
Event retrieval bugfix, reorg methods under NodeAndContext, misc cleanups

### DIFF
--- a/core/src/entity.rs
+++ b/core/src/entity.rs
@@ -343,35 +343,41 @@ impl WeakEntitySet {
         }
     }
 
-    pub async fn get_or_retrieve(
+    pub async fn get_or_retrieve<R>(
         &self,
+        retriever: &R,
         collection_id: &CollectionId,
-        collection: &StorageCollectionWrapper,
         id: &EntityId,
-    ) -> Result<Option<Entity>, RetrievalError> {
+    ) -> Result<Option<Entity>, RetrievalError>
+    where
+        R: Retrieve<Id = EventId, Event = Event> + Send + Sync,
+    {
         // do it in two phases to avoid holding the lock while waiting for the collection
         match self.get(id) {
             Some(entity) => Ok(Some(entity)),
-            None => match collection.get_state(*id).await {
-                Err(RetrievalError::EntityNotFound(_)) => Ok(None),
-                Err(e) => Err(e),
-                Ok(state) => {
+            None => match retriever.get_state(*id).await {
+                Ok(None) => Ok(None),
+                Ok(Some(state)) => {
                     // technically someone could have added the entity since we last checked, so it's better to use the
                     // with_state method to re-check
-                    let (_, entity) = self.with_state(collection, *id, collection_id.to_owned(), state.payload.state).await?;
+                    let (_, entity) = self.with_state(retriever, *id, collection_id.to_owned(), state.payload.state).await?;
                     Ok(Some(entity))
                 }
+                Err(e) => Err(e),
             },
         }
     }
     /// Returns a resident entity, or fetches it from storage, or finally creates if neither of the two are found
-    pub async fn get_retrieve_or_create(
+    pub async fn get_retrieve_or_create<R>(
         &self,
+        retriever: &R,
         collection_id: &CollectionId,
-        collection: &StorageCollectionWrapper,
         id: &EntityId,
-    ) -> Result<Entity, RetrievalError> {
-        match self.get_or_retrieve(collection_id, collection, id).await? {
+    ) -> Result<Entity, RetrievalError>
+    where
+        R: Retrieve<Id = EventId, Event = Event> + Send + Sync,
+    {
+        match self.get_or_retrieve(retriever, collection_id, id).await? {
             Some(entity) => Ok(entity),
             None => {
                 let mut entities = self.0.write().unwrap();
@@ -432,7 +438,7 @@ impl WeakEntitySet {
         // Handle the case where entity is not resident (either vacant or deallocated)
         let Some(entity) = entity else {
             // Check if there's existing state in storage before creating a new entity
-            if let Some(existing_state) = retriever.get_local_state(id).await? {
+            if let Some(existing_state) = retriever.get_state(id).await? {
                 debug!("Found existing state in storage for {id}");
                 let entity = Entity::from_state(id, collection_id.to_owned(), &existing_state.payload.state)?;
 

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -10,7 +10,7 @@ use ankql::{ast::Predicate, error::ParseError};
 use ankurah_proto::Attested;
 use async_trait::async_trait;
 use thiserror::Error;
-use tracing::{debug, info};
+use tracing::debug;
 /// The result of a policy check. Currently just Allow/Deny, but will support Trace in the future
 #[derive(Debug, Error)]
 pub enum AccessDenied {
@@ -185,7 +185,7 @@ impl PolicyAgent for PermissiveAgent {
         _node: &Node<SE, Self>,
         _cdata: &Self::ContextData,
         _entity: &Entity,
-        event: &proto::Event,
+        _event: &proto::Event,
     ) -> Result<Option<proto::Attestation>, AccessDenied> {
         Ok(None)
     }
@@ -193,13 +193,13 @@ impl PolicyAgent for PermissiveAgent {
     fn validate_received_event<SE: StorageEngine>(
         &self,
         _node: &Node<SE, Self>,
-        from_node: &proto::EntityId,
-        event: &proto::Attested<proto::Event>,
+        _from_node: &proto::EntityId,
+        _event: &proto::Attested<proto::Event>,
     ) -> Result<(), AccessDenied> {
         Ok(())
     }
 
-    fn attest_state<SE: StorageEngine>(&self, _node: &Node<SE, Self>, state: &proto::EntityState) -> Option<proto::Attestation> {
+    fn attest_state<SE: StorageEngine>(&self, _node: &Node<SE, Self>, _state: &proto::EntityState) -> Option<proto::Attestation> {
         // This PolicyAgent does not require attestation, so we return None
         // Client/Server policy agents may also return None and defer to the server identity to validate the received state
         None
@@ -209,19 +209,19 @@ impl PolicyAgent for PermissiveAgent {
         &self,
         _node: &Node<SE, Self>,
         _from_node: &proto::EntityId,
-        state: &Attested<proto::EntityState>,
+        _state: &Attested<proto::EntityState>,
     ) -> Result<(), AccessDenied> {
         // This PolicyAgent does not require validation, so we return Ok
         // Client/Server policy agents may use the _from_node to validate the received state rather than an attestation
         Ok(())
     }
 
-    fn can_access_collection(&self, _context: &Self::ContextData, collection: &proto::CollectionId) -> Result<(), AccessDenied> { Ok(()) }
+    fn can_access_collection(&self, _context: &Self::ContextData, _collection: &proto::CollectionId) -> Result<(), AccessDenied> { Ok(()) }
 
     fn check_read(
         &self,
         _context: &Self::ContextData,
-        id: &proto::EntityId,
+        _id: &proto::EntityId,
         _collection: &proto::CollectionId,
         _state: &proto::State,
     ) -> Result<(), AccessDenied> {
@@ -229,13 +229,13 @@ impl PolicyAgent for PermissiveAgent {
         Ok(())
     }
 
-    fn check_read_event(&self, _context: &Self::ContextData, event: &Attested<proto::Event>) -> Result<(), AccessDenied> {
+    fn check_read_event(&self, _context: &Self::ContextData, _event: &Attested<proto::Event>) -> Result<(), AccessDenied> {
         // TODO - think about the best way to get the entity properties for cases where we want to inspect
         // presumably this would need to be changed to async, and we'd need a way to retrieve entity state from storage, or possibly even a remote node
         Ok(())
     }
 
-    fn check_write(&self, _context: &Self::ContextData, _entity: &Entity, event: Option<&proto::Event>) -> Result<(), AccessDenied> {
+    fn check_write(&self, _context: &Self::ContextData, _entity: &Entity, _event: Option<&proto::Event>) -> Result<(), AccessDenied> {
         Ok(())
     }
 

--- a/tests/tests/rt106.rs
+++ b/tests/tests/rt106.rs
@@ -4,7 +4,6 @@ use ankurah::{policy::DEFAULT_CONTEXT as c, Mutable, Node, PermissiveAgent};
 use ankurah_connector_local_process::LocalProcessConnection;
 use ankurah_storage_sled::SledStorageEngine;
 use std::sync::Arc;
-use tracing::info;
 
 mod common;
 use common::{Album, AlbumView};


### PR DESCRIPTION
* Fixes a few places where events weren't being properly retrieved from the remote node.
* Move Node methods solely used by NodeAndContext under same to avoid duplicate NodeAndContext construction for Retriever impl (Also this feels like a more appropriate place than Node for porcelain methods)
* Quiesce misc lints