### PR TITLE
Fix react vs wasm feature mistake + React Hook Error Handling in WASM Bindings

### DIFF
--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -16,10 +16,10 @@ wasm = [
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
     "dep:js-sys",
-    "dep:ankurah-react-signals",
     "dep:reactive_graph",
     "ankurah-core/wasm",
 ]
+react = ["dep:ankurah-react-signals"]
 derive = ["dep:ankurah-derive"]
 instrument = ["ankurah-core/instrument"]
 

--- a/ankurah/src/lib.rs
+++ b/ankurah/src/lib.rs
@@ -179,7 +179,7 @@ pub use ankurah_derive::*;
 pub mod derive_deps {
     #[cfg(feature = "wasm")]
     pub use crate::GetSignalValue;
-    #[cfg(feature = "wasm")]
+    #[cfg(feature = "react")]
     pub use ::ankurah_react_signals;
     #[cfg(feature = "wasm")]
     pub use ::js_sys;

--- a/react-signals/src/react_binding.rs
+++ b/react-signals/src/react_binding.rs
@@ -10,7 +10,7 @@ use std::sync::Weak;
 
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen(module = "wasm")]
+#[wasm_bindgen(module = "react")]
 extern "C" {
     fn useRef() -> JsValue;
     fn useSyncExternalStore(


### PR DESCRIPTION
**Summary:**
Improves error handling for React hooks in WebAssembly bindings by properly catching and propagating JavaScript exceptions.

**Changes:**

1. **Restore React feature separation**:
   - Reverts the small part of previous cleanup that went too far in consolidating the "react" feature into "wasm" (turns out we need it after all)
   - Corrected extern binding module from `"wasm"` to `"react"` (whoops)
   - Proper feature gating for `ankurah-react-signals` dependency

2. **Handle React hook exceptions**:
   - Added `#[wasm_bindgen(catch)]` to `useRef()` and `useSyncExternalStore()` extern functions
   - Updated return types to `Result<JsValue, JsValue>` to handle JavaScript exceptions
   - Modified `withSignals()` to propagate React hook failures naturally using `?` operator

**Why:**
This ensures that React hook exceptions (e.g., calling hooks outside render context) properly rethrow in javascript land rather than bailing out of the wasm bindgen shim and gradually overflowing the externref stack 🤦 

React does some crazy things with dispatching components outside of a render context to get stack trace information (getStackAddendum, and other insane monkey-patching of console.warn / console.error which cause. Yeah, don't stare too deep into _that_ abyss)

...so the exceptions from rendering outside of a render context are unavoidable. (action failed successfully)

Anyhow, coping with react shenanigans aside, it seems like a good hygiene practice to trap JS dispatch errors. So yeah ✨ 