### PR TITLE
Add Native WebSocket Client Connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
  "send_wrapper",
  "serde",
  "serde-wasm-bindgen",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -263,6 +263,8 @@ dependencies = [
  "ankurah-react-signals",
  "ankurah-storage-postgres",
  "ankurah-storage-sled",
+ "ankurah-websocket-client",
+ "ankurah-websocket-server",
  "anyhow",
  "async-trait",
  "bb8",
@@ -270,6 +272,7 @@ dependencies = [
  "ctor",
  "itertools",
  "js-sys",
+ "rand 0.8.5",
  "reactive_graph",
  "serde",
  "serde_json",
@@ -281,6 +284,27 @@ dependencies = [
  "tracing-subscriber",
  "ulid",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ankurah-websocket-client"
+version = "0.5.1"
+dependencies = [
+ "ankurah",
+ "ankurah-core",
+ "ankurah-proto",
+ "ankurah-storage-sled",
+ "ankurah-websocket-server",
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "futures-util",
+ "strum 0.27.2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-tungstenite 0.27.0",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -305,7 +329,7 @@ dependencies = [
  "send_wrapper",
  "serde",
  "serde-wasm-bindgen",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.12",
  "tracing",
  "tracing-wasm",
@@ -474,7 +498,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2796,7 +2820,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2809,6 +2842,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3091,7 +3136,23 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.27.0",
 ]
 
 [[package]]
@@ -3263,6 +3324,25 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.0",
+ "sha1",
+ "thiserror 2.0.12",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.0",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",
  "utf-8",

--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -10,7 +10,6 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [features]
-react = ["dep:ankurah-react-signals", "wasm"]
 wasm = [
     "derive",
     "ankurah-derive?/wasm",

--- a/ankurah/src/lib.rs
+++ b/ankurah/src/lib.rs
@@ -153,14 +153,14 @@ pub use ankurah_core::{
 
 // TODO move this somewhere else - it's a dependency of the signal derive macro
 #[doc(hidden)]
-#[cfg(feature = "react")]
+#[cfg(feature = "wasm")]
 pub trait GetSignalValue: reactive_graph::traits::Get {
     fn cloned(&self) -> Box<dyn GetSignalValue<Value = Self::Value>>;
 }
 
 // Add a blanket implementation for any type that implements Get + Clone
 #[doc(hidden)]
-#[cfg(feature = "react")]
+#[cfg(feature = "wasm")]
 impl<T> GetSignalValue for T
 where
     T: reactive_graph::traits::Get + Clone + 'static,
@@ -177,20 +177,20 @@ pub use ankurah_derive::*;
 #[cfg(feature = "derive")]
 #[doc(hidden)]
 pub mod derive_deps {
-    #[cfg(feature = "react")]
+    #[cfg(feature = "wasm")]
     pub use crate::GetSignalValue;
-    #[cfg(feature = "react")]
+    #[cfg(feature = "wasm")]
     pub use ::ankurah_react_signals;
-    #[cfg(feature = "react")]
+    #[cfg(feature = "wasm")]
     pub use ::js_sys;
-    #[cfg(feature = "react")]
+    #[cfg(feature = "wasm")]
     pub use ::reactive_graph;
     pub use ::tracing; // Why does this fail with a Sized error: `the trait `GetSignalValue` cannot be made into an object the trait cannot be made into an object because it requires `Self: Sized``
                        // pub use reactive_graph::traits::Get as GetSignalValue; // and this one works fine?
     pub use ::ankurah_proto;
-    #[cfg(feature = "react")]
+    #[cfg(feature = "wasm")]
     pub use ::wasm_bindgen;
-    #[cfg(feature = "react")]
+    #[cfg(feature = "wasm")]
     pub use ::wasm_bindgen_futures;
 
     pub use ::serde;

--- a/connectors/websocket-client-wasm/Cargo.toml
+++ b/connectors/websocket-client-wasm/Cargo.toml
@@ -14,17 +14,16 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = []
-react   = ["ankurah-react-signals"]
 
 [dependencies]
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm", "react"], version = "^0.5.1" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.5.1" }
 ankurah-core       = { path = "../../core", version = "^0.5.1" }
 ankurah-proto      = { path = "../../proto", version = "^0.5.1" }
 ankurah-derive     = { path = "../../derive", version = "^0.5.1" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 
-ankurah-react-signals = { path = "../../react-signals", optional = true, version = "^0.5.1" }
+ankurah-react-signals = { path = "../../react-signals", version = "^0.5.1" }
 wasm-bindgen = "0.2.84"
 futures = "0.3.30"
 js-sys = "0.3.69"

--- a/connectors/websocket-client-wasm/src/connection_state.rs
+++ b/connectors/websocket-client-wasm/src/connection_state.rs
@@ -3,7 +3,6 @@ use wasm_bindgen::prelude::*;
 
 use ankurah_proto as proto;
 
-// #[cfg_attr(feature = "react", derive(WasmSignal))]
 #[derive(Debug, Clone, PartialEq, strum::Display)]
 pub enum ConnectionState {
     None,

--- a/connectors/websocket-client/Cargo.toml
+++ b/connectors/websocket-client/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name          = "ankurah-websocket-client"
+version       = "0.5.1"
+edition       = "2021"
+description   = "Ankurah WebSocket Client - Native WebSocket client for Ankurah"
+license       = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/ankurah-websocket-client"
+homepage      = "https://github.com/ankurah/ankurah"
+repository    = "https://github.com/ankurah/ankurah"
+
+[dependencies]
+ankurah-core  = { path = "../../core", version = "^0.5.1" }
+ankurah-proto = { path = "../../proto", version = "^0.5.1" }
+
+# WebSocket implementation
+tokio-tungstenite = { version = "0.27", features = ["rustls-tls-native-roots"] }
+tokio             = { version = "1.40", features = ["full"] }
+
+# Async utilities
+futures-util = "0.3"
+async-trait  = "0.1"
+
+# Serialization 
+bincode = "1.3"
+
+# Error handling and utilities
+anyhow    = "1.0"
+thiserror = "2.0"
+tracing   = "0.1"
+url       = "2.0"
+strum     = { version = "0.27", features = ["derive"] }
+
+[dev-dependencies]
+ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.5.1" }
+ankurah-websocket-server = { path = "../websocket-server", version = "^0.5.1" }
+ankurah                  = { path = "../../ankurah", version = "^0.5.1", features = ["derive"] }

--- a/connectors/websocket-client/src/client.rs
+++ b/connectors/websocket-client/src/client.rs
@@ -1,0 +1,378 @@
+use crate::sender::WebsocketPeerSender;
+use ankurah_core::{connector::PeerSender, policy::PolicyAgent, storage::StorageEngine, Node};
+use ankurah_proto as proto;
+use anyhow::Result;
+use futures_util::{SinkExt, StreamExt};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+use strum::Display;
+use tokio::{select, sync::Notify, task::JoinHandle, time::sleep};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{debug, error, info, warn};
+
+/// Connection state for the websocket client
+#[derive(Debug, Clone, PartialEq, Display)]
+pub enum ConnectionState {
+    Disconnected,
+    #[strum(serialize = "Connecting")]
+    Connecting {
+        url: String,
+    },
+    #[strum(serialize = "Connected")]
+    Connected {
+        url: String,
+        server_presence: proto::Presence,
+    },
+    #[strum(serialize = "Error")]
+    Error {
+        message: String,
+    },
+}
+
+const MAX_CONNECTION_WAIT: Duration = Duration::from_secs(30);
+const CONNECTION_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+struct Inner<SE, PA>
+where
+    SE: StorageEngine + Send + Sync + 'static,
+    PA: PolicyAgent + Send + Sync + 'static,
+{
+    node: Node<SE, PA>,
+    server_url: String,
+    state: std::sync::RwLock<ConnectionState>,
+    connected: AtomicBool,
+    shutdown: Notify,
+    shutdown_requested: AtomicBool,
+}
+
+/// A WebSocket client for connecting Ankurah nodes
+pub struct WebsocketClient<SE, PA>
+where
+    SE: StorageEngine + Send + Sync + 'static,
+    PA: PolicyAgent + Send + Sync + 'static,
+{
+    inner: Arc<Inner<SE, PA>>,
+    task: std::sync::Mutex<Option<JoinHandle<()>>>,
+}
+
+impl<SE, PA> WebsocketClient<SE, PA>
+where
+    SE: StorageEngine + Send + Sync + 'static,
+    PA: PolicyAgent + Send + Sync + 'static,
+{
+    /// Create a new WebSocket client and start connecting to the server
+    pub async fn new(node: Node<SE, PA>, server_url: &str) -> anyhow::Result<Self> {
+        let ws_url = Self::normalize_url(server_url);
+        info!("Creating WebSocket client for {}", ws_url);
+
+        let inner = Arc::new(Inner {
+            node,
+            server_url: ws_url,
+            state: std::sync::RwLock::new(ConnectionState::Disconnected),
+            connected: AtomicBool::new(false),
+            shutdown: Notify::new(),
+            shutdown_requested: AtomicBool::new(false),
+        });
+
+        let task = tokio::spawn(Self::run_connection_loop(inner.clone()));
+        Ok(Self { inner, task: std::sync::Mutex::new(Some(task)) })
+    }
+
+    fn normalize_url(url: &str) -> String {
+        match url {
+            u if u.starts_with("ws://") || u.starts_with("wss://") => format!("{}/ws", u),
+            u if u.starts_with("http://") => format!("ws://{}/ws", &u[7..]),
+            u if u.starts_with("https://") => format!("wss://{}/ws", &u[8..]),
+            u => format!("wss://{}/ws", u),
+        }
+    }
+
+    /// Wait for the client to establish a connection to the server
+    pub async fn wait_connected(&self) -> anyhow::Result<()> {
+        let start = Instant::now();
+        while start.elapsed() < MAX_CONNECTION_WAIT {
+            match self.connection_state() {
+                ConnectionState::Connected { .. } => return Ok(()),
+                ConnectionState::Error { message } => return Err(anyhow::anyhow!("Connection failed: {}", message)),
+                _ => tokio::time::sleep(CONNECTION_POLL_INTERVAL).await,
+            }
+        }
+        Err(anyhow::anyhow!("Timeout waiting for connection"))
+    }
+
+    /// Get the current connection state
+    pub fn connection_state(&self) -> ConnectionState { self.inner.state.read().unwrap().clone() }
+
+    /// Check if currently connected to the server
+    pub fn is_connected(&self) -> bool { self.inner.connected.load(Ordering::Acquire) }
+
+    /// Gracefully shutdown the WebSocket connection
+    pub async fn shutdown(self) -> anyhow::Result<()> {
+        info!("Shutting down WebSocket client");
+
+        if let Some(task) = self.task.lock().unwrap().take() {
+            self.inner.shutdown_requested.store(true, Ordering::Release);
+            self.inner.shutdown.notify_waiters();
+
+            match task.await {
+                Ok(()) => info!("WebSocket client shutdown completed"),
+                Err(e) => warn!("Connection task join error during shutdown: {}", e),
+            }
+        } else {
+            info!("WebSocket client already shut down");
+        }
+        Ok(())
+    }
+
+    /// Get the node ID of the connected server (if connected)
+    pub fn server_node_id(&self) -> Option<proto::EntityId> {
+        match self.connection_state() {
+            ConnectionState::Connected { server_presence, .. } => Some(server_presence.node_id),
+            _ => None,
+        }
+    }
+
+    /// Main connection loop with automatic reconnection
+    async fn run_connection_loop(inner: Arc<Inner<SE, PA>>) {
+        let mut backoff = INITIAL_BACKOFF;
+        info!("Starting websocket connection loop to {}", inner.server_url);
+
+        loop {
+            select! {
+                _ = inner.shutdown.notified() => {
+                    info!("Websocket connection shutting down");
+                    break;
+                }
+                result = Self::connect_once(&inner) => {
+                    match result {
+                        Ok(()) => {
+                            info!("Connection to {} completed normally", inner.server_url);
+                            backoff = INITIAL_BACKOFF;
+                            if inner.shutdown_requested.load(Ordering::Acquire) {
+                                info!("Shutdown requested, stopping reconnection attempts");
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            error!("Connection to {} failed: {}", inner.server_url, e);
+                            Self::update_state(&inner.state, ConnectionState::Error { message: e.to_string() });
+                            inner.connected.store(false, Ordering::Release);
+
+                            info!("Retrying connection in {:?}", backoff);
+                            select! {
+                                _ = inner.shutdown.notified() => break,
+                                _ = sleep(backoff) => {}
+                            }
+                            backoff = (backoff * 2).min(MAX_BACKOFF);
+                        }
+                    }
+                }
+            }
+        }
+
+        Self::update_state(&inner.state, ConnectionState::Disconnected);
+        inner.connected.store(false, Ordering::Release);
+    }
+
+    /// Attempt a single connection
+    async fn connect_once(inner: &Arc<Inner<SE, PA>>) -> Result<()> {
+        info!("Attempting to connect to {}", inner.server_url);
+        Self::update_state(&inner.state, ConnectionState::Connecting { url: inner.server_url.clone() });
+
+        let (ws_stream, _) = connect_async(inner.server_url.as_str()).await?;
+        info!("WebSocket handshake completed with {}", inner.server_url);
+
+        let (mut sink, mut stream) = ws_stream.split();
+        debug!("Starting connection handling");
+
+        // Send our presence immediately
+        let presence = proto::Message::Presence(proto::Presence {
+            node_id: inner.node.id,
+            durable: inner.node.durable,
+            system_root: inner.node.system.root(),
+        });
+
+        sink.send(Message::Binary(bincode::serialize(&presence)?.into())).await?;
+        debug!("Sent client presence");
+
+        let mut peer_sender: Option<WebsocketPeerSender> = None;
+        let mut outgoing_rx: Option<tokio::sync::mpsc::UnboundedReceiver<proto::NodeMessage>> = None;
+
+        loop {
+            select! {
+                _ = inner.shutdown.notified() => {
+                    debug!("Connection received shutdown signal");
+                    break;
+                }
+                msg = async {
+                    match &mut outgoing_rx {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    if Self::handle_outgoing_message(&mut sink, msg).await.is_err() {
+                        break;
+                    }
+                }
+                msg = stream.next() => {
+                    match Self::handle_incoming_message(inner, msg, &mut peer_sender, &mut outgoing_rx, &mut sink).await? {
+                        MessageResult::Continue => continue,
+                        MessageResult::Break => break,
+                    }
+                }
+            }
+        }
+
+        // Cleanup
+        inner.connected.store(false, Ordering::Release);
+        if let Some(sender) = peer_sender {
+            inner.node.deregister_peer(sender.recipient_node_id());
+            debug!("Deregistered peer {}", sender.recipient_node_id());
+        }
+        Ok(())
+    }
+
+    async fn handle_outgoing_message(
+        sink: &mut futures_util::stream::SplitSink<
+            tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+            Message,
+        >,
+        msg: Option<proto::NodeMessage>,
+    ) -> Result<()> {
+        if let Some(node_message) = msg {
+            let proto_message = proto::Message::PeerMessage(node_message);
+            match bincode::serialize(&proto_message) {
+                Ok(data) => {
+                    sink.send(Message::Binary(data.into())).await?;
+                }
+                Err(e) => error!("Failed to serialize outgoing message: {}", e),
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_incoming_message(
+        inner: &Arc<Inner<SE, PA>>,
+        msg: Option<Result<Message, tokio_tungstenite::tungstenite::Error>>,
+        peer_sender: &mut Option<WebsocketPeerSender>,
+        outgoing_rx: &mut Option<tokio::sync::mpsc::UnboundedReceiver<proto::NodeMessage>>,
+        sink: &mut futures_util::stream::SplitSink<
+            tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+            Message,
+        >,
+    ) -> Result<MessageResult> {
+        match msg {
+            Some(Ok(Message::Binary(data))) => match bincode::deserialize(&data) {
+                Ok(proto::Message::Presence(server_presence)) => {
+                    Self::handle_server_presence(inner, server_presence, peer_sender, outgoing_rx).await;
+                    Ok(MessageResult::Continue)
+                }
+                Ok(proto::Message::PeerMessage(node_msg)) => {
+                    Self::handle_peer_message(inner, node_msg).await;
+                    Ok(MessageResult::Continue)
+                }
+                Err(e) => {
+                    warn!("Failed to deserialize message: {}", e);
+                    Ok(MessageResult::Continue)
+                }
+            },
+            Some(Ok(Message::Close(_))) => {
+                info!("WebSocket connection closed by server");
+                Ok(MessageResult::Break)
+            }
+            Some(Ok(Message::Ping(data))) => {
+                debug!("Received ping, sending pong");
+                if let Err(e) = sink.send(Message::Pong(data)).await {
+                    warn!("Failed to send pong: {}", e);
+                    return Err(e.into());
+                }
+                Ok(MessageResult::Continue)
+            }
+            Some(Ok(Message::Pong(_))) => {
+                debug!("Received pong");
+                Ok(MessageResult::Continue)
+            }
+            Some(Ok(Message::Text(text))) => {
+                debug!("Received unexpected text message: {}", text);
+                Ok(MessageResult::Continue)
+            }
+            Some(Ok(_)) => {
+                debug!("Received other message type");
+                Ok(MessageResult::Continue)
+            }
+            Some(Err(e)) => {
+                error!("WebSocket error: {}", e);
+                Err(e.into())
+            }
+            None => {
+                info!("WebSocket stream closed");
+                Ok(MessageResult::Break)
+            }
+        }
+    }
+
+    async fn handle_server_presence(
+        inner: &Arc<Inner<SE, PA>>,
+        server_presence: proto::Presence,
+        peer_sender: &mut Option<WebsocketPeerSender>,
+        outgoing_rx: &mut Option<tokio::sync::mpsc::UnboundedReceiver<proto::NodeMessage>>,
+    ) {
+        info!("Received server presence: {}", server_presence.node_id);
+
+        let (sender, rx) = WebsocketPeerSender::new(server_presence.node_id);
+        inner.node.register_peer(server_presence.clone(), Box::new(sender.clone()));
+
+        *outgoing_rx = Some(rx);
+        *peer_sender = Some(sender);
+
+        Self::update_state(&inner.state, ConnectionState::Connected { url: inner.server_url.to_string(), server_presence });
+        inner.connected.store(true, Ordering::Release);
+        info!("Successfully connected to server {}", inner.server_url);
+    }
+
+    async fn handle_peer_message(inner: &Arc<Inner<SE, PA>>, node_msg: proto::NodeMessage) {
+        debug!("Received peer message");
+        let node = inner.node.clone();
+        tokio::spawn(async move {
+            if let Err(e) = node.handle_message(node_msg).await {
+                warn!("Error handling peer message: {}", e);
+            }
+        });
+    }
+
+    fn update_state(state: &std::sync::RwLock<ConnectionState>, new_state: ConnectionState) {
+        let mut current = state.write().unwrap();
+        if *current != new_state {
+            debug!("Connection state changed: {:?} -> {:?}", *current, new_state);
+            *current = new_state;
+        }
+    }
+}
+
+#[derive(Debug)]
+enum MessageResult {
+    Continue,
+    Break,
+}
+
+impl<SE, PA> Drop for WebsocketClient<SE, PA>
+where
+    SE: StorageEngine + Send + Sync + 'static,
+    PA: PolicyAgent + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        if let Some(task) = self.task.lock().unwrap().take() {
+            debug!("WebSocket client dropped, requesting shutdown");
+            self.inner.shutdown_requested.store(true, Ordering::Release);
+            self.inner.shutdown.notify_waiters();
+            task.abort();
+        }
+    }
+}

--- a/connectors/websocket-client/src/lib.rs
+++ b/connectors/websocket-client/src/lib.rs
@@ -1,0 +1,52 @@
+//! # Ankurah WebSocket Client
+//!
+//! A native (non-browser) WebSocket client for connecting an Ankurah node to another
+//! Ankurah node which hosts a WebSocket server
+//!
+//! ## Automatic reconnection
+//!
+//!  Reconnects to the server if the connection is lost using exponential backoff
+//!
+//! ## Graceful shutdown
+//!
+//!   To shutdown the client, call the `shutdown` method. This will wait for the connection to be closed and then return.
+//!
+//! ## Basic Usage
+//!
+//! ```rust,no_run
+//! # use ankurah::{Node, PermissiveAgent};
+//! # use ankurah_storage_sled::SledStorageEngine;
+//! # use ankurah_websocket_client::WebsocketClient;
+//! # use ankurah::policy::DEFAULT_CONTEXT as c;
+//! # use std::sync::Arc;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     // Create a client node
+//!     let storage = Arc::new(SledStorageEngine::new_test()?);
+//!     let my_node = Node::new(storage, PermissiveAgent::new());
+//!
+//!     // Create WebSocket client to connect to remote server (automatically starts connecting)
+//!     let client = WebsocketClient::new(my_node.clone(), "ws://localhost:8080").await?;
+//!
+//!     println!("State: {}", client.connection_state()); // State: Connected
+//!
+//!     // See [ankurah] for usage details
+//!
+//!     // When you're done, shutdown the client
+//!     client.shutdown().await?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! // See ankurah for basic details
+
+pub mod client;
+pub mod sender;
+
+// Re-export the main types for easy use
+pub use client::{ConnectionState, WebsocketClient};
+pub use sender::WebsocketPeerSender;
+
+// Re-export common types for convenience
+pub use tokio_tungstenite::tungstenite::Error as TungsteniteError;

--- a/connectors/websocket-client/src/sender.rs
+++ b/connectors/websocket-client/src/sender.rs
@@ -1,0 +1,35 @@
+use ankurah_core::connector::{PeerSender, SendError};
+use ankurah_proto as proto;
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+/// PeerSender implementation for websocket connections
+#[derive(Clone)]
+pub struct WebsocketPeerSender {
+    tx: mpsc::UnboundedSender<proto::NodeMessage>,
+    recipient_node_id: proto::EntityId,
+}
+
+impl WebsocketPeerSender {
+    pub fn new(recipient_node_id: proto::EntityId) -> (Self, mpsc::UnboundedReceiver<proto::NodeMessage>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Self { tx, recipient_node_id }, rx)
+    }
+}
+
+#[async_trait]
+impl PeerSender for WebsocketPeerSender {
+    fn send_message(&self, message: proto::NodeMessage) -> Result<(), SendError> {
+        debug!("Queuing message for peer {}", self.recipient_node_id);
+
+        self.tx.send(message).map_err(|_| {
+            warn!("Failed to send message to peer {} - channel closed", self.recipient_node_id);
+            SendError::ConnectionClosed
+        })
+    }
+
+    fn recipient_node_id(&self) -> proto::EntityId { self.recipient_node_id }
+
+    fn cloned(&self) -> Box<dyn PeerSender> { Box::new(self.clone()) }
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [features]
-wasm       = ["wasm-bindgen", "wasm-bindgen-futures", "serde-wasm-bindgen"]
+wasm       = ["wasm-bindgen", "wasm-bindgen-futures", "serde-wasm-bindgen", "ankurah-proto/wasm"]
 default    = []
 instrument = []
 

--- a/examples/model/Cargo.toml
+++ b/examples/model/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["wasm"]
-wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/react"]
+default = []
+wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/wasm"]
 
 [dependencies]
 ankurah        = { path = "../../ankurah", features = ["derive"], version = "^0.5.1" }

--- a/examples/wasm-bindings/Cargo.toml
+++ b/examples/wasm-bindings/Cargo.toml
@@ -7,24 +7,22 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ankurah = { path = "../../ankurah", features = ["derive", "wasm", "react"], version = "^0.5.1" }
-ankurah-websocket-client-wasm = { path = "../../connectors/websocket-client-wasm", features = [
-    "react",
-], version = "^0.5.1" }
+ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.5.1" }
+ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "^0.5.1" }
 ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "^0.5.1" }
-example-model = { path = "../model", features = ["wasm"], version = "0.5.1" }
-wasm-bindgen = "0.2.84"
-wasm-bindgen-futures = "0.4.42"
-wasm-logger = "0.2.0"
-tracing = "0.1.40"
-tracing-wasm = "0.2.1"
-console_error_panic_hook = "0.1.7"
-any_spawner = { version = "0.2.0", features = ["wasm-bindgen"] }
-reactive_graph = { version = "0.1.4", features = ["effects"] }
-send_wrapper = { version = "0.6.0" }
-tokio = { version = "1.39.0", features = ["sync"] }
-lazy_static = "1.4.0"
-once_cell = "1.19.0"
+example-model                  = { path = "../model", features = ["wasm"], version = "0.5.1" }
+wasm-bindgen                   = "0.2.84"
+wasm-bindgen-futures           = "0.4.42"
+wasm-logger                    = "0.2.0"
+tracing                        = "0.1.40"
+tracing-wasm                   = "0.2.1"
+console_error_panic_hook       = "0.1.7"
+any_spawner                    = { version = "0.2.0", features = ["wasm-bindgen"] }
+reactive_graph                 = { version = "0.1.4", features = ["effects"] }
+send_wrapper                   = { version = "0.6.0" }
+tokio                          = { version = "1.39.0", features = ["sync"] }
+lazy_static                    = "1.4.0"
+once_cell                      = "1.19.0"
 ##### patch - something is wrong with the uuid crate for wasm
 getrandom = { version = "0.3", features = ["wasm_js"] }
 ###### 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -9,7 +9,7 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [features]
-default  = ["wasm"]
+default  = []
 postgres = ["dep:postgres-types", "dep:postgres-protocol", "dep:fallible-iterator"]
 wasm     = ["dep:wasm-bindgen", "dep:js-sys"]
 

--- a/proto/src/id.rs
+++ b/proto/src/id.rs
@@ -3,12 +3,13 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use ulid::Ulid;
 
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
 use crate::error::DecodeError;
 // TODO - split out the different id types. Presently there's a lot of not-entities that are using this type for their ID
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Ord, PartialOrd)]
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct EntityId(pub(crate) Ulid);
 
 impl EntityId {
@@ -38,6 +39,7 @@ impl EntityId {
 impl EntityId {
     pub fn as_string(&self) -> String { self.to_base64() }
 
+    #[cfg(feature = "wasm")]
     #[wasm_bindgen(js_name = to_base64)]
     pub fn to_base64_js(&self) -> String { general_purpose::URL_SAFE_NO_PAD.encode(self.0.to_bytes()) }
 

--- a/react-signals/src/react_binding.rs
+++ b/react-signals/src/react_binding.rs
@@ -10,7 +10,7 @@ use std::sync::Weak;
 
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen(module = "react")]
+#[wasm_bindgen(module = "wasm")]
 extern "C" {
     fn useRef() -> JsValue;
     fn useSyncExternalStore(

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,7 +12,7 @@ postgres = ["ankurah-storage-postgres", "tokio-postgres", "bb8", "bb8-postgres"]
 anyhow                          = "1.0"
 tracing                         = "0.1"
 ankql                           = { path = "../ankql", version = "^0.5.1" }
-ankurah                         = { path = "../ankurah", features = ["derive", "react", "instrument"], version = "^0.5.1" }
+ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "^0.5.1" }
 ankurah-storage-sled            = { path = "../storage/sled", version = "^0.5.1" }
 ankurah-connector-local-process = { path = "../connectors/local-process", version = "^0.5.1" }
 ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "^0.5.1" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,6 +15,8 @@ ankql                           = { path = "../ankql", version = "^0.5.1" }
 ankurah                         = { path = "../ankurah", features = ["derive", "react", "instrument"], version = "^0.5.1" }
 ankurah-storage-sled            = { path = "../storage/sled", version = "^0.5.1" }
 ankurah-connector-local-process = { path = "../connectors/local-process", version = "^0.5.1" }
+ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "^0.5.1" }
+ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "^0.5.1" }
 tokio-postgres                  = { version = "0.7", optional = true }
 ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "^0.5.1" }
 bb8                             = { version = "0.9", optional = true }
@@ -33,3 +35,4 @@ ulid                            = "1.1"
 itertools                       = "0.14"
 async-trait                     = "0.1"
 serde_json                      = "1.0"
+rand                            = "0.8"

--- a/tests/tests/websocket.rs
+++ b/tests/tests/websocket.rs
@@ -1,0 +1,320 @@
+use ankurah::{changes::ChangeKind, policy::DEFAULT_CONTEXT as c, EntityId, Node, PermissiveAgent};
+use ankurah_storage_sled::SledStorageEngine;
+use ankurah_websocket_client::WebsocketClient;
+use ankurah_websocket_server::WebsocketServer;
+use anyhow::Result;
+use std::sync::Arc;
+use tracing::info;
+
+mod common;
+use common::*;
+
+#[tokio::test]
+async fn test_websocket_client_server_fetch() -> Result<()> {
+    let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
+
+    // Start websocket server
+    let (server_node, server_url, server_task) = start_test_server().await?;
+
+    info!("Server node ID: {}", server_node.id);
+
+    // Get server context
+    let server_ctx = server_node.context(c)?;
+
+    // Create some data on the server
+    {
+        let trx = server_ctx.begin();
+        trx.create(&Album { name: "Dark Side of the Moon".into(), year: "1973".into() }).await?;
+        trx.create(&Album { name: "Wish You Were Here".into(), year: "1975".into() }).await?;
+        trx.create(&Album { name: "Animals".into(), year: "1977".into() }).await?;
+        trx.commit().await?;
+    }
+
+    // Create client node
+    let client_storage = Arc::new(SledStorageEngine::new_test()?);
+    let client_node = Node::new(client_storage, PermissiveAgent::new());
+
+    info!("Client node ID: {}", client_node.id);
+
+    // Create websocket client and connect
+    let client = WebsocketClient::new(client_node.clone(), &server_url).await?;
+    client.wait_connected().await?;
+
+    info!("Client connected successfully");
+
+    // Give time for initial data sync
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    // Get client context
+    let client_ctx = client_node.context(c)?;
+
+    // Test fetching data through websocket connection
+    let query = "name = 'Dark Side of the Moon'";
+    let results = client_ctx.fetch(query).await?;
+    assert_eq!(names(results), ["Dark Side of the Moon"]);
+
+    // Test broader query
+    let all_results = client_ctx.fetch("year > '1970'").await?;
+    let mut all_names = names(all_results);
+    all_names.sort();
+    assert_eq!(all_names, ["Animals", "Dark Side of the Moon", "Wish You Were Here"]);
+
+    info!("Fetch tests passed");
+
+    // Clean shutdown
+    client.shutdown().await?;
+    server_task.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_websocket_client_create_propagation() -> Result<()> {
+    let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
+
+    // Start websocket server
+    let (server_node, server_url, server_task) = start_test_server().await?;
+
+    // Create client
+    let client_storage = Arc::new(SledStorageEngine::new_test()?);
+    let client_node = Node::new(client_storage, PermissiveAgent::new());
+    let client = WebsocketClient::new(client_node.clone(), &server_url).await?;
+    client.wait_connected().await?;
+
+    let server_ctx = server_node.context(c)?;
+    let client_ctx = client_node.context(c)?;
+
+    // Create entity on client
+    {
+        let trx = client_ctx.begin();
+        trx.create(&Album { name: "The Wall".into(), year: "1979".into() }).await?;
+        trx.commit().await?;
+    }
+
+    // Wait for propagation
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+    // Verify it's queryable on server
+    let query = "name = 'The Wall'";
+    let server_results = server_ctx.fetch(query).await?;
+    assert_eq!(names(server_results), ["The Wall"]);
+
+    info!("Create propagation test passed");
+
+    client.shutdown().await?;
+    server_task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_websocket_subscription_propagation() -> Result<()> {
+    let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
+
+    // Start websocket server
+    let (server_node, server_url, server_task) = start_test_server().await?;
+
+    // Create client
+    let client_storage = Arc::new(SledStorageEngine::new_test()?);
+    let client_node = Node::new(client_storage, PermissiveAgent::new());
+    let client = WebsocketClient::new(client_node.clone(), &server_url).await?;
+    client.wait_connected().await?;
+
+    let server_ctx = server_node.context(c)?;
+    let client_ctx = client_node.context(c)?;
+
+    // Set up subscription watchers
+    let (server_watcher, check_server) = changeset_watcher::<AlbumView>();
+    let (client_watcher, check_client) = changeset_watcher::<AlbumView>();
+
+    // Subscribe on both ends
+    let _server_sub = server_ctx.subscribe("name = 'Abbey Road'", server_watcher).await?;
+    let _client_sub = client_ctx.subscribe("name = 'Abbey Road'", client_watcher).await?;
+
+    // Initial state should be empty
+    assert_eq!(check_server(), vec![vec![]] as Vec<Vec<(EntityId, ChangeKind)>>);
+    assert_eq!(check_client(), vec![vec![]] as Vec<Vec<(EntityId, ChangeKind)>>);
+
+    // Create matching entity on server
+    let album_id = {
+        let trx = server_ctx.begin();
+        let album = trx.create(&Album { name: "Abbey Road".into(), year: "1969".into() }).await?;
+        let id = album.id();
+        trx.commit().await?;
+        id
+    };
+
+    // Wait for propagation
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+    // Check that both server and client received the change
+    let server_changes = check_server();
+    let client_changes = check_client();
+
+    // Both should see exactly 1 change with the correct entity ID
+    assert_eq!(server_changes.len(), 1);
+    assert_eq!(client_changes.len(), 1);
+    assert_eq!(server_changes[0].len(), 1);
+    assert_eq!(client_changes[0].len(), 1);
+
+    // Check entity IDs match (ChangeKind may vary between Add/Initial)
+    assert_eq!(server_changes[0][0].0, album_id);
+    assert_eq!(client_changes[0][0].0, album_id);
+
+    info!("Subscription propagation test passed");
+
+    client.shutdown().await?;
+    server_task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_websocket_bidirectional_subscription() -> Result<()> {
+    // Add timeout to prevent test hanging
+    tokio::time::timeout(tokio::time::Duration::from_secs(10), test_websocket_bidirectional_subscription_impl())
+        .await
+        .map_err(|_| anyhow::anyhow!("Test timed out"))?
+}
+
+async fn test_websocket_bidirectional_subscription_impl() -> Result<()> {
+    let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
+
+    // Start websocket server
+    let (server_node, server_url, server_task) = start_test_server().await?;
+
+    // Create client
+    let client_storage = Arc::new(SledStorageEngine::new_test()?);
+    let client_node = Node::new(client_storage, PermissiveAgent::new());
+    let client = WebsocketClient::new(client_node.clone(), &server_url).await?;
+    client.wait_connected().await?;
+
+    let server_ctx = server_node.context(c)?;
+    let client_ctx = client_node.context(c)?;
+
+    // Set up subscription watchers
+    let (server_watcher, check_server) = changeset_watcher::<PetView>();
+    let (client_watcher, check_client) = changeset_watcher::<PetView>();
+
+    // Subscribe to pets with age > 5
+    let _server_sub = server_ctx.subscribe("age > 5", server_watcher).await?;
+    let _client_sub = client_ctx.subscribe("age > 5", client_watcher).await?;
+
+    // Create pet on server
+    let server_pet_id = {
+        let trx = server_ctx.begin();
+        let pet = trx.create(&Pet { name: "Rex".to_string(), age: "7".to_string() }).await?;
+        let id = pet.id();
+        trx.commit().await?;
+        id
+    };
+
+    // Wait for propagation
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Create pet on client
+    let client_pet_id = {
+        let trx = client_ctx.begin();
+        let pet = trx.create(&Pet { name: "Buddy".to_string(), age: "8".to_string() }).await?;
+        let id = pet.id();
+        trx.commit().await?;
+        id
+    };
+
+    // Wait for propagation
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Both sides should see both pets
+    let server_changes = check_server();
+    let client_changes = check_client();
+
+    info!("Server changes: {:?}", server_changes);
+    info!("Client changes: {:?}", client_changes);
+
+    // Both should see exactly 3 change events (empty initial + 2 pets)
+    assert_eq!(server_changes.len(), 3);
+    assert_eq!(client_changes.len(), 3);
+
+    // Initial should be empty
+    assert_eq!(server_changes[0], vec![]);
+    assert_eq!(client_changes[0], vec![]);
+
+    // Both should see both pets (event types may vary)
+    let mut server_pets: Vec<_> = server_changes.iter().skip(1).flat_map(|v| v.iter().map(|(id, _)| *id)).collect();
+    let mut client_pets: Vec<_> = client_changes.iter().skip(1).flat_map(|v| v.iter().map(|(id, _)| *id)).collect();
+
+    server_pets.sort();
+    client_pets.sort();
+
+    let mut expected_pets = vec![server_pet_id, client_pet_id];
+    expected_pets.sort();
+
+    assert_eq!(server_pets, expected_pets);
+    assert_eq!(client_pets, expected_pets);
+
+    info!("Bidirectional subscription test passed");
+
+    client.shutdown().await?;
+    server_task.abort();
+    Ok(())
+}
+
+/// Helper to extract names from album query results
+fn names(resultset: ankurah::ResultSet<AlbumView>) -> Vec<String> {
+    resultset.items.iter().map(|r| r.name().unwrap()).collect::<Vec<String>>()
+}
+
+/// Start a test websocket server and return the server node, URL, and task handle
+async fn start_test_server() -> Result<(Node<SledStorageEngine, PermissiveAgent>, String, tokio::task::JoinHandle<()>)> {
+    // Create and initialize server node
+    let server_storage = Arc::new(SledStorageEngine::new_test()?);
+    let server_node = Node::new_durable(server_storage, PermissiveAgent::new());
+    server_node.system.create().await?;
+
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+
+    // Retry logic for port conflicts
+    const MAX_PORT_RETRIES: usize = 10;
+    let mut last_error = None;
+
+    for attempt in 0..MAX_PORT_RETRIES {
+        let port: u16 = rng.gen_range(20000..=65000);
+        let bind_addr = format!("127.0.0.1:{}", port);
+        let server_url = format!("ws://127.0.0.1:{}", port);
+
+        info!("Attempt {} - Starting websocket server on {}", attempt + 1, server_url);
+
+        // Start server in background task
+        let server_node_clone = server_node.clone();
+        let bind_addr_clone = bind_addr.clone();
+
+        let server_task = tokio::spawn(async move {
+            let mut server = WebsocketServer::new(server_node_clone);
+            if let Err(e) = server.run(&bind_addr_clone).await {
+                tracing::warn!("Test server error on {}: {}", bind_addr_clone, e);
+            }
+        });
+
+        // Wait briefly for the TcpListener::bind() call to complete
+        // If port is in use, the server task will complete immediately with an error
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        // Check if the server task is still running (successful bind) or completed (failed bind)
+        if server_task.is_finished() {
+            // Server task completed immediately, which means binding failed
+            tracing::warn!("Failed to bind server on port {} (attempt {})", port, attempt + 1);
+            last_error = Some(anyhow::anyhow!("Port {} binding failed", port));
+
+            if attempt < MAX_PORT_RETRIES - 1 {
+                tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            }
+            continue;
+        }
+
+        // Server task is still running, which means TcpListener::bind() succeeded
+        // The server is now listening and ready for connections
+        info!("Successfully started websocket server on {} (attempt {})", server_url, attempt + 1);
+        return Ok((server_node, server_url, server_task));
+    }
+
+    Err(anyhow::anyhow!("Failed to start test server after {} attempts. Last error: {:?}", MAX_PORT_RETRIES, last_error))
+}


### PR DESCRIPTION
Introduces `ankurah-websocket-client`, a native WebSocket client for connecting to remote Ankurah nodes which offer a websocket server connector.

### Key Features

- **Native WebSocket connectivity** - Connects Ankurah nodes over WebSocket using `tokio-tungstenite`
- **Automatic reconnection** - Exponential backoff with configurable timeouts when connection is lost  
- **Connection state management** - Tracks connection status (Disconnected, Connecting, Connected, Error)
- **Graceful shutdown** - Clean connection termination with proper resource cleanup

### Usage

```rust
// Connect to remote Ankurah server
let client = WebsocketClient::new(my_node, "ws://server:8080").await?;
client.wait_connected().await?;

// Use normal Ankurah operations - they work transparently across the connection
let results = client_ctx.fetch("status = 'active'").await?;
let subscription = client_ctx.subscribe("age > 21", callback).await?;

// Clean shutdown
client.shutdown().await?;
```

### Relationship to Existing Code

- Complements existing `websocket-client-wasm` (for browser environments) 
- Uses same protocol as `websocket-server`

Tested with comprehensive integration tests covering fetch operations, entity creation propagation, and bidirectional subscriptions.