### PR TITLE
EntityView and Active Values now implement Signal traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "ankql",
  "ankurah-derive",
  "ankurah-proto",
+ "ankurah-signals",
  "anyhow",
  "append-only-vec",
  "async-trait",
@@ -3858,9 +3859,9 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.21.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81de5913bca29f43a1d12ca92a7b39a2945e9420e01602a7563917c7bfc60f70"
+checksum = "f904a99678a852d7cbc6958c94087f739c10cfb19642635951219c525a5fdb89"
 dependencies = [
  "arc-swap",
  "async-lock",
@@ -3871,7 +3872,7 @@ dependencies = [
  "serde_json",
  "smallstr",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/ankurah/src/lib.rs
+++ b/ankurah/src/lib.rs
@@ -160,8 +160,6 @@ pub use ankurah_derive::*;
 #[cfg(feature = "derive")]
 #[doc(hidden)]
 pub mod derive_deps {
-    pub use ::ankurah_proto;
-    pub use ::ankurah_signals;
     #[cfg(feature = "wasm")]
     pub use ::js_sys;
     #[cfg(feature = "wasm")]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ instrument = []
 ankurah-derive = { path = "../derive", optional = true, version = "^0.5.4" }
 ankql          = { path = "../ankql", version = "^0.5.4" }
 ankurah-proto  = { path = "../proto", version = "^0.5.4" }
+ankurah-signals = { path = "../signals", version = "^0.5.4" }
 
 rand                 = "0.8"
 anyhow               = "1.0"
@@ -30,7 +31,7 @@ tracing              = { version = "0.1.40", features = ["max_level_debug", "rel
 bincode              = "1.3.3"
 append-only-vec      = "0.1"
 async-trait          = "0.1"
-yrs                  = "0.21.2"
+yrs                  = "0.24.0"
 tokio                = { version = "1.40", default-features = false, features = ["sync", "rt", "time", "macros"] }
 futures              = "0.3"
 futures-util         = "0.3"

--- a/core/src/property/backend/mod.rs
+++ b/core/src/property/backend/mod.rs
@@ -1,12 +1,8 @@
-use ankurah_proto::{Operation, State, StateBuffers};
+use ankurah_proto::Operation;
 use anyhow::Result;
 use std::any::Any;
 use std::fmt::Debug;
-use std::sync::MutexGuard;
-use std::{
-    collections::BTreeMap,
-    sync::{Arc, Mutex},
-};
+use std::{collections::BTreeMap, sync::Arc};
 
 pub mod lww;
 //pub mod pn_counter;
@@ -21,7 +17,7 @@ use super::{PropertyName, PropertyValue};
 pub trait PropertyBackend: Any + Send + Sync + Debug + 'static {
     fn as_arc_dyn_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync + 'static>;
     fn as_debug(&self) -> &dyn Debug;
-    fn fork(&self) -> Box<dyn PropertyBackend>;
+    fn fork(&self) -> Arc<dyn PropertyBackend>;
 
     fn properties(&self) -> Vec<PropertyName>;
     fn property_value(&self, property_name: &PropertyName) -> Option<PropertyValue> {
@@ -41,15 +37,18 @@ pub trait PropertyBackend: Any + Send + Sync + Debug + 'static {
     where Self: Sized;
 
     /// Retrieve operations applied to this backend since the last time we called this method.
-    fn to_operations(&self) -> Result<Vec<Operation>, MutationError>;
+    fn to_operations(&self) -> Result<Option<Vec<Operation>>, MutationError>;
 
     fn apply_operations(&self, operations: &Vec<Operation>) -> Result<(), MutationError>;
-}
 
-/// Holds the property backends inside of entities.
-#[derive(Debug)]
-pub struct Backends {
-    pub backends: Arc<Mutex<BTreeMap<String, Arc<dyn PropertyBackend>>>>,
+    /// Listen to changes for a specific field managed by this backend.
+    /// Auto-creates the broadcast if it doesn't exist yet.
+    /// Returns a subscription guard that will unsubscribe when dropped.
+    fn listen_field(
+        &self,
+        field_name: &PropertyName,
+        listener: ankurah_signals::broadcast::Listener,
+    ) -> ankurah_signals::broadcast::ListenerGuard;
 }
 
 // This is where this gets a bit tough.
@@ -80,112 +79,5 @@ pub fn backend_from_string(name: &str, buffer: Option<&Vec<u8>>) -> Result<Arc<d
     } */
     else {
         panic!("unknown backend: {:?}", name);
-    }
-}
-
-impl Default for Backends {
-    fn default() -> Self { Self::new() }
-}
-
-impl Backends {
-    pub fn new() -> Self { Self { backends: Arc::new(Mutex::new(BTreeMap::default())) } }
-
-    fn backends_lock(&self) -> MutexGuard<BTreeMap<String, Arc<dyn PropertyBackend>>> {
-        self.backends.lock().expect("other thread panicked, panic here too")
-    }
-
-    pub fn get<P: PropertyBackend>(&self) -> Result<Arc<P>, RetrievalError> {
-        let backend_name = P::property_backend_name();
-        let backend = self.get_raw(backend_name)?;
-        let upcasted = backend.as_arc_dyn_any();
-        Ok(upcasted.downcast::<P>().unwrap())
-    }
-
-    pub fn get_raw(&self, backend_name: String) -> Result<Arc<dyn PropertyBackend>, RetrievalError> {
-        let mut backends = self.backends_lock();
-        if let Some(backend) = backends.get(&backend_name) {
-            Ok(backend.clone())
-        } else {
-            let backend = backend_from_string(&backend_name, None)?;
-            backends.insert(backend_name, backend.clone());
-            Ok(backend)
-        }
-    }
-
-    /// Fork the data behind the backends.
-    pub fn fork(&self) -> Backends {
-        let backends = self.backends_lock();
-        let mut forked = BTreeMap::new();
-        for (name, backend) in &*backends {
-            forked.insert(name.clone(), backend.fork().into());
-        }
-
-        Self { backends: Arc::new(Mutex::new(forked)) }
-    }
-
-    fn insert(&self, backend_name: String, backend: Arc<dyn PropertyBackend>) {
-        let mut backends = self.backends_lock();
-        backends.insert(backend_name, backend);
-    }
-
-    pub fn to_state_buffers(&self) -> Result<StateBuffers, StateError> {
-        let backends = self.backends_lock();
-        let mut state_buffers = BTreeMap::default();
-        for (name, backend) in &*backends {
-            let state_buffer = backend.to_state_buffer()?;
-            state_buffers.insert(name.clone(), state_buffer);
-        }
-        Ok(StateBuffers(state_buffers))
-    }
-
-    pub fn from_state_buffers(state_buffers: &StateBuffers) -> Result<Self, RetrievalError> {
-        let backends = Backends::new();
-        for (name, state_buffer) in state_buffers.iter() {
-            let backend = backend_from_string(name, Some(state_buffer))?;
-            backends.insert(name.to_owned(), backend);
-        }
-        Ok(backends)
-    }
-
-    pub fn take_accumulated_operations(&self) -> Result<BTreeMap<String, Vec<Operation>>, MutationError> {
-        let backends = self.backends_lock();
-        let mut operations = BTreeMap::<String, Vec<Operation>>::new();
-        for (name, backend) in &*backends {
-            operations.insert(name.clone(), backend.to_operations()?);
-        }
-
-        Ok(operations)
-    }
-
-    pub fn apply_operations(&self, backend_name: String, operations: &Vec<Operation>) -> Result<(), MutationError> {
-        let backend = self.get_raw(backend_name)?;
-        backend.apply_operations(operations)?;
-        Ok(())
-    }
-
-    /// HACK - this should be based on a play forward of events
-    pub fn apply_state(&self, state: &State) -> Result<(), MutationError> {
-        let mut backends = self.backends_lock();
-        for (name, state_buffer) in state.state_buffers.iter() {
-            let backend = backend_from_string(name, Some(state_buffer))?;
-            backends.insert(name.to_owned(), backend);
-        }
-        Ok(())
-    }
-
-    pub fn property_values(&self) -> BTreeMap<PropertyName, Option<PropertyValue>> {
-        let backends = self.backends_lock();
-        let mut map = BTreeMap::new();
-        for (_, backend) in backends.iter() {
-            let values = backend.property_values();
-            for (property, value) in values {
-                if map.contains_key(&property) {
-                    panic!("Property '{:?}' is in multiple property backends", property);
-                }
-
-                map.insert(property, value);
-            }
-        }
-        map
     }
 }

--- a/core/src/property/backend/pn_counter.rs
+++ b/core/src/property/backend/pn_counter.rs
@@ -17,7 +17,7 @@ use crate::{
     Node,
 };
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub struct PNBackend {
@@ -92,7 +92,7 @@ impl PropertyBackend for PNBackend {
         let diffs = values.iter().map(|(key, value)| (key, value.diff())).collect::<BTreeMap<_, _>>();
 
         let serialized_diffs = bincode::serialize(&diffs)?;
-        Ok(vec![Operation { diff: serialized_diffs }])
+        Ok(Some(vec![Operation { diff: serialized_diffs }]))
     }
 
     fn apply_operations(
@@ -114,7 +114,6 @@ impl PropertyBackend for PNBackend {
         Ok(())
     }
 }
-
 
 macro_rules! pn_value {
     ($($integer:ty => $variant:ident),*) => {

--- a/core/src/property/mod.rs
+++ b/core/src/property/mod.rs
@@ -5,7 +5,7 @@ pub mod value;
 use std::fmt::Display;
 
 use ankurah_proto::EntityId;
-pub use backend::Backends;
+
 pub use traits::{FromActiveType, FromEntity, InitializeWith, PropertyError};
 pub use value::YrsString;
 

--- a/core/src/property/value/pn_counter.rs
+++ b/core/src/property/value/pn_counter.rs
@@ -45,7 +45,7 @@ impl<I> FromEntity for PNCounter<I>
 where I: Into<PNValue> + From<PNValue> + Copy + Clone
 {
     fn from_entity(property_name: PropertyName, entity: &Entity) -> Self {
-        let backend = entity.backends().get::<PNBackend>().expect("PNBackend should exist");
+        let backend = entity.get_backend::<PNBackend>().expect("PNBackend should exist");
         Self::new(property_name, backend)
     }
 }

--- a/core/src/property/value/yrs.rs
+++ b/core/src/property/value/yrs.rs
@@ -1,52 +1,54 @@
-use std::{
-    marker::PhantomData,
-    sync::{Arc, Weak},
-};
+use std::{marker::PhantomData, sync::Arc};
 
 use crate::{
     entity::Entity,
     error::MutationError,
     property::{
-        backend::YrsBackend,
+        backend::{PropertyBackend, YrsBackend},
         traits::{FromActiveType, FromEntity, InitializeWith, PropertyError},
         PropertyName,
     },
 };
 
-#[derive(Debug)]
+use ankurah_signals::Signal;
+
+#[derive(Debug, Clone)]
 pub struct YrsString<Projected> {
     // ideally we'd store the yrs::TransactionMut in the Transaction as an ExtendableOp or something like that
     // and call encode_update_v2 on it when we're ready to commit
     // but its got a lifetime of 'doc and that requires some refactoring
     pub property_name: PropertyName,
-    pub backend: Weak<YrsBackend>,
+    pub backend: Arc<YrsBackend>,
     phantom: PhantomData<Projected>,
+    // TODO: Pretty sure we need to store a clone of the Entity here so it's kept alive for the lifetime of the YrsString
+    // Previously this didn't matter because the YrsString wasn't clonable. Followup question on this:
+    // Will we need to update ListenerGuard to hold a dyn Any to achieve this?
+    // I ask because the ListenerGuard/SubscriptionGuard will be the only thing directly held by the user, not the YrsString/LWW
+    // OR - will the closure be enough to hold the Entity or the YrsString/LWW alive? Ideally we wouldn't overthink this and just
+    // use TDD to determine it imperically.
 }
 
 // Starting with basic string type operations
 impl<Projected> YrsString<Projected> {
-    pub fn new(property_name: PropertyName, backend: Arc<YrsBackend>) -> Self {
-        Self { property_name, backend: Arc::downgrade(&backend), phantom: PhantomData }
-    }
-    pub fn backend(&self) -> Arc<YrsBackend> { self.backend.upgrade().expect("Expected `Yrs` property backend to exist") }
-    pub fn value(&self) -> Option<String> { self.backend().get_string(&self.property_name) }
-    pub fn insert(&self, index: u32, value: &str) -> Result<(), MutationError> { self.backend().insert(&self.property_name, index, value) }
-    pub fn delete(&self, index: u32, length: u32) -> Result<(), MutationError> { self.backend().delete(&self.property_name, index, length) }
+    pub fn new(property_name: PropertyName, backend: Arc<YrsBackend>) -> Self { Self { property_name, backend, phantom: PhantomData } }
+    pub fn value(&self) -> Option<String> { self.backend.get_string(&self.property_name) }
+    pub fn insert(&self, index: u32, value: &str) -> Result<(), MutationError> { self.backend.insert(&self.property_name, index, value) }
+    pub fn delete(&self, index: u32, length: u32) -> Result<(), MutationError> { self.backend.delete(&self.property_name, index, length) }
     pub fn overwrite(&self, start: u32, length: u32, value: &str) -> Result<(), MutationError> {
-        self.backend().delete(&self.property_name, start, length)?;
-        self.backend().insert(&self.property_name, start, value)?;
+        self.backend.delete(&self.property_name, start, length)?;
+        self.backend.insert(&self.property_name, start, value)?;
         Ok(())
     }
     pub fn replace(&self, value: &str) -> Result<(), MutationError> {
-        self.backend().delete(&self.property_name, 0, self.value().unwrap_or_default().len() as u32)?;
-        self.backend().insert(&self.property_name, 0, value)?;
+        self.backend.delete(&self.property_name, 0, self.value().unwrap_or_default().len() as u32)?;
+        self.backend.insert(&self.property_name, 0, value)?;
         Ok(())
     }
 }
 
 impl<Projected> FromEntity for YrsString<Projected> {
     fn from_entity(property_name: PropertyName, entity: &Entity) -> Self {
-        let backend = entity.backends().get::<YrsBackend>().expect("YrsBackend should exist");
+        let backend = entity.get_backend::<YrsBackend>().expect("YrsBackend should exist");
         Self::new(property_name, backend)
     }
 }
@@ -94,5 +96,31 @@ impl<Projected> InitializeWith<Option<String>> for YrsString<Projected> {
             new_string.insert(0, value).unwrap();
         }
         new_string
+    }
+}
+
+impl<Projected> ankurah_signals::Signal for YrsString<Projected> {
+    fn listen(&self, listener: ankurah_signals::broadcast::Listener) -> ankurah_signals::broadcast::ListenerGuard {
+        self.backend.listen_field(&self.property_name, listener)
+    }
+
+    // TODO: determine if we should cache this or not.
+    fn broadcast_id(&self) -> ankurah_signals::broadcast::BroadcastId { self.backend.field_broadcast_id(&self.property_name) }
+}
+
+impl<Projected> ankurah_signals::Subscribe<String> for YrsString<Projected>
+where Projected: Clone + Send + Sync + 'static
+{
+    fn subscribe<F>(&self, listener: F) -> ankurah_signals::SubscriptionGuard
+    where F: ankurah_signals::subscribe::IntoSubscribeListener<String> {
+        let listener = listener.into_subscribe_listener();
+        let yrs_string = self.clone();
+        let subscription = self.listen(ankurah_signals::broadcast::IntoListener::into_listener(move || {
+            // Get current value when the broadcast fires
+            if let Some(current_value) = yrs_string.value() {
+                listener(current_value);
+            }
+        }));
+        ankurah_signals::SubscriptionGuard::new(subscription)
     }
 }

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -120,7 +120,7 @@ where
 
         let system_entity = self.0.entities.create(collection_id.clone());
 
-        let lww_backend = system_entity.backends().get::<LWWBackend>().expect("LWW Backend should exist");
+        let lww_backend = system_entity.get_backend::<LWWBackend>().expect("LWW Backend should exist");
         lww_backend.set("item".into(), proto::sys::Item::SysRoot.into_value()?);
 
         let event = system_entity.generate_commit_event()?.ok_or(anyhow!("Expected event"))?;
@@ -254,7 +254,7 @@ where
         for state in storage.fetch_states(&ankql::ast::Predicate::True).await? {
             let (_entity_changed, entity) =
                 self.0.entities.with_state(&retriever, state.payload.entity_id, collection_id.clone(), state.payload.state.clone()).await?;
-            let lww_backend = entity.backends().get::<LWWBackend>().expect("LWW Backend should exist");
+            let lww_backend = entity.get_backend::<LWWBackend>().expect("LWW Backend should exist");
             if let Some(value) = lww_backend.get(&"item".to_string()) {
                 let item = proto::sys::Item::from_value(Some(value)).expect("Invalid sys item");
 

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -279,6 +279,11 @@ pub fn derive_model_impl(stream: TokenStream) -> TokenStream {
             pub fn id(&self) -> ankurah::proto::EntityId {
                 self.entity.id().clone()
             }
+            /// Manually track this View in the current observer
+            pub fn track(&self) {
+                use ::ankurah::signals::CurrentObserver;
+                CurrentObserver::track(self);
+            }
             #(
                 #active_field_visibility fn #active_field_names(&self) -> Result<#projected_field_types, ankurah::property::PropertyError> {
                     use ankurah::property::{FromActiveType, FromEntity};

--- a/derive/src/wasm_signal.rs
+++ b/derive/src/wasm_signal.rs
@@ -54,6 +54,12 @@ pub fn derive_wasm_signal_impl(input: TokenStream) -> TokenStream {
                 use ::ankurah::signals::Get;
                 self.sig.get()
             }
+
+            #[wasm_bindgen(getter)]
+            pub fn peek(&self) -> #name {
+                use ::ankurah::signals::Peek;
+                self.sig.peek()
+            }
         }
     };
 

--- a/derive/src/wasm_signal.rs
+++ b/derive/src/wasm_signal.rs
@@ -24,7 +24,7 @@ pub fn derive_wasm_signal_impl(input: TokenStream) -> TokenStream {
 
         #[::ankurah::derive_deps::wasm_bindgen::prelude::wasm_bindgen]
         pub struct #wrapper_name{
-            pub (crate) sig: Box<dyn ::ankurah::derive_deps::ankurah_signals::GetAndDynSubscribe<#name>>,
+            pub (crate) sig: Box<dyn ::ankurah::signals::GetAndDynSubscribe<#name>>,
             pub (crate) handle: ::std::boxed::Box<dyn ::std::any::Any>
         }
 
@@ -36,8 +36,8 @@ pub fn derive_wasm_signal_impl(input: TokenStream) -> TokenStream {
         impl #wrapper_name {
 
             #[wasm_bindgen(js_name = "subscribe", skip_typescript)]
-            pub fn subscribe(&self, callback: ::ankurah::derive_deps::js_sys::Function) -> ::ankurah::derive_deps::ankurah_signals::SubscriptionGuard {
-                use ::ankurah::derive_deps::ankurah_signals::DynSubscribe;
+            pub fn subscribe(&self, callback: ::ankurah::derive_deps::js_sys::Function) -> ::ankurah::signals::SubscriptionGuard {
+                use ::ankurah::signals::DynSubscribe;
                 let callback = ::ankurah::derive_deps::send_wrapper::SendWrapper::new(callback);
 
                 self.sig.dyn_subscribe(Box::new(move |value: #name| {
@@ -51,7 +51,7 @@ pub fn derive_wasm_signal_impl(input: TokenStream) -> TokenStream {
 
             #[wasm_bindgen(getter)]
             pub fn value(&self) -> #name {
-                use ::ankurah::derive_deps::ankurah_signals::Get;
+                use ::ankurah::signals::Get;
                 self.sig.get()
             }
         }

--- a/examples/wasm-bindings/src/lib.rs
+++ b/examples/wasm-bindings/src/lib.rs
@@ -65,3 +65,16 @@ pub async fn ready() -> Result<(), JsValue> {
     }
     .map_err(|_| JsValue::from_str("Failed to connect to server"))
 }
+
+#[wasm_bindgen]
+pub async fn edit_entry(entry: &EntryView) -> Result<(), JsValue> {
+    let ctx = ctx()?;
+    let trx = ctx.begin();
+    tracing::info!("Editing entry: {:?}", entry);
+    let w = entry.edit(&trx)?;
+    w.ip_address.insert(0, "meow");
+    tracing::info!("IP address: {:?}", w.ip_address.value());
+
+    trx.commit().await?;
+    Ok(())
+}

--- a/signals/src/lib.rs
+++ b/signals/src/lib.rs
@@ -46,7 +46,7 @@ day.set("Saturday");
 
 */
 
-mod broadcast;
+pub mod broadcast;
 mod context;
 pub mod observer;
 pub mod porcelain;
@@ -56,6 +56,7 @@ mod value;
 #[cfg(feature = "react")]
 pub mod react;
 
+pub use broadcast::BroadcastId;
 pub use context::*;
 pub use observer::*;
 pub use porcelain::*;

--- a/signals/src/observer/callback_observer.rs
+++ b/signals/src/observer/callback_observer.rs
@@ -1,22 +1,25 @@
 use super::Observer;
-use crate::{CurrentObserver, Signal, broadcast::ListenerGuard};
+use crate::{
+    CurrentObserver, Signal,
+    broadcast::{BroadcastId, ListenerGuard},
+};
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::{Arc, Weak};
 
 /// A CallbackObserver is an observer that wraps a callback which is called
 /// whenver the observed signals notify the observer of a change.
 #[derive(Clone)]
 pub struct CallbackObserver(Arc<Inner>);
 struct SubscriptionEntry {
-    _guard: ListenerGuard,
+    guard: ListenerGuard,
     marked_for_removal: bool,
 }
 
 struct Inner {
     // The callback to call when the observed signals notify the observer of a change
     callback: Box<dyn Fn() + Send + Sync>,
-    // Subscriptions mapped by signal pointer for mark-and-sweep
-    subscriptions: RwLock<HashMap<usize, SubscriptionEntry>>,
+    // Subscriptions mapped by broadcast ID for mark-and-sweep
+    entries: std::sync::RwLock<HashMap<BroadcastId, SubscriptionEntry>>,
 }
 struct WeakCallbackObserver(Weak<Inner>);
 
@@ -27,7 +30,7 @@ impl WeakCallbackObserver {
 impl CallbackObserver {
     /// Create a new callback observer
     pub fn new<F: Fn() + Send + Sync + 'static>(callback: Arc<F>) -> Self {
-        Self(Arc::new(Inner { callback: Box::new(move || callback()), subscriptions: RwLock::new(HashMap::new()) }))
+        Self(Arc::new(Inner { callback: Box::new(move || callback()), entries: std::sync::RwLock::new(HashMap::new()) }))
     }
 
     /// Trigger the callback using this observer's context
@@ -35,76 +38,66 @@ impl CallbackObserver {
 
     /// Execute a function with this observer as the current context
     pub fn with_context<F: Fn()>(&self, f: &F) {
-        // Mark all existing subscriptions for removal
+        // Mark all existing listeners for removal
         self.mark_all_for_removal();
 
         CurrentObserver::set(self.clone());
         f();
         CurrentObserver::remove(self);
 
-        // Sweep away any subscriptions that weren't preserved during the callback
-        self.sweep_marked_subscriptions();
+        // Sweep away any listeners that weren't preserved during the callback
+        self.sweep_marked_listeners();
     }
 
     pub fn clear(&self) {
-        // Clear all subscriptions - they'll be dropped automatically
-        match self.0.subscriptions.try_write() {
-            Ok(mut subscriptions) => {
-                subscriptions.clear();
-            }
-            Err(_) => {
-                tracing::warn!("Possible recursion detected in clear - subscriptions lock is held");
-                // Try with blocking write just in case we're not in a recursive situation
-                self.0.subscriptions.write().unwrap().clear();
-            }
-        }
+        // Clear all listeners - they'll be dropped automatically
+        self.0.entries.write().expect("entries lock is poisoned").clear();
     }
 
-    /// Mark all existing subscriptions for removal (mark phase of mark-and-sweep)
+    /// Mark all existing listeners for removal (mark phase of mark-and-sweep)
     fn mark_all_for_removal(&self) {
-        if let Ok(mut subscriptions) = self.0.subscriptions.write() {
-            for entry in subscriptions.values_mut() {
-                entry.marked_for_removal = true;
-            }
+        // keep the for loop
+        let mut entries = self.0.entries.write().expect("entries lock is poisoned");
+        for entry in entries.values_mut() {
+            entry.marked_for_removal = true;
         }
     }
 
-    /// Remove all subscriptions that are still marked for removal (sweep phase)
-    fn sweep_marked_subscriptions(&self) {
-        if let Ok(mut subscriptions) = self.0.subscriptions.write() {
-            subscriptions.retain(|_, entry| !entry.marked_for_removal);
-        }
+    /// Remove all listeners that are still marked for removal (sweep phase)
+    fn sweep_marked_listeners(&self) {
+        let mut entries = self.0.entries.write().expect("entries lock is poisoned");
+        entries.retain(|_, entry| !entry.marked_for_removal);
     }
 }
 
 // Observer trait implementation - dyn safe
 impl Observer for CallbackObserver {
     fn observe(&self, signal: &dyn Signal) {
-        // Use the broadcast inner pointer as a unique identifier for the signal
-        let broadcast_ref = signal.broadcast();
-        let signal_id = broadcast_ref.unique_id();
+        // Use the signal's broadcast ID for identification
+        let broadcast_id = signal.broadcast_id();
 
-        // Check if we already have a subscription to this signal
-        if let Ok(mut subscriptions) = self.0.subscriptions.write() {
-            if let Some(entry) = subscriptions.get_mut(&signal_id) {
-                // We already have a subscription, just unmark it for removal
-                entry.marked_for_removal = false;
-                return;
-            }
+        // Check if we already have a listener for this broadcast
+        let mut entries = self.0.entries.write().expect("entries lock is poisoned");
 
-            // Create new subscription
-            let weak = WeakCallbackObserver(Arc::downgrade(&self.0));
-
-            let subscription = broadcast_ref.listen(move || {
-                if let Some(observer) = weak.upgrade() {
-                    observer.trigger();
-                }
-            });
-
-            let entry = SubscriptionEntry { _guard: subscription, marked_for_removal: false };
-
-            subscriptions.insert(signal_id, entry);
+        if let Some(entry) = entries.get_mut(&broadcast_id) {
+            // We already have a Listener/ListenerGuard for this broadcast, just unmark it for removal
+            entry.marked_for_removal = false;
+            return;
         }
+
+        // Create new listener
+        let weak = WeakCallbackObserver(Arc::downgrade(&self.0));
+        entries.insert(
+            broadcast_id,
+            SubscriptionEntry {
+                guard: signal.listen(Arc::new(move || {
+                    if let Some(observer) = weak.upgrade() {
+                        observer.trigger();
+                    }
+                })),
+                marked_for_removal: false,
+            },
+        );
     }
 
     fn observer_id(&self) -> usize { Arc::as_ptr(&self.0) as *const _ as usize }

--- a/signals/src/porcelain/subscribe.rs
+++ b/signals/src/porcelain/subscribe.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-use crate::{Get, broadcast::ListenerGuard};
+use crate::{Get, Peek, broadcast::ListenerGuard};
 
 /// Type alias for subscribe listeners with conditional thread safety bounds
 pub type SubscribeListener<T> = Box<dyn Fn(T) + Send + Sync + 'static>;
@@ -28,8 +28,8 @@ where S: Subscribe<T>
     fn dyn_subscribe(&self, listener: Box<dyn Fn(T) + Send + Sync + 'static>) -> SubscriptionGuard { Subscribe::subscribe(self, listener) }
 }
 
-pub trait GetAndDynSubscribe<T: 'static>: Get<T> + DynSubscribe<T> {}
-impl<T: 'static, S> GetAndDynSubscribe<T> for S where S: Get<T> + DynSubscribe<T> {}
+pub trait GetAndDynSubscribe<T: 'static>: Get<T> + Peek<T> + DynSubscribe<T> {}
+impl<T: 'static, S> GetAndDynSubscribe<T> for S where S: Get<T> + Peek<T> + DynSubscribe<T> {}
 
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct SubscriptionGuard {

--- a/signals/src/signal.rs
+++ b/signals/src/signal.rs
@@ -9,9 +9,17 @@ pub use read::*;
 
 /// Core trait for signals - provides observation capability without regard to a payload value
 /// The sole purpose of this trait is to provide a way to listen to changes to a signal.
+///
+/// Note: Multiple signals may share the same broadcast (and thus the same broadcast_id).
+/// This is intentional and allows observers to deduplicate subscriptions efficiently.
 pub trait Signal {
-    /// Get a reference to this signal's broadcast
-    fn broadcast(&self) -> crate::broadcast::Ref;
+    /// Listen to changes to this signal with a listener function
+    fn listen(&self, listener: crate::broadcast::Listener) -> crate::broadcast::ListenerGuard;
+
+    /// Get the broadcast identifier for this signal.
+    /// Multiple signals may return the same broadcast_id if they share a broadcast.
+    /// The broadcast_id remains valid as a deduplication key as long as any ListenerGuard for that broadcast exists.
+    fn broadcast_id(&self) -> crate::broadcast::BroadcastId;
 }
 
 /// Trait for getting the current value of a signal in a way that will be tracked by the current context

--- a/signals/src/signal/map.rs
+++ b/signals/src/signal/map.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
+    Peek,
     context::CurrentObserver,
     porcelain::{Subscribe, SubscriptionGuard, subscribe::IntoSubscribeListener},
     signal::{Get, Signal, With},
@@ -68,6 +69,19 @@ where
     fn get(&self) -> Output {
         // Track the source signal with the current observer
         CurrentObserver::track(&self.source);
+        // Get the source value and transform it on-demand, returning owned value
+        self.source.with(|input| (self.transform)(input))
+    }
+}
+
+impl<Upstream, Input, Output, Transform> Peek<Output> for Map<Upstream, Input, Output, Transform>
+where
+    Upstream: Signal + With<Input>,
+    Transform: Fn(&Input) -> Output,
+    Input: 'static,
+    Output: 'static,
+{
+    fn peek(&self) -> Output {
         // Get the source value and transform it on-demand, returning owned value
         self.source.with(|input| (self.transform)(input))
     }

--- a/signals/src/signal/read.rs
+++ b/signals/src/signal/read.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     broadcast::Broadcast,
     context::CurrentObserver,
@@ -56,7 +58,11 @@ impl<T: 'static> GetReadCell<T> for Read<T> {
 }
 
 impl<T> Signal for Read<T> {
-    fn broadcast(&self) -> crate::broadcast::Ref { self.broadcast.reference() }
+    fn listen(&self, listener: crate::broadcast::Listener) -> crate::broadcast::ListenerGuard {
+        self.broadcast.reference().listen(listener)
+    }
+
+    fn broadcast_id(&self) -> crate::broadcast::BroadcastId { self.broadcast.id() }
 }
 
 /// foo == bar will automatically track the signals used in the comparison against the current observer
@@ -83,12 +89,11 @@ where T: Clone + Send + Sync + 'static
     where F: IntoSubscribeListener<T> {
         let listener = listener.into_subscribe_listener();
         let ro_value = self.get_readcell(); // Get read-only value handle
-        let reader = self.broadcast();
-        let subscription = reader.listen(move || {
+        let subscription = self.listen(Arc::new(move || {
             // Get current value when the broadcast fires
             let current_value = ro_value.value();
             listener(current_value);
-        });
+        }));
         SubscriptionGuard::new(subscription)
     }
 }

--- a/signals/src/signal/read.rs
+++ b/signals/src/signal/read.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
+    Peek,
     broadcast::Broadcast,
     context::CurrentObserver,
     porcelain::{Subscribe, SubscriptionGuard, subscribe::IntoSubscribeListener},
@@ -44,6 +45,10 @@ impl<T: Clone + 'static> Get<T> for Read<T> {
         CurrentObserver::track(self);
         self.value.value()
     }
+}
+
+impl<T: Clone + 'static> Peek<T> for Read<T> {
+    fn peek(&self) -> T { self.value.value() }
 }
 
 impl<T: 'static> With<T> for Read<T> {

--- a/tests/tests/basic.rs
+++ b/tests/tests/basic.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use std::sync::Arc;
 #[cfg(feature = "postgres")]
 mod pg_common;
+use ankurah::signals::Subscribe;
 use ankurah::{policy::DEFAULT_CONTEXT as c, Node, PermissiveAgent};
+use ankurah_storage_sled::SledStorageEngine;
 
 #[tokio::test]
 async fn test_postgres() -> Result<()> {
@@ -26,3 +28,62 @@ async fn test_postgres() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_sled() -> Result<()> {
+    use common::*;
+
+    let storage_engine = SledStorageEngine::new_test()?;
+    let node = Node::new_durable(Arc::new(storage_engine), PermissiveAgent::new());
+
+    // Initialize the node's system catalog
+    node.system.create().await?;
+
+    // Get context after system is ready
+    let context = node.context_async(c).await;
+
+    let album_id;
+    {
+        let trx = context.begin();
+        let _album = trx.create(&Album { name: "The rest of the bowl".to_owned(), year: "2024".to_owned() }).await?;
+        album_id = _album.id();
+        trx.commit().await?;
+    }
+
+    // get a new copy just for clarity purposes. it shouldn't matter how you get the AlbumView, as long as it's
+    // resident, so it receives updates made on the local node.
+    // (remote updates are another story)
+    let album = context.get::<AlbumView>(album_id).await?;
+
+    let (w, check) = generic_watcher::<AlbumView>();
+    let (w2, check2) = generic_watcher::<String>();
+
+    // store the handles to keep the subscriptions alive
+    let _h1 = album.subscribe(w);
+    let _h2 = album.name().subscribe(w2); // TODO: YrsString<String> implement Subscribe<String>
+
+    let trx2 = context.begin();
+    let album_mut2 = album.edit(&trx2)?;
+
+    album_mut2.name().delete(16, 1)?; // remove the "typo" b from bowl
+
+    // we haven't committed the transaction yet - neither watcher should have received any changes
+    assert_eq!(check(), vec![]);
+    assert_eq!(check2(), Vec::<String>::new());
+
+    // commit the transaction
+    trx2.commit().await?;
+
+    // now we should have one change since we performed a delete operation
+    // TODO - implement PartialEq for Views
+    assert_eq!(check(), vec![album]);
+    assert_eq!(check2(), vec!["The rest of the owl".to_owned()]);
+
+    Ok(())
+}
+
+// After this:
+// 1. ensure that each ActiveValue (YrsString<T>, LWW<T>) keeps the AlbumView resident so it continues to receive updates made on the local node
+// 2. ensure that doing so doesn't leak memory by confirming that the AlbumView is dropped immediately after the YrsString<T> or LWW<T> is dropped.
+//    We will have to test this in the inter_node test because the only way to make edits on a single-node test is to keep the AlbumMut alive, which
+// invalidates the test, because that will continue to update the

--- a/tests/tests/common.rs
+++ b/tests/tests/common.rs
@@ -80,3 +80,18 @@ where
 
     (watcher, check)
 }
+
+/// Watcher that takes values by value (for use with Subscriber trait)
+pub fn generic_watcher<T: Clone + Send + 'static>() -> (Box<dyn Fn(T) + Send + Sync>, Box<dyn Fn() -> Vec<T> + Send + Sync>) {
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let accumulate = {
+        let values = values.clone();
+        Box::new(move |value: T| {
+            values.lock().unwrap().push(value);
+        })
+    };
+
+    let check = Box::new(move || values.lock().unwrap().drain(..).collect());
+
+    (accumulate, check)
+}


### PR DESCRIPTION
This PR implements the ankurah_signals `Signal` and `Subscribe` traits for Views and Active values

Please do note that at present these are only receiving local values.
This PR does not keep remote subscriptions active after the active query subscription has been dropped. That will be coming soon in a subsequent PR.

Basic Subscribe example 
```
    let album = context.get::<AlbumView>(album_id).await?;
    
    //  create individual subscriptions to the AlbumView, and it's two fields
    let _h1 = album.subscribe(w);
    let _h2 = album.name().subscribe(w2);
    let _h3 = album.year().subscribe(w3);
```
