### PR TITLE
Introduce ankurah-signals subcrate and migrate websocket-client to reactive state management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ankurah-signals"
+version = "0.5.1"
+
+[[package]]
 name = "ankurah-storage-indexeddb-wasm"
 version = "0.5.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,10 @@ dependencies = [
 [[package]]
 name = "ankurah-signals"
 version = "0.5.1"
+dependencies = [
+ "tokio",
+ "tokio-test",
+]
 
 [[package]]
 name = "ankurah-storage-indexeddb-wasm"
@@ -297,6 +301,7 @@ dependencies = [
  "ankurah",
  "ankurah-core",
  "ankurah-proto",
+ "ankurah-signals",
  "ankurah-storage-sled",
  "ankurah-websocket-server",
  "anyhow",
@@ -453,6 +458,28 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3129,6 +3156,19 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "xattr",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ members = [
     "storage/*",
     "tests",
     "ankurah",
+    "signals",
 ]
 resolver = "2"

--- a/connectors/websocket-client/Cargo.toml
+++ b/connectors/websocket-client/Cargo.toml
@@ -9,8 +9,9 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core  = { path = "../../core", version = "^0.5.1" }
-ankurah-proto = { path = "../../proto", version = "^0.5.1" }
+ankurah-core    = { path = "../../core", version = "^0.5.1" }
+ankurah-proto   = { path = "../../proto", version = "^0.5.1" }
+ankurah-signals = { path = "../../signals", version = "^0.5.1" }
 
 # WebSocket implementation
 tokio-tungstenite = { version = "0.27", features = ["rustls-tls-native-roots"] }

--- a/connectors/websocket-client/src/lib.rs
+++ b/connectors/websocket-client/src/lib.rs
@@ -29,7 +29,7 @@
 //!     // Create WebSocket client to connect to remote server (automatically starts connecting)
 //!     let client = WebsocketClient::new(my_node.clone(), "ws://localhost:8080").await?;
 //!
-//!     println!("State: {}", client.connection_state()); // State: Connected
+//!     println!("State: {}", client.state().value()); // State: Connected
 //!
 //!     // See [ankurah] for usage details
 //!

--- a/signals/Cargo.toml
+++ b/signals/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name    = "ankurah-signals"
+version = "0.5.1"
+edition = "2024"
+
+[dependencies]
+tokio = { version = "1.40", features = ["sync"] }
+
+[dev-dependencies]
+tokio      = { version = "1.40", features = ["sync", "macros", "rt", "time"] }
+tokio-test = "0.4"

--- a/signals/src/core.rs
+++ b/signals/src/core.rs
@@ -1,0 +1,89 @@
+use crate::{Renderer, Subscriber, observer::Observer, traits::Signal};
+use std::{
+    ops::Deref,
+    sync::{Arc, RwLock, RwLockReadGuard},
+};
+
+pub(crate) struct Value<T>(Arc<RwLock<T>>);
+
+impl<T> Clone for Value<T> {
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+impl<T> Value<T> {
+    pub fn new(value: T) -> Self { Self(Arc::new(RwLock::new(value))) }
+
+    pub fn set(&self, value: T) {
+        let mut current = self.0.write().unwrap();
+        *current = value;
+    }
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        let guard = self.0.read().unwrap();
+        f(&*guard)
+    }
+    pub fn set_with<R>(&self, value: T, f: impl Fn(&T) -> R) -> R {
+        let mut current = self.0.write().unwrap();
+        *current = value;
+        f(&*current)
+    }
+}
+
+impl<T: Clone> Value<T> {
+    pub fn value(&self) -> T { self.0.read().unwrap().clone() }
+}
+
+// impl<T> Into<T> for Value<T>
+// where
+//     T: Clone,
+// {
+//     fn into(self) -> T { self.0.read().unwrap().clone() }
+// }
+
+static CURRENT_CONTEXT: RwLock<Option<ObserverContext>> = RwLock::new(None);
+pub struct CurrentContext {}
+
+impl CurrentContext {
+    /// Subscribes the current context to a signal
+    pub fn track<S: Signal<T>, T>(signal: &S) {
+        if let Some(observer) = CURRENT_CONTEXT.read().unwrap().as_ref() {
+            signal.subscribe(observer.subscriber());
+        }
+    }
+
+    /// Sets an observer as the current context
+    pub fn set(current: impl Into<ObserverContext>) {
+        let current: ObserverContext = current.into();
+        current.clear();
+        *CURRENT_CONTEXT.write().unwrap() = Some(current);
+    }
+
+    /// Resets the current context to no observer
+    pub fn unset() { *CURRENT_CONTEXT.write().unwrap() = None; }
+}
+
+pub enum ObserverContext {
+    Renderer(Renderer),
+    Observer(Observer),
+}
+
+impl ObserverContext {
+    pub fn clear(&self) {
+        match self {
+            ObserverContext::Renderer(renderer) => renderer.clear(),
+            ObserverContext::Observer(observer) => observer.clear(),
+        }
+    }
+    pub fn subscriber<T>(&self) -> Subscriber<T> {
+        match self {
+            ObserverContext::Renderer(renderer) => renderer.subscriber(),
+            ObserverContext::Observer(observer) => observer.subscriber(),
+        }
+    }
+}
+
+impl Into<ObserverContext> for Renderer {
+    fn into(self) -> ObserverContext { ObserverContext::Renderer(self) }
+}
+impl Into<ObserverContext> for Observer {
+    fn into(self) -> ObserverContext { ObserverContext::Observer(self) }
+}

--- a/signals/src/lib.rs
+++ b/signals/src/lib.rs
@@ -1,0 +1,67 @@
+/*!
+A reactive signals library for ankurah
+
+# Design requirements:
+- Must be dyn object safe - Not sure if we want traits, but if we do, they must be dyn object safe.
+- Writers and readers must be different types
+- writers should not implement subscription methods
+- should be able to derive directly from either writer or reader via .map()
+- reader should keep a reference to the present value
+- Should offer closure subscriptions for T ?Clone (not sure what other bounds are needed)
+- Should offer stream subscriptions for T: Clone (not sure what other bounds are needed)
+
+# Nomenclature (not sure if applicable to different types or traits - we will have to see):
+- fn subscribe_now - immediately calls the given closure with the current value, and also with future values. Only applicable to stateful types
+- fn subscribe - does not immediately call the given closure - only when the value changes. could be stateless or stateful
+
+# Basic usage
+
+```rust
+use ankurah_signals::*;
+
+let signal = Mut::new(42);
+// cant subscribe to a mutable signal
+signal.read().subscribe(|value: &i32| println!("Read value: {}", value));
+// signal.map(|value| *value * 2).subscribe(|value| println!("Mapped value: {value}"));
+signal.set(43);
+// Should print:
+// Read value: 42
+// Mapped value: 84
+// Read value: 43
+// Mapped value: 86
+```
+# Observer usage
+
+```rust
+use ankurah_signals::*;
+
+let name = Mut::new("Buffy".to_string());
+let age = Mut::new(29);
+// let retired = age.map(|age| *age > 65);
+let renderer = {
+    let name = name.read();
+    let age = age.read();
+    Renderer::new(move || println!("name: {name}, age: {age}"))
+};
+
+renderer.render();
+// name: Buffy, age: 29, retired: false
+
+// observer is still listening to all three signals
+age.set(70); // So render gets called (but only ONCE, not twice)
+// name: Buffy, age: 70, retired: true
+```
+
+*/
+
+mod core;
+mod observer;
+mod signal;
+mod subscription;
+mod traits;
+
+pub use core::*;
+pub use observer::*;
+pub use signal::*;
+pub use subscription::*;
+pub use traits::*;

--- a/signals/src/observer.rs
+++ b/signals/src/observer.rs
@@ -1,0 +1,102 @@
+use std::sync::{Arc, RwLock, Weak};
+
+use crate::{CurrentContext, ObserverContext, SubscriptionHandle, subscription::Subscriber, traits::Notify};
+
+/// A Renderer is an observer that wraps a "render" callback
+/// which automatically contextualizes itself for render, including those which
+/// are triggered by the observed values from previous renders
+pub struct Renderer(Arc<RendererInner>);
+pub struct RendererInner {
+    renderer: Box<dyn Fn() + Send + Sync>,
+    subscription_handles: RwLock<Vec<SubscriptionHandle<'static>>>,
+}
+
+/// An Observer automatically subscribes to all signals whose values are gotten while it is the current context
+/// It calls the callback without contextualizing itself
+pub struct Observer(Arc<ObserverInner>);
+pub struct ObserverInner {
+    callback: Box<dyn Fn() + Send + Sync>,
+    subscription_handles: RwLock<Vec<SubscriptionHandle<'static>>>,
+}
+
+impl Renderer {
+    /// Create a new renderer context from a callback
+    pub fn new<F: Fn() + Send + Sync + 'static>(callback: F) -> Self {
+        Self(Arc::new(RendererInner { renderer: Box::new(callback), subscription_handles: RwLock::new(vec![]) }))
+    }
+}
+impl std::ops::Deref for Renderer {
+    type Target = Arc<RendererInner>;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+impl RendererInner {
+    /// Render the callback using this context
+    pub fn render(self: &Arc<Self>) { self.with_context(&self.renderer); }
+    pub fn with_context<F: Fn()>(self: &Arc<Self>, f: &F) {
+        CurrentContext::set(self.clone());
+        f();
+        CurrentContext::unset();
+    }
+    pub fn subscriber<T>(self: &Arc<Self>) -> Subscriber<T> { Subscriber::Notify(Box::new(Arc::downgrade(self))) }
+    pub fn clear(self: &Arc<Self>) { self.subscription_handles.write().unwrap().clear() }
+    pub fn clone(self: &Arc<Self>) -> Renderer { Renderer(Arc::clone(&self)) }
+}
+
+impl Observer {
+    /// Create a new observer from a callback - contextualizing will be managed externally
+    pub fn new<F: Fn() + Send + Sync + 'static>(callback: Arc<F>) -> Self {
+        Self(Arc::new(ObserverInner { callback: Box::new(move || callback()), subscription_handles: RwLock::new(vec![]) }))
+    }
+}
+
+impl std::ops::Deref for Observer {
+    type Target = Arc<ObserverInner>;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+impl ObserverInner {
+    pub fn subscriber<T>(self: &Arc<Self>) -> Subscriber<T> { Subscriber::Notify(Box::new(Arc::downgrade(self))) }
+    pub fn clear(self: &Arc<Self>) { self.subscription_handles.write().unwrap().clear(); }
+
+    /// Execute a function with this observer as the current context
+    pub fn with_context<F: Fn()>(self: &Arc<Self>, f: &F) {
+        CurrentContext::set(self.clone());
+        f();
+        CurrentContext::unset();
+    }
+
+    /// Notify all subscribers of this observer - contextualized to this observer
+    pub fn trigger(self: &Arc<Self>) { self.with_context(&self.callback); }
+    pub fn clone(self: &Arc<Self>) -> Observer { Observer(Arc::clone(&self)) }
+}
+
+impl Notify for Weak<ObserverInner> {
+    fn notify(&self) {
+        if let Some(inner) = self.upgrade() {
+            inner.trigger();
+        }
+    }
+}
+impl Notify for Weak<RendererInner> {
+    fn notify(&self) {
+        if let Some(inner) = self.upgrade() {
+            inner.render();
+        }
+    }
+}
+
+impl<T> Into<Subscriber<T>> for ObserverContext {
+    fn into(self) -> Subscriber<T> {
+        match self {
+            ObserverContext::Renderer(renderer) => Subscriber::Notify(Box::new(Arc::downgrade(&renderer.0))),
+            ObserverContext::Observer(observer) => Subscriber::Notify(Box::new(Arc::downgrade(&observer.0))),
+        }
+    }
+}
+impl<T> Into<Subscriber<T>> for &ObserverContext {
+    fn into(self) -> Subscriber<T> {
+        match self {
+            ObserverContext::Renderer(renderer) => Subscriber::Notify(Box::new(Arc::downgrade(&renderer.0))),
+            ObserverContext::Observer(observer) => Subscriber::Notify(Box::new(Arc::downgrade(&observer.0))),
+        }
+    }
+}

--- a/signals/src/signal.rs
+++ b/signals/src/signal.rs
@@ -1,0 +1,9 @@
+pub mod map;
+pub mod memo;
+pub mod mutable;
+pub mod read;
+
+pub use map::*;
+pub use memo::*;
+pub use mutable::*;
+pub use read::*;

--- a/signals/src/signal/map.rs
+++ b/signals/src/signal/map.rs
@@ -1,0 +1,50 @@
+use crate::core::Value;
+use crate::subscription::{Subscriber, SubscriberSet};
+use crate::traits::Get;
+use std::sync::Arc;
+
+/// A signal that is a map of another signal
+/// Stateless.
+pub struct Map<I, O: 'static, F: Fn(&I) -> O> {
+    upstream: Value<I>,
+    map_function: Arc<F>,
+    subscribers: SubscriberSet<O>,
+}
+
+impl<I, O: 'static, F> Map<I, O, F>
+where F: Fn(&I) -> O + Send + Sync + 'static
+{
+    // fn with_value<R>(&self, f: impl FnOnce(&O) -> R) -> R {
+    //     // todo - figure out how to subscribe the current global observer to this signal
+    //     self.input.with_value(|input| {
+    //         let mapped = (self.map_function)(input);
+    //         f(&mapped)
+    //     })
+    // }
+
+    // pub fn subscribe<S>(&self, subscriber: S)
+    // where S: Fn(&O) + Send + Sync + 'static {
+    //     self.with_value(|value| subscriber(value));
+    //     self.subscribers.write().unwrap().subscribe(Subscriber::Callback(Box::new(subscriber)));
+    // }
+}
+
+// impl<I, O: 'static, F> Get<O> for Map<I, O, F>
+// where
+//     U: WithValue<I>,
+//     F: Fn(&I) -> O + Send + Sync + 'static,
+// {
+//     fn get(&self) -> O { self.with_value(|v| v.clone()) }
+// }
+
+// impl<I, O: Clone + 'static, F> Stateful<O> for Map<I, O, F>
+// where F: Fn(&I) -> O + Send + Sync + 'static
+// {
+//     fn value(&self) -> O { self.with_value(|v| v.clone()) }
+// }
+
+// impl<I, O: std::fmt::Display + 'static, F> std::fmt::Display for Map<I, O, F>
+// where F: Fn(&I) -> O + Send + Sync + 'static
+// {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.with_value(|v| write!(f, "{}", v)) }
+// }

--- a/signals/src/signal/memo.rs
+++ b/signals/src/signal/memo.rs
@@ -1,0 +1,30 @@
+use crate::{
+    core::{CurrentContext, Value},
+    subscription::SubscriberSet,
+    traits::{Get, Signal},
+};
+use std::{
+    marker::PhantomData,
+    sync::{Arc, RwLock},
+};
+
+/// Similar to a Map Signal, but it is stateful.
+pub struct Memo<I, O: 'static, F: Fn(&I) -> O> {
+    function: F,
+    upstream: Value<I>,
+    value: Value<O>,
+    subscribers: SubscriberSet<O>,
+}
+
+// impl<I, O: 'static, F: Fn(&I) -> O> Signal<O> for Memo<I, O, F> {}
+
+// impl<I, O: Clone + 'static, F: Fn(&I) -> O> Get<O> for Memo<I, O, F> {
+//     fn get(&self) -> O {
+//         CurrentContext::track(self);
+//         self.value.clone()
+//     }
+// }
+
+// impl WithValue<I, O> for Memo<I, O, F> {
+//     fn with_value(&self, f: impl Fn(&I) -> O) -> O { f(&self.value.read().unwrap()) }
+// }

--- a/signals/src/signal/mutable.rs
+++ b/signals/src/signal/mutable.rs
@@ -1,0 +1,31 @@
+use crate::{Read, core::Value, subscription::SubscriberSet};
+
+/// Mutable (stateful) signal. We intentionally do not implement Subscribe for this signal type
+pub struct Mut<T> {
+    value: Value<T>,
+    subscribers: SubscriberSet<T>,
+}
+
+impl<T> Mut<T> {
+    pub fn new(value: T) -> Self { Self { value: Value::new(value), subscribers: SubscriberSet::new() } }
+
+    pub fn set(&self, value: T) { self.value.set_with(value, |value| self.subscribers.notify(value)) }
+
+    /// Calls a closure with a borrow of the current value
+    /// not tracked by the current context
+    fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R { self.value.with(f) }
+
+    /// Readonly signal downstream of this mutable signal
+    pub fn read(&self) -> Read<T> {
+        let value = self.value.clone();
+        let subscribers = self.subscribers.clone();
+        Read { value, subscribers }
+    }
+}
+
+impl<T> Mut<T>
+where T: Clone
+{
+    /// Returns a clone of the current value - not tracked by the current context
+    fn value(&self) -> T { self.value.value() }
+}

--- a/signals/src/signal/read.rs
+++ b/signals/src/signal/read.rs
@@ -1,0 +1,138 @@
+use std::sync::{Arc, RwLock};
+
+use crate::{
+    core::{CurrentContext, Value},
+    subscription::{Subscriber, SubscriberSet, SubscriptionHandle},
+    traits::{Get, Signal, WaitResult},
+};
+
+/// Read-only signal
+pub struct Read<T> {
+    pub(crate) value: Value<T>,
+    pub(crate) subscribers: SubscriberSet<T>,
+}
+
+impl<T> Read<T> {
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        CurrentContext::track(self);
+        self.value.with(f)
+    }
+
+    /// Wait for the signal to match a specific value
+    ///
+    /// This method waits until the signal's value equals the given target value using `PartialEq`.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use ankurah_signals::*;
+    /// # tokio_test::block_on(async {
+    /// let signal = Mut::new(42); // Already at target value
+    ///
+    /// // Wait for the signal to reach the value 42 (already there)
+    /// signal.read().wait_value(42).await;
+    /// # });
+    /// ```
+    pub async fn wait_value(&self, target_value: T) -> ()
+    where T: PartialEq + Clone + Send + Sync + 'static {
+        // Check if current value already matches
+        if self.value.with(|v| *v == target_value) {
+            return;
+        }
+
+        // Create a notification channel
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // Subscribe to notifications
+        let _handle = self.subscribe(Subscriber::Notify(Box::new(tx)));
+
+        // Loop over notifications until we find a match
+        while rx.recv().await.is_some() {
+            if self.value.with(|v| *v == target_value) {
+                break;
+            }
+        }
+
+        // Subscription handle drops here, automatically unsubscribing
+    }
+
+    /// Wait for the signal to reach a value matching the given predicate
+    ///
+    /// This method supports flexible return types through the [`WaitResult`] trait.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use ankurah_signals::*;
+    /// # tokio_test::block_on(async {
+    /// let signal = Mut::new(11);
+    ///
+    /// // Wait for a boolean predicate - returns ()
+    /// signal.read().wait_for(|&v| v > 5).await;
+    ///
+    /// // Wait for a the predicate and include a value in the response
+    /// assert_eq!(1, signal.read().wait_for(|&v| {
+    ///     let rem = v % 5;
+    ///     if rem == 0 { None } else { Some(rem) }
+    /// }).await);
+    /// # });
+    /// ```
+    ///
+    /// ## Behavior
+    /// - The predicate is called with the current value immediately
+    /// - If it returns a "ready" result (true, Some(value)), that result is returned
+    /// - Otherwise, the method subscribes to signal updates and calls the predicate on each change
+    /// - Returns when the predicate indicates readiness by returning true or Some(value)
+    ///
+    /// [`WaitResult`]: crate::traits::WaitResult
+    pub async fn wait_for<F, R>(&self, predicate: F) -> R::Output
+    where
+        F: Fn(&T) -> R,
+        R: WaitResult,
+        T: Send + Sync,
+    {
+        // Check current value first
+        if let Some(result) = self.with(|value| predicate(value).result()) {
+            return result;
+        }
+
+        // Need to subscribe and wait
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+
+        // Keep the subscription handle alive for the duration of waiting
+        let _handle = self.subscribe(Subscriber::Notify(Box::new(sender)));
+
+        // Wait for notifications
+        while let Some(()) = receiver.recv().await {
+            if let Some(result) = self.with(|value| predicate(value).result()) {
+                return result;
+            }
+        }
+
+        // This should never happen since Read<T> cannot be dropped while we hold &self
+        unreachable!("Subscription channel closed unexpectedly - this should not be possible");
+    }
+}
+
+impl<T> Read<T>
+where T: Clone
+{
+    pub fn value(&self) -> T { self.value.value() }
+}
+
+impl<T> Clone for Read<T> {
+    fn clone(&self) -> Self { Self { value: self.value.clone(), subscribers: self.subscribers.clone() } }
+}
+
+impl<T: Clone> Get<T> for Read<T> {
+    fn get(&self) -> T {
+        CurrentContext::track(self);
+        self.value.value()
+    }
+}
+
+impl<T> Signal<T> for Read<T> {
+    fn subscribe<S: Into<Subscriber<T>>>(&self, subscriber: S) -> SubscriptionHandle { self.subscribers.subscribe(subscriber) }
+}
+
+impl<T: std::fmt::Display> std::fmt::Display for Read<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.with(|v| write!(f, "{}", v)) }
+}

--- a/signals/src/subscription.rs
+++ b/signals/src/subscription.rs
@@ -1,0 +1,114 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+
+use crate::traits::{Notify, NotifyValue};
+
+trait Unsubscriber<'a>: Send + Sync {
+    fn unsubscribe(&self);
+}
+
+struct SetUnsubscriber<T> {
+    set: Weak<SubscriberSetInner<T>>,
+    id: SubscriptionId,
+}
+
+impl<'a, T> Unsubscriber<'a> for SetUnsubscriber<T> {
+    fn unsubscribe(&self) {
+        if let Some(set) = self.set.upgrade() {
+            set.unsubscribe(self.id);
+        }
+    }
+}
+
+pub struct SubscriptionHandle<'a> {
+    unsubscriber: Box<dyn Unsubscriber<'a> + 'a>,
+}
+
+impl<'a> Drop for SubscriptionHandle<'a> {
+    fn drop(&mut self) { self.unsubscriber.unsubscribe(); }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SubscriptionId(usize);
+
+pub struct SubscriberSet<T>(Arc<SubscriberSetInner<T>>);
+
+pub struct SubscriberSetInner<T> {
+    active: Mutex<Vec<(SubscriptionId, Subscriber<T>)>>,
+    pending: Mutex<Vec<(SubscriptionId, Subscriber<T>)>>,
+    next_id: AtomicUsize,
+}
+
+impl<T> Clone for SubscriberSet<T> {
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+/// A value observer is an observer that wants to be notified of changes to a value with a borrow of the value
+pub enum Subscriber<T> {
+    Callback(Box<dyn Fn(&T) + Send + Sync>),
+    Notify(Box<dyn Notify>),
+    Value(Box<dyn NotifyValue<T>>),
+}
+
+impl<T, F> From<F> for Subscriber<T>
+where F: Fn(&T) + Send + Sync + 'static
+{
+    fn from(f: F) -> Self { Subscriber::Callback(Box::new(f)) }
+}
+
+impl<T> Into<Subscriber<T>> for Box<dyn Notify> {
+    fn into(self) -> Subscriber<T> { Subscriber::Notify(self) }
+}
+
+impl<T> From<tokio::sync::mpsc::UnboundedSender<()>> for Subscriber<T> {
+    fn from(sender: tokio::sync::mpsc::UnboundedSender<()>) -> Self { Subscriber::Notify(Box::new(sender)) }
+}
+
+impl<T> SubscriberSet<T> {
+    pub fn new() -> Self {
+        Self(Arc::new(SubscriberSetInner { active: Mutex::new(Vec::new()), pending: Mutex::new(Vec::new()), next_id: AtomicUsize::new(0) }))
+    }
+}
+
+impl<T> std::ops::Deref for SubscriberSet<T> {
+    type Target = Arc<SubscriberSetInner<T>>;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl<T> SubscriberSetInner<T> {
+    pub fn subscribe<'a, S: Into<Subscriber<T>>>(self: &'a Arc<Self>, subscriber: S) -> SubscriptionHandle<'a> {
+        let id = SubscriptionId(self.next_id.fetch_add(1, Ordering::Relaxed));
+        match self.active.try_lock() {
+            Ok(mut active) => {
+                active.push((id, subscriber.into()));
+            }
+            Err(_) => {
+                // TODO - document why the pending set is needed. I faintly recall that
+                // it had to do with subscribing during a notification and avoiding a deadlock
+                // but it's been a while and the approach needs to be revalidated.
+                self.pending.lock().unwrap().push((id, subscriber.into()));
+            }
+        }
+        SubscriptionHandle { unsubscriber: Box::new(SetUnsubscriber { set: Arc::downgrade(self), id }) }
+    }
+    pub fn unsubscribe(self: &Arc<Self>, id: SubscriptionId) {
+        let mut active = self.active.lock().unwrap();
+        active.retain(|(id, _)| id != id);
+    }
+
+    pub fn notify(self: &Arc<Self>, value: &T) {
+        let mut active = self.active.lock().unwrap();
+
+        // Notify all current subscribers
+        for (id, subscriber) in active.iter() {
+            match subscriber {
+                Subscriber::Callback(callback) => callback(value),
+                Subscriber::Notify(notify) => notify.notify(),
+                Subscriber::Value(notify) => notify.notify(value),
+            }
+        }
+
+        // Merge in any pending subscribers - no need for read check
+        active.extend(self.pending.lock().unwrap().drain(..));
+    }
+}

--- a/signals/src/traits.rs
+++ b/signals/src/traits.rs
@@ -1,0 +1,45 @@
+use std::sync::{Arc, RwLock};
+
+use crate::subscription::{Subscriber, SubscriptionHandle};
+pub trait Signal<T> {
+    fn subscribe<S: Into<Subscriber<T>>>(&self, subscriber: S) -> SubscriptionHandle;
+}
+pub trait Get<T> {
+    fn get(&self) -> T;
+}
+
+pub trait Notify: Send + Sync {
+    fn notify(&self);
+}
+
+pub trait NotifyValue<T>: Send + Sync {
+    fn notify(&self, value: &T);
+}
+
+/// Helper trait for `wait_for` to allow flexible predicate return types.
+///
+/// ## Semantics
+/// - `result()` returns `Some(output)` to stop waiting and return `output`
+/// - `result()` returns `None` to continue waiting for the next signal update
+pub trait WaitResult {
+    type Output;
+    /// Returns Some(output) if we should stop waiting, None if we should continue
+    fn result(self) -> Option<Self::Output>;
+}
+
+// Blanket impl for bool: true = stop with (), false = continue waiting
+impl WaitResult for bool {
+    type Output = ();
+    fn result(self) -> Option<Self::Output> { if self { Some(()) } else { None } }
+}
+
+// Blanket impl for Option<T>: Some(value) = stop with value, None = continue waiting
+impl<T> WaitResult for Option<T> {
+    type Output = T;
+    fn result(self) -> Option<Self::Output> { self }
+}
+
+/// Simple Notify implementation for tokio unbounded sender
+impl Notify for tokio::sync::mpsc::UnboundedSender<()> {
+    fn notify(&self) { let _ = self.send(()); }
+}

--- a/signals/tests/basic.rs
+++ b/signals/tests/basic.rs
@@ -1,0 +1,180 @@
+use ankurah_signals::*;
+mod common;
+use common::watcher;
+use tokio::{
+    sync::mpsc::unbounded_channel,
+    time::{Duration, timeout},
+};
+
+#[test]
+fn test_basic_signal() {
+    let mutable = Mut::new(42);
+    let read = mutable.read();
+
+    // closure subscription
+    let (w, check) = watcher();
+    let _handle = read.subscribe(w);
+
+    mutable.set(43);
+    mutable.set(44);
+    assert_eq!(check(), vec![43, 44]); // Signals are only notified on updates, not initial value
+
+    // channel subscription
+    let (sender, mut receiver) = unbounded_channel();
+    let _handle2 = read.subscribe(sender);
+
+    mutable.set(45);
+
+    // both should have received the update
+    assert_eq!(check(), vec![45]);
+    assert!(receiver.try_recv().is_ok(), "Should have received notification");
+}
+
+#[tokio::test]
+async fn test_wait_value() {
+    let mutable = Mut::new(1);
+    let read = mutable.read();
+
+    // Test immediate return when value already matches
+    read.wait_value(1).await;
+
+    // Test waiting for a future value
+    let task = tokio::spawn(async move { read.wait_value(42).await });
+
+    // Change the value after a short delay
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    mutable.set(42);
+
+    // The task should complete within a reasonable time
+    timeout(Duration::from_millis(100), task).await.expect("wait_value should have completed within timeout").unwrap();
+}
+
+#[tokio::test]
+async fn test_wait_predicate() {
+    let mutable = Mut::new(1);
+    let read = mutable.read();
+
+    // Test waiting for a value matching a predicate
+    let task = tokio::spawn(async move {
+        read.wait_for(|v| *v > 10).await;
+    });
+
+    // Change the value to something that matches the predicate
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    mutable.set(15);
+
+    // The task should complete
+    task.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_wait_for_result() {
+    #[derive(Debug, Clone, PartialEq)]
+    enum State {
+        Loading,
+        Success(String),
+        Error(String),
+    }
+
+    let mutable = Mut::new(State::Loading);
+
+    // Test waiting with Option<Result<>> return type
+    let read = mutable.read();
+    let success_task = tokio::spawn(async move {
+        read.wait_for(|state| match state {
+            State::Success(data) => Some(Ok(data.clone())),
+            State::Error(msg) => Some(Err(format!("Failed: {}", msg))),
+            State::Loading => None,
+        })
+        .await
+    });
+
+    // Change to success state
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    mutable.set(State::Success("completed".to_string()));
+
+    // Should get Ok result
+    let result = success_task.await.unwrap();
+    assert_eq!(result, Ok("completed".to_string()));
+
+    // Test error case
+    mutable.set(State::Loading); // Reset
+    let read = mutable.read();
+    let error_task = tokio::spawn(async move {
+        read.wait_for(|state| match state {
+            State::Success(data) => Some(Ok(data.clone())),
+            State::Error(msg) => Some(Err(format!("Failed: {}", msg))),
+            State::Loading => None,
+        })
+        .await
+    });
+
+    // Change to error state
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    mutable.set(State::Error("network timeout".to_string()));
+
+    // Should get Err result
+    let result = error_task.await.unwrap();
+    assert_eq!(result, Err("Failed: network timeout".to_string()));
+}
+
+#[tokio::test]
+async fn test_wait_for_boolean() {
+    let mutable = Mut::new(1);
+
+    // Start a task that will wait for the condition
+    let read = mutable.read();
+    let task = tokio::spawn(async move {
+        read.wait_for(|&value| value > 5).await;
+    });
+
+    // Change the value after a short delay
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    mutable.set(10);
+
+    // The task should complete within a reasonable time
+    timeout(Duration::from_millis(100), task).await.expect("wait_for should complete within timeout").unwrap();
+}
+
+#[tokio::test]
+async fn test_wait_for_option() {
+    let mutable = Mut::new(5);
+    let read = mutable.read();
+
+    // Start a task that will wait for non-zero remainder when divided by 5
+    let task = tokio::spawn(async move {
+        read.wait_for(|&value| {
+            let rem = value % 5;
+            if rem == 0 { None } else { Some(rem) }
+        })
+        .await
+    });
+
+    // Change the value after a short delay
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    mutable.set(7);
+
+    // The task should complete and return the remainder
+    let remainder = timeout(Duration::from_millis(100), task).await.expect("wait_for should complete within timeout").unwrap();
+
+    assert_eq!(remainder, 2); // 7 % 5 = 2
+}
+
+#[tokio::test]
+async fn test_wait_for_immediate_match() {
+    let mutable = Mut::new(10);
+    let read = mutable.read();
+
+    // Should return immediately since condition is already met
+    read.wait_for(|&value| value > 5).await;
+
+    // Should return immediately with extracted value
+    let remainder: usize = read
+        .wait_for(|&value| {
+            let rem = value % 7;
+            if rem == 0 { None } else { Some(rem) }
+        })
+        .await;
+
+    assert_eq!(remainder, 3); // 10 % 7 = 3
+}

--- a/signals/tests/common.rs
+++ b/signals/tests/common.rs
@@ -1,0 +1,15 @@
+use std::sync::{Arc, Mutex};
+
+pub fn watcher<T: Clone + Send + 'static>() -> (Box<dyn Fn(&T) + Send + Sync>, Box<dyn Fn() -> Vec<T> + Send + Sync>) {
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let accumulate = {
+        let values = values.clone();
+        Box::new(move |value: &T| {
+            values.lock().unwrap().push(value.clone());
+        })
+    };
+
+    let check = Box::new(move || values.lock().unwrap().drain(..).collect());
+
+    (accumulate, check)
+}

--- a/signals/tests/observer.rs
+++ b/signals/tests/observer.rs
@@ -1,0 +1,46 @@
+mod common;
+use ankurah_signals::*;
+use common::watcher;
+
+#[test]
+fn test_observer() {
+    let name: Mut<&str> = Mut::new("Buffy");
+    let age: Mut<u32> = Mut::new(29);
+    // let retired: Map<u32, bool> = age.map(|age| *age > 65);
+
+    let (accumulate, check) = watcher();
+    let renderer = {
+        let name = name.read();
+        let age = age.read();
+
+        Renderer::new(move || {
+            let body = format!("name: {}, age: {}", name.get(), age.get());
+            println!("Render: {body}");
+            accumulate(&body)
+        })
+    };
+
+    renderer.render();
+    assert_eq!(check(), ["name: Buffy, age: 29"]); // got initial render
+    assert_eq!(check(), [] as [&str; 0]); // no changes
+
+    age.set(70);
+
+    // LEFT OFF HERE for observer - audit internals
+    // this .render() should not be necessary - so something is wrong with the tracking logic (probably just never finished it)
+    // be sure to validate that signals are un-tracked at the start of each render, and re-tracked based on usage
+    // so that we are only observing signals relevant to the current conditional state
+    // eg:
+    // Renderer::new(move || {
+    //     let doc = if(age.get() < 18) {
+    //       // render function is not called subsequently if name changes
+    //       "Jane Doe (minor)".to_string();
+    //     }else{
+    //        // name and age are observed
+    //        format!("name: {}, age: {}", name.get(), age.get())
+    //     }
+    //    accumulate(doc);
+    // });
+    renderer.render();
+    assert_eq!(check(), ["name: Buffy, age: 70"]);
+}

--- a/tests/tests/websocket.rs
+++ b/tests/tests/websocket.rs
@@ -81,6 +81,9 @@ async fn test_websocket_client_create_propagation() -> Result<()> {
     let client = WebsocketClient::new(client_node.clone(), &server_url).await?;
     client.wait_connected().await?;
 
+    // Wait for system synchronization
+    client_node.system.wait_system_ready().await;
+
     let server_ctx = server_node.context(c)?;
     let client_ctx = client_node.context(c)?;
 
@@ -118,6 +121,9 @@ async fn test_websocket_subscription_propagation() -> Result<()> {
     let client_node = Node::new(client_storage, PermissiveAgent::new());
     let client = WebsocketClient::new(client_node.clone(), &server_url).await?;
     client.wait_connected().await?;
+
+    // Wait for system synchronization
+    client_node.system.wait_system_ready().await;
 
     let server_ctx = server_node.context(c)?;
     let client_ctx = client_node.context(c)?;
@@ -186,6 +192,9 @@ async fn test_websocket_bidirectional_subscription_impl() -> Result<()> {
     let client_node = Node::new(client_storage, PermissiveAgent::new());
     let client = WebsocketClient::new(client_node.clone(), &server_url).await?;
     client.wait_connected().await?;
+
+    // Wait for system synchronization
+    client_node.system.wait_system_ready().await;
 
     let server_ctx = server_node.context(c)?;
     let client_ctx = client_node.context(c)?;


### PR DESCRIPTION
## Overview

This PR introduces the new `ankurah-signals` subcrate and demonstrates its usage by migrating the ankurah-websocket-client from polling-based to reactive state management

## What's New

### 🆕 ankurah-signals Subcrate

New reactive signals library designed as an eventual replacement for `reactive-graph`:
- Provides `Mut<T>` (mutable) and `Read<T>` (read-only) signal primitives
- Supports reactive `wait_for()` and `wait_value()` methods for async state waiting
- Includes Observer and Renderer (WIP)
- **Status**: Early stage, being introduced incrementally

```rust
let state = Mut::new(ConnectionState::Disconnected);
let read_state = state.read();
read_state.wait_for(|s| matches!(s, ConnectionState::Connected { .. })).await;
```

### 🔄 WebSocket Client Migration

**Before**: `RwLock<ConnectionState>` + polling loops in `wait_connected()`
**After**: `Mut<ConnectionState>` signal + reactive `wait_for()` - no more polling!

## API Changes

### 🆕 New Reactive APIs
```rust
let client = WebsocketClient::new(node, "ws://localhost:8080").await?;

// Get reactive connection state signal  
let state_signal = client.state(); // Returns Read<ConnectionState>

state_signal.wait_for(|state| matches!(state, ConnectionState::Connected { .. })).await;

// Or just use the convenience function:
client.wait_connected().await?; // Same API, better implementation
```

## Future Work

Gradually migrate other components from `reactive-graph` to `ankurah-signals` as the library matures.