### PR TITLE
Add Automated Crate Publishing System

### DIFF
--- a/.release/publish.sh
+++ b/.release/publish.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ankurah Publishing Script
+# Publishes crates based on the top entry in the RELEASES file
+
+RELEASES_FILE="RELEASES"
+PUBLISHED_CRATES_FILE=".release/published_crates"
+ALLOW_EXISTING=false
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Safety check: ensure only RELEASES file was changed in the last commit
+check_commit_safety() {
+    log_info "Checking commit safety..."
+    
+    local changed_files
+    changed_files=$(git diff --name-only HEAD~1 HEAD)
+    
+    if [ "$changed_files" != "$RELEASES_FILE" ]; then
+        log_error "Commit contains changes to files other than $RELEASES_FILE:"
+        echo "$changed_files"
+        log_error "Publishing can only be triggered by commits that change only the $RELEASES_FILE"
+        exit 1
+    fi
+    
+    log_info "✓ Commit safety check passed"
+}
+
+# Read the top line of RELEASES file and extract version
+get_version_from_releases() {
+    if [ ! -f "$RELEASES_FILE" ]; then
+        log_error "$RELEASES_FILE not found"
+        exit 1
+    fi
+    
+    local top_line
+    top_line=$(head -n 1 "$RELEASES_FILE")
+    
+    if [ -z "$top_line" ]; then
+        log_error "$RELEASES_FILE is empty"
+        exit 1
+    fi
+    
+    # Extract version (everything before the first space)
+    local version
+    version=$(echo "$top_line" | cut -d' ' -f1)
+    
+    if [ -z "$version" ]; then
+        log_error "Could not extract version from: $top_line"
+        exit 1
+    fi
+    
+    # Validate version format (basic semver check)
+    if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
+        log_error "Invalid version format: $version (expected semver like 1.2.3)"
+        exit 1
+    fi
+    
+    echo "$version"
+}
+
+# Check if version has already been published (tag exists)
+check_already_published() {
+    local version=$1
+    local tag="v$version"
+    
+    log_info "Checking if version $version has already been published..."
+    
+    if git tag -l | grep -q "^$tag$"; then
+        log_warn "Tag $tag already exists. This version has already been published."
+        return 1  # Return non-zero to indicate already published
+    fi
+    
+    log_info "✓ Version $version has not been published yet"
+    return 0  # Return zero to indicate ready to publish
+}
+
+# Validate that we can parse the version from RELEASES file
+validate_releases_format() {
+    log_info "Validating RELEASES file format..."
+    
+    if [ ! -f "$RELEASES_FILE" ]; then
+        log_error "$RELEASES_FILE not found"
+        exit 1
+    fi
+    
+    local top_line
+    top_line=$(head -n 1 "$RELEASES_FILE")
+    
+    if [ -z "$top_line" ]; then
+        log_error "$RELEASES_FILE is empty"
+        exit 1
+    fi
+    
+    # Try to extract version to validate format
+    local version
+    version=$(echo "$top_line" | cut -d' ' -f1)
+    
+    if [ -z "$version" ]; then
+        log_error "Could not extract version from top line: $top_line"
+        exit 1
+    fi
+    
+    log_info "✓ RELEASES file format validation passed"
+}
+
+# Run cargo release to bump versions
+bump_versions() {
+    local version=$1
+    
+    log_info "Bumping versions to $version..."
+    
+    if ! cargo release version "$version" --execute --no-confirm --workspace; then
+        log_error "Failed to bump versions"
+        exit 1
+    fi
+    
+    log_info "✓ Version bump completed"
+}
+
+# Commit the version changes
+commit_version_bump() {
+    local version=$1
+    
+    log_info "Committing version bump..."
+    
+    git add .
+    git commit -m "Bump version to $version"
+    
+    log_info "✓ Version bump committed"
+}
+
+# Publish crates using cargo publish
+publish_crates() {
+    local version=$1
+    
+    log_info "Publishing crates..."
+    
+    if [ ! -f "$PUBLISHED_CRATES_FILE" ]; then
+        log_error "$PUBLISHED_CRATES_FILE not found"
+        exit 1
+    fi
+    
+    local crates
+    crates=$(grep -v '^#' "$PUBLISHED_CRATES_FILE" | grep -v '^$' | tr '\n' ' ')
+    
+    log_info "Publishing crates: $crates"
+    
+    # Use cargo publish with workspace support (available in recent Cargo versions)
+    for crate in $crates; do
+        log_info "Publishing $crate..."
+        
+        # Capture output to check for "already exists" error
+        local output
+        if output=$(cargo publish --package "$crate" 2>&1); then
+            log_info "✓ $crate published successfully"
+        else
+            # Check if it failed because the version already exists
+            if echo "$output" | grep -q "already exists on crates.io"; then
+                if [ "$ALLOW_EXISTING" = true ]; then
+                    log_warn "✓ $crate version $version already exists on crates.io, skipping"
+                else
+                    log_error "$crate version $version already exists on crates.io"
+                    log_error "Use --allow-existing flag to continue with already-published crates"
+                    exit 1
+                fi
+            else
+                log_error "Failed to publish $crate"
+                echo "$output"
+                exit 1
+            fi
+        fi
+    done
+    
+    log_info "✓ All crates published successfully"
+}
+
+# Create and push git tag
+create_and_push_tag() {
+    local version=$1
+    local tag="v$version"
+    
+    log_info "Creating and pushing tag $tag..."
+    
+    # Extract release text from RELEASES file (everything after the first space)
+    local release_text
+    release_text=$(head -n 1 "$RELEASES_FILE" | cut -d' ' -f2-)
+    
+    # Create annotated tag with release text
+    git tag -a "$tag" -m "$release_text"
+    
+    # Push the tag and current branch
+    git push origin HEAD
+    git push origin "$tag"
+    
+    log_info "✓ Tag $tag created and pushed"
+}
+
+# Main execution
+main() {
+    log_info "Starting Ankurah publishing process..."
+    
+    # Safety checks
+    check_commit_safety
+    validate_releases_format
+    
+    # Get version and validate
+    local version
+    version=$(get_version_from_releases)
+    log_info "Target version: $version"
+    
+    if ! check_already_published "$version"; then
+        log_info "Version $version has already been published. Nothing to do."
+        return 0
+    fi
+    
+    # Publishing workflow
+    bump_versions "$version"
+    commit_version_bump "$version"
+    publish_crates "$version"
+    create_and_push_tag "$version"
+    
+    log_info "🎉 Publishing completed successfully for version $version!"
+}
+
+# Parse command line arguments
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --allow-existing)
+            ALLOW_EXISTING=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "OPTIONS:"
+            echo "  --dry-run         Validate setup without actually publishing"
+            echo "  --allow-existing  Continue when crate versions already exist on crates.io"
+            echo "  -h, --help        Show this help message"
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Handle dry-run mode
+if [ "$DRY_RUN" = true ]; then
+    log_warn "DRY RUN MODE - No actual publishing will occur"
+    
+    # Just validate and show what would happen
+    check_commit_safety
+    validate_releases_format
+    
+    version=$(get_version_from_releases)
+    log_info "Would publish version: $version"
+    
+    if ! check_already_published "$version"; then
+        log_info "Version $version has already been published. Nothing would be done."
+        exit 0
+    fi
+    
+    crates=$(grep -v '^#' "$PUBLISHED_CRATES_FILE" 2>/dev/null | grep -v '^$' | tr '\n' ' ' || echo "ERROR: $PUBLISHED_CRATES_FILE not found")
+    log_info "Would publish crates: $crates"
+    
+    log_info "✓ Dry run completed - everything looks good!"
+    exit 0
+fi
+
+# Run main workflow
+main "$@" 

--- a/.release/published_crates
+++ b/.release/published_crates
@@ -1,1 +1,21 @@
-ankql ankurah-derive ankurah-proto ankurah-core ankurah-react-signals ankurah ankurah-storage-indexeddb-wasm ankurah-websocket-client-wasm ankurah-connector-local-process ankurah-storage-sled ankurah-websocket-server ankurah-storage-postgres 
+# Tier 1: Foundation crate (no internal dependencies)
+ankql
+
+# Tier 2: Core infrastructure (depends only on ankql)
+ankurah-proto
+ankurah-derive
+
+# Tier 3: Core functionality (depends on tier 1 & 2)
+ankurah-core
+ankurah-react-signals
+
+# Tier 4: Main API crate (depends on all above)
+ankurah
+
+# Tier 5: Storage and connector crates (depends on core tiers)
+ankurah-connector-local-process
+ankurah-websocket-server
+ankurah-storage-sled
+ankurah-storage-postgres
+ankurah-storage-indexeddb-wasm
+ankurah-websocket-client-wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ankql"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankql",
  "ankurah-connector-local-process",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-connector-local-process"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankql",
  "ankurah-derive",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-derive"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankql",
  "proc-macro2",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-example-server"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankurah",
  "ankurah-storage-sled",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-proto"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankql",
  "anyhow",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-react-signals"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankurah-derive",
  "any_spawner",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-signals"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "tokio",
  "tokio-test",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-indexeddb-wasm"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-postgres"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-sled"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client-wasm"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-server"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "example-model"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankurah",
  "chrono",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "example-wasm-bindings"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ankurah",
  "ankurah-storage-indexeddb-wasm",

--- a/RELEASES
+++ b/RELEASES
@@ -1,3 +1,4 @@
+0.5.2  Handle exceptions from react hooks, restore react feature flag differentiation vs wasm flag, revert erroneous edit to react extern binding
 0.5.1  Fix subscription caching bug where stale locally-cached records were included in re-subscriptions
 0.5.0  Event retrieval bugfixes, improved ID serialization, NodeAndContext reorganization
 0.4.7  

--- a/RELEASES
+++ b/RELEASES
@@ -1,0 +1,25 @@
+0.5.1  Fix subscription caching bug where stale locally-cached records were included in re-subscriptions
+0.5.0  Event retrieval bugfixes, improved ID serialization, NodeAndContext reorganization
+0.4.7  
+0.4.6  
+0.4.5  
+0.4.4  
+0.4.3  
+0.4.2  
+0.4.1  
+0.4.0  
+0.3.5  
+0.3.4  
+0.3.3  
+0.3.2  
+0.3.1  
+0.3.0  
+0.2.2  
+0.2.1  
+0.2.0  
+0.1.5  
+0.1.4  
+0.1.3  
+0.1.2  
+0.1.1  
+0.1.0  

--- a/ankql/Cargo.toml
+++ b/ankql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankql"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Ankurah Query Language - Aspirational query language for Ankurah in the style of Open Cypher and GQL (ISO/IEC 39075:2024)"
 license       = "MIT OR Apache-2.0"

--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -18,6 +18,7 @@ wasm = [
     "dep:js-sys",
     "dep:reactive_graph",
     "ankurah-core/wasm",
+    "ankurah-proto/wasm",
 ]
 react = ["dep:ankurah-react-signals"]
 derive = ["dep:ankurah-derive"]

--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Observable, event-driven state management for native and web"
 license       = "MIT OR Apache-2.0"
@@ -25,10 +25,10 @@ derive = ["dep:ankurah-derive"]
 instrument = ["ankurah-core/instrument"]
 
 [dependencies]
-ankurah-core   = { path = "../core", version = "^0.5.1" }
-ankurah-proto  = { path = "../proto", version = "^0.5.1" }
-ankurah-derive = { path = "../derive", version = "^0.5.1", optional = true }
-ankql          = { path = "../ankql", version = "^0.5.1" }
+ankurah-core   = { path = "../core", version = "^0.5.2" }
+ankurah-proto  = { path = "../proto", version = "^0.5.2" }
+ankurah-derive = { path = "../derive", version = "^0.5.2", optional = true }
+ankql          = { path = "../ankql", version = "^0.5.2" }
 serde_json     = { version = "1.0" }
 serde          = { version = "1.0" }
 tracing        = { version = "0.1.40" }
@@ -36,7 +36,7 @@ tracing        = { version = "0.1.40" }
 wasm-bindgen          = { version = "0.2", optional = true }
 wasm-bindgen-futures  = { version = "0.4", optional = true }
 js-sys                = { version = "0.3", optional = true }
-ankurah-react-signals = { path = "../react-signals", optional = true, version = "^0.5.1" }
+ankurah-react-signals = { path = "../react-signals", optional = true, version = "^0.5.2" }
 reactive_graph        = { version = "0.1.4", features = ["effects"], optional = true }
 
 [dev-dependencies]

--- a/connectors/local-process/Cargo.toml
+++ b/connectors/local-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-connector-local-process"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Ankurah connector for local processes"
 license       = "MIT OR Apache-2.0"
@@ -9,8 +9,8 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core  = { path = "../../core", version = "^0.5.1" }
-ankurah-proto = { path = "../../proto", version = "^0.5.1" }
+ankurah-core  = { path = "../../core", version = "^0.5.2" }
+ankurah-proto = { path = "../../proto", version = "^0.5.2" }
 
 tokio       = { version = "1.40", features = ["full"] }
 async-trait = "0.1"

--- a/connectors/websocket-client-wasm/Cargo.toml
+++ b/connectors/websocket-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client-wasm"
-version       = "0.5.1"
+version       = "0.5.2"
 authors       = ["Daniel Norman <daniel@danielnorman.net>"]
 edition       = "2021"
 description   = "Ankurah WebSocket Client - A WebSocket client for Ankurah"
@@ -16,14 +16,14 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm", "react"], version = "^0.5.1" }
-ankurah-core       = { path = "../../core", version = "^0.5.1" }
-ankurah-proto      = { path = "../../proto", version = "^0.5.1", features = ["wasm"] }
-ankurah-derive     = { path = "../../derive", version = "^0.5.1" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm", "react"], version = "^0.5.2" }
+ankurah-core       = { path = "../../core", version = "^0.5.2" }
+ankurah-proto      = { path = "../../proto", version = "^0.5.2", features = ["wasm"] }
+ankurah-derive     = { path = "../../derive", version = "^0.5.2" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 
-ankurah-react-signals = { path = "../../react-signals", version = "^0.5.1" }
+ankurah-react-signals = { path = "../../react-signals", version = "^0.5.2" }
 wasm-bindgen = "0.2.84"
 futures = "0.3.30"
 js-sys = "0.3.69"

--- a/connectors/websocket-client-wasm/Cargo.toml
+++ b/connectors/websocket-client-wasm/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.5.1" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm", "react"], version = "^0.5.1" }
 ankurah-core       = { path = "../../core", version = "^0.5.1" }
-ankurah-proto      = { path = "../../proto", version = "^0.5.1" }
+ankurah-proto      = { path = "../../proto", version = "^0.5.1", features = ["wasm"] }
 ankurah-derive     = { path = "../../derive", version = "^0.5.1" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/connectors/websocket-client/Cargo.toml
+++ b/connectors/websocket-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Ankurah WebSocket Client - Native WebSocket client for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -9,9 +9,9 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core    = { path = "../../core", version = "^0.5.1" }
-ankurah-proto   = { path = "../../proto", version = "^0.5.1" }
-ankurah-signals = { path = "../../signals", version = "^0.5.1" }
+ankurah-core    = { path = "../../core", version = "^0.5.2" }
+ankurah-proto   = { path = "../../proto", version = "^0.5.2" }
+ankurah-signals = { path = "../../signals", version = "^0.5.2" }
 
 # WebSocket implementation
 tokio-tungstenite = { version = "0.27", features = ["rustls-tls-native-roots"] }
@@ -32,6 +32,6 @@ url       = "2.0"
 strum     = { version = "0.27", features = ["derive"] }
 
 [dev-dependencies]
-ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.5.1" }
-ankurah-websocket-server = { path = "../websocket-server", version = "^0.5.1" }
-ankurah                  = { path = "../../ankurah", version = "^0.5.1", features = ["derive"] }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.5.2" }
+ankurah-websocket-server = { path = "../websocket-server", version = "^0.5.2" }
+ankurah                  = { path = "../../ankurah", version = "^0.5.2", features = ["derive"] }

--- a/connectors/websocket-server/Cargo.toml
+++ b/connectors/websocket-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-server"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Ankurah WebSocket Server - A WebSocket server for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ instrument = []
 [dependencies]
 
 # Base dependencies
-ankurah-proto          = { path = "../../proto", version = "^0.5.1" }
-ankurah-core           = { path = "../../core", version = "^0.5.1" }
+ankurah-proto          = { path = "../../proto", version = "^0.5.2" }
+ankurah-core           = { path = "../../core", version = "^0.5.2" }
 anyhow                 = "1.0"
 bincode                = "1.3"
 serde                  = { version = "1.0.203", features = ["derive", "serde_derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-core"
 description   = "Core state management functionality for Ankurah"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-core"
@@ -15,9 +15,9 @@ instrument = []
 
 [dependencies]
 # Internal dependencies
-ankurah-derive = { path = "../derive", optional = true, version = "^0.5.1" }
-ankql          = { path = "../ankql", version = "^0.5.1" }
-ankurah-proto  = { path = "../proto", version = "^0.5.1" }
+ankurah-derive = { path = "../derive", optional = true, version = "^0.5.2" }
+ankql          = { path = "../ankql", version = "^0.5.2" }
+ankurah-proto  = { path = "../proto", version = "^0.5.2" }
 
 rand                 = "0.8"
 anyhow               = "1.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-derive"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Ankurah Derive - Derive macros for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -26,5 +26,5 @@ syn = { version = "2.0", default-features = false, features = [
     "extra-traits",
 ] }
 serde_derive_internals = "0.29"
-ankql = { path = "../ankql", version = "^0.5.1" }
+ankql = { path = "../ankql", version = "^0.5.2" }
 regex = "1.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -26,5 +26,5 @@ syn = { version = "2.0", default-features = false, features = [
     "extra-traits",
 ] }
 serde_derive_internals = "0.29"
-ankql = { path = "../ankql" }
+ankql = { path = "../ankql", version = "^0.5.1" }
 regex = "1.0"

--- a/examples/model/Cargo.toml
+++ b/examples/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "example-model"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 publish = false
 
@@ -9,7 +9,7 @@ default = []
 wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/wasm", "ankurah/react"]
 
 [dependencies]
-ankurah        = { path = "../../ankurah", features = ["derive"], version = "^0.5.1" }
+ankurah        = { path = "../../ankurah", features = ["derive"], version = "^0.5.2" }
 serde          = { version = "1.0", features = ["derive"] }
 wasm-bindgen   = { version = "0.2", optional = true }
 reactive_graph = { version = "0.1.4", features = ["effects"], optional = true }

--- a/examples/model/Cargo.toml
+++ b/examples/model/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [features]
 default = []
-wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/wasm"]
+wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/wasm", "ankurah/react"]
 
 [dependencies]
 ankurah        = { path = "../../ankurah", features = ["derive"], version = "^0.5.1" }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name    = "ankurah-example-server"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 publish = false
 
 [dependencies]
-ankurah                  = { path = "../../ankurah", version = "^0.5.1" }
-ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "^0.5.1" }
-ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.5.1" }
+ankurah                  = { path = "../../ankurah", version = "^0.5.2" }
+ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "^0.5.2" }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.5.2" }
 tracing                  = "0.1"
 tracing-subscriber       = "0.3"
 tokio                    = { version = "1.38", features = ["rt-multi-thread"] }

--- a/examples/wasm-bindings/Cargo.toml
+++ b/examples/wasm-bindings/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name    = "example-wasm-bindings"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.5.1" }
-ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "^0.5.1" }
-ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "^0.5.1" }
-example-model                  = { path = "../model", features = ["wasm"], version = "0.5.1" }
+ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.5.2" }
+ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "^0.5.2" }
+ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "^0.5.2" }
+example-model                  = { path = "../model", features = ["wasm"], version = "0.5.2" }
 wasm-bindgen                   = "0.2.84"
 wasm-bindgen-futures           = "0.4.42"
 wasm-logger                    = "0.2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-proto"
 description   = "Inter-node communication protocol for Ankurah"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-proto"
@@ -22,7 +22,7 @@ serde              = { version = "1.0.204", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 ulid               = { version = "1.1.3", features = ["serde"] }
 base64             = { version = "0.22" }
-ankql              = { path = "../ankql", version = "^0.5.1" }
+ankql              = { path = "../ankql", version = "^0.5.2" }
 sha2               = "0.10.8"
 postgres-types     = { version = "0.2", optional = true }
 postgres-protocol  = { version = "0.6", optional = true }

--- a/react-signals/Cargo.toml
+++ b/react-signals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-react-signals"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Observe ankurah state with signals in react"
 license       = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ futures-signals      = "0.3"
 wasm-bindgen         = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys               = "0.3"
-ankurah-derive       = { path = "../derive", version = "^0.5.1", features = ["wasm"] }
+ankurah-derive       = { path = "../derive", version = "^0.5.2", features = ["wasm"] }
 reactive_graph       = { version = "0.1.4", features = ["effects"] }
 any_spawner          = { version = "0.2.0", features = ["wasm-bindgen"] }
 log                  = "0.4.22"

--- a/signals/Cargo.toml
+++ b/signals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-signals"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 
 [dependencies]

--- a/storage/indexeddb-wasm/Cargo.toml
+++ b/storage/indexeddb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-indexeddb-wasm"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Ankurah storage engine using IndexedDB in the browser"
 license       = "MIT OR Apache-2.0"
@@ -12,10 +12,10 @@ repository    = "https://github.com/ankurah/ankurah"
 default = []
 
 [dependencies]
-ankurah-core       = { path = "../../core", version = "^0.5.1" }
-ankurah-proto      = { path = "../../proto", version = "^0.5.1", features = ["wasm"] }
-ankql              = { path = "../../ankql", version = "^0.5.1" }
-ankurah-derive     = { path = "../../derive", version = "^0.5.1" }
+ankurah-core       = { path = "../../core", version = "^0.5.2" }
+ankurah-proto      = { path = "../../proto", version = "^0.5.2", features = ["wasm"] }
+ankql              = { path = "../../ankql", version = "^0.5.2" }
+ankurah-derive     = { path = "../../derive", version = "^0.5.2" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 tokio              = { version = "1.39", features = ["sync"] }
@@ -68,7 +68,7 @@ lazy_static = "1.5.0"
 #[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-ankurah           = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.5.1" }
+ankurah           = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.5.2" }
 
 
     [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/storage/indexeddb-wasm/Cargo.toml
+++ b/storage/indexeddb-wasm/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 
 [dependencies]
 ankurah-core       = { path = "../../core", version = "^0.5.1" }
-ankurah-proto      = { path = "../../proto", version = "^0.5.1" }
+ankurah-proto      = { path = "../../proto", version = "^0.5.1", features = ["wasm"] }
 ankql              = { path = "../../ankql", version = "^0.5.1" }
 ankurah-derive     = { path = "../../derive", version = "^0.5.1" }
 serde              = { version = "1.0", features = ["derive"] }

--- a/storage/postgres/Cargo.toml
+++ b/storage/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-postgres"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Ankurah storage engine using Postgres"
 license       = "MIT OR Apache-2.0"
@@ -18,9 +18,9 @@ anyhow         = "1.0"
 thiserror      = "2.0"
 tokio          = { version = "1.36", features = ["full"] }
 
-ankql         = { path = "../../ankql", version = "^0.5.1" }
-ankurah-core  = { path = "../../core", version = "^0.5.1" }
-ankurah-proto = { path = "../../proto", version = "^0.5.1", features = ["postgres"] }
+ankql         = { path = "../../ankql", version = "^0.5.2" }
+ankurah-core  = { path = "../../core", version = "^0.5.2" }
+ankurah-proto = { path = "../../proto", version = "^0.5.2", features = ["postgres"] }
 tracing       = "0.1"
 async-trait   = "0.1"
 futures-util  = "0.3"

--- a/storage/sled/Cargo.toml
+++ b/storage/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-sled"
-version       = "0.5.1"
+version       = "0.5.2"
 edition       = "2021"
 description   = "Ankurah storage engine using Sled"
 license       = "MIT OR Apache-2.0"
@@ -9,9 +9,9 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-proto = { path = "../../proto", version = "^0.5.1" }
-ankurah-core  = { path = "../../core", version = "^0.5.1" }
-ankql         = { path = "../../ankql", version = "^0.5.1" }
+ankurah-proto = { path = "../../proto", version = "^0.5.2" }
+ankurah-core  = { path = "../../core", version = "^0.5.2" }
+ankql         = { path = "../../ankql", version = "^0.5.2" }
 anyhow        = "1.0"
 async-trait   = "0.1"
 sled          = "0.34"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-tests"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 publish = false
 
@@ -11,14 +11,14 @@ postgres = ["ankurah-storage-postgres", "tokio-postgres", "bb8", "bb8-postgres"]
 [dependencies]
 anyhow                          = "1.0"
 tracing                         = "0.1"
-ankql                           = { path = "../ankql", version = "^0.5.1" }
-ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "^0.5.1" }
-ankurah-storage-sled            = { path = "../storage/sled", version = "^0.5.1" }
-ankurah-connector-local-process = { path = "../connectors/local-process", version = "^0.5.1" }
-ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "^0.5.1" }
-ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "^0.5.1" }
+ankql                           = { path = "../ankql", version = "^0.5.2" }
+ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "^0.5.2" }
+ankurah-storage-sled            = { path = "../storage/sled", version = "^0.5.2" }
+ankurah-connector-local-process = { path = "../connectors/local-process", version = "^0.5.2" }
+ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "^0.5.2" }
+ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "^0.5.2" }
 tokio-postgres                  = { version = "0.7", optional = true }
-ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "^0.5.1" }
+ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "^0.5.2" }
 bb8                             = { version = "0.9", optional = true }
 bb8-postgres                    = { version = "0.9", optional = true }
 tokio                           = { version = "1.40", features = ["full"] }
@@ -28,7 +28,7 @@ testcontainers-modules          = { version = "0.11.4", features = ["postgres"] 
 ctor                            = "0.2"
 wasm-bindgen                    = "0"
 js-sys                          = "0"
-ankurah-react-signals           = { path = "../react-signals", version = "^0.5.1" }
+ankurah-react-signals           = { path = "../react-signals", version = "^0.5.2" }
 reactive_graph                  = { version = "0.1.4", features = ["effects"] }
 serde                           = { version = "1.0", features = ["derive"] }
 ulid                            = "1.1"


### PR DESCRIPTION
This PR introduces an automated publishing system for Ankurah crates to crates.io.

### What's Added

- **Publishing Script** (`.release/publish.sh`): Handles version bumping, crate publishing in dependency order, and git tagging
- **Crate List** (`.release/published_crates`): Defines the 12 crates to publish in correct dependency order
- **Release Log** (`RELEASES`): Plaintext format tracking releases (format: `<version>  <description>`)

### How It Works

1. Parse version from top line of `RELEASES` file
2. Bump all crate versions using `cargo release`
3. Publish crates to crates.io in dependency order
4. Create and push git tag (e.g., `v0.5.2`)

### Safety Features

- **Commit Safety**: Only processes commits that change only the `RELEASES` file
- **No Duplicate Publishing**: Aborts if versions already exist (use `--allow-existing` to skip instead)
- **Tag added on Publishing**: Creates git tag only after successful publishing
- **Dependency Order**: Publishes foundation crates before dependent ones

### Local Testing

```bash
# Dry run
./.release/publish.sh --dry-run

# Real publish (with existing crate handling)
./.release/publish.sh --allow-existing
```

### Future GitHub Action

A GitHub Action will follow in a separate PR to automatically trigger publishing when PRs modify only the `RELEASES` file. This PR includes the `RELEASES` file creation (which would be illegal under the future publishing rules) to prime the system.

### Tested

✅ Successfully published 0.5.2 release locally as a verification (an already pending release)
✅ Handles already-published crates gracefully  
✅ Proper dependency order publishing  
✅ Version bumping and git tagging work correctly  
