### PR TITLE
 Reactor Hot Path Serialization & Parallelization

### DIFF
--- a/core/src/changes.rs
+++ b/core/src/changes.rs
@@ -1,10 +1,20 @@
-use crate::{entity::Entity, error::MutationError, model::View};
+use crate::{entity::Entity, error::MutationError, model::View, reactor::ChangeNotification};
 use ankurah_proto::{Attested, Event};
 
 #[derive(Debug, Clone)]
 pub struct EntityChange {
     entity: Entity,
     events: Vec<Attested<Event>>,
+}
+
+// Implement the trait for EntityChange
+impl ChangeNotification for EntityChange {
+    type Entity = Entity;
+    type Event = ankurah_proto::Attested<Event>;
+
+    fn into_parts(self) -> (Self::Entity, Vec<Self::Event>) { (self.entity, self.events) }
+    fn entity(&self) -> &Self::Entity { &self.entity }
+    fn events(&self) -> &[Self::Event] { &self.events }
 }
 
 // TODO consider a flattened version of EntityChange that includes the entity and Vec<(operations, parent, attestations)> rather than a Vec<Attested<Event>>
@@ -23,8 +33,6 @@ impl EntityChange {
         }
         Ok(Self { entity, events })
     }
-    pub fn entity(&self) -> &Entity { &self.entity }
-    pub fn events(&self) -> &[Attested<Event>] { &self.events }
     pub fn into_parts(self) -> (Entity, Vec<Attested<Event>>) { (self.entity, self.events) }
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -283,7 +283,7 @@ where
         }
 
         // Notify reactor of ALL changes
-        self.node.reactor.notify_change(changes);
+        self.node.reactor.notify_change(changes).await;
         Ok(())
     }
 }

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -546,7 +546,7 @@ where
             }
         }
 
-        self.reactor.notify_change(changes);
+        self.reactor.notify_change(changes).await;
 
         Ok(())
     }

--- a/core/src/peer_subscription/applier.rs
+++ b/core/src/peer_subscription/applier.rs
@@ -71,7 +71,7 @@ impl UpdateApplier {
                 Self::apply_update(node, from_peer_id, update, &retriever, &mut changes, &mut ()).await?;
             }
 
-            node.reactor.notify_change(changes);
+            node.reactor.notify_change(changes).await;
         }
 
         Ok(())

--- a/core/src/reactor.rs
+++ b/core/src/reactor.rs
@@ -1,38 +1,35 @@
+mod candidate_changes;
 mod comparison_index;
 pub mod fetch_gap;
 mod subscription;
 mod subscription_state;
 mod update;
+mod watcherset;
 
 pub(crate) use self::{
-    comparison_index::ComparisonIndex,
+    candidate_changes::CandidateChanges,
     subscription::{ReactorSubscription, ReactorSubscriptionId},
     update::{MembershipChange, ReactorUpdate, ReactorUpdateItem},
+    watcherset::{WatcherChange, WatcherSet},
 };
 
 // Re-export fetch_gap items
 pub(crate) use self::fetch_gap::GapFetcher;
 
 use crate::{
-    changes::EntityChange,
     entity::Entity,
     error::SubscriptionError,
     indexing::{IndexDirection, IndexKeyPart, KeySpec, NullsOrder},
-    reactor::{
-        subscription::ReactorSubInner,
-        subscription_state::{QueryState, SubscriptionState},
-    },
+    reactor::{subscription::ReactorSubInner, subscription_state::Subscription, watcherset::WatcherOp},
     resultset::EntityResultSet,
     value::{Value, ValueType},
 };
 use ankurah_proto::{self as proto};
-use indexmap::IndexMap;
+use futures::future::join_all;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::{Arc, Mutex},
 };
-
-use tracing::debug;
 
 /// Trait for entities that can be used in reactor notifications
 pub trait AbstractEntity: Clone + std::fmt::Debug {
@@ -47,6 +44,8 @@ pub trait ChangeNotification: std::fmt::Debug + std::fmt::Display {
     type Event: Clone + std::fmt::Debug;
 
     fn into_parts(self) -> (Self::Entity, Vec<Self::Event>);
+    fn entity(&self) -> &Self::Entity;
+    fn events(&self) -> &[Self::Event];
 }
 
 // Implement ReactorEntity for Entity
@@ -66,14 +65,6 @@ impl AbstractEntity for Entity {
     }
 }
 
-// Implement the trait for EntityChange
-impl ChangeNotification for EntityChange {
-    type Entity = Entity;
-    type Event = ankurah_proto::Attested<proto::Event>;
-
-    fn into_parts(self) -> (Self::Entity, Vec<Self::Event>) { self.into_parts() }
-}
-
 /// A Reactor is a collection of subscriptions, which are to be notified of changes to a set of entities
 pub struct Reactor<
     E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static = Entity,
@@ -81,49 +72,12 @@ pub struct Reactor<
 >(Arc<ReactorInner<E, Ev>>);
 
 struct ReactorInner<E: AbstractEntity + ankql::selection::filter::Filterable, Ev> {
-    subscriptions: Mutex<HashMap<ReactorSubscriptionId, SubscriptionState<E, Ev>>>,
-    watcher_set: Mutex<WatcherSet>,
+    subscriptions: std::sync::Mutex<HashMap<ReactorSubscriptionId, Subscription<E, Ev>>>,
+    // TODO: per-entity locking would be better than a global lock
+    watcher_set: std::sync::Mutex<WatcherSet>,
+    /// Serializes notify_change invocations to ensure consistent watcher state
+    notify_lock: tokio::sync::Mutex<()>,
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum EntityWatcherId {
-    Predicate(ReactorSubscriptionId, proto::QueryId),
-    Subscription(ReactorSubscriptionId),
-}
-
-impl EntityWatcherId {
-    pub fn subscription_id(&self) -> ReactorSubscriptionId {
-        match self {
-            EntityWatcherId::Predicate(sub_id, _) => *sub_id,
-            EntityWatcherId::Subscription(sub_id) => *sub_id,
-        }
-    }
-}
-
-struct WatcherSet {
-    /// Each field has a ComparisonIndex so we can quickly find all subscriptions that care if a given value CHANGES (creation and deletion also count as change
-    index_watchers: HashMap<(proto::CollectionId, FieldId), ComparisonIndex<(ReactorSubscriptionId, proto::QueryId)>>,
-    /// The set of watchers who want to be notified of any changes to a given collection
-    wildcard_watchers: HashMap<proto::CollectionId, HashSet<(ReactorSubscriptionId, proto::QueryId)>>,
-    /// Index of subscriptions that presently match each entity, either by predicate or by entity subscription.
-    /// This is used to quickly find all subscriptions that need to be notified when an entity changes.
-    /// We have to maintain this to add and remove subscriptions when their matching state changes.
-    entity_watchers: HashMap<ankurah_proto::EntityId, HashSet<EntityWatcherId>>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FieldId(String);
-
-impl From<&str> for FieldId {
-    fn from(val: &str) -> Self { FieldId(val.to_string()) }
-}
-
-#[derive(Debug, Copy, Clone)]
-enum WatcherOp {
-    Add,
-    Remove,
-}
-
 // don't require Clone SE or PA, because we have an Arc
 impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, Ev: Clone + Send + 'static> Clone for Reactor<E, Ev> {
     fn clone(&self) -> Self { Self(self.0.clone()) }
@@ -137,97 +91,79 @@ impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, 
     pub fn new() -> Self {
         Self(Arc::new(ReactorInner {
             subscriptions: Mutex::new(HashMap::new()),
-            watcher_set: Mutex::new(WatcherSet {
-                index_watchers: HashMap::new(),
-                wildcard_watchers: HashMap::new(),
-                entity_watchers: HashMap::new(),
-            }),
+            watcher_set: Mutex::new(WatcherSet::new()),
+            notify_lock: tokio::sync::Mutex::new(()),
         }))
     }
 
     /// Create a new subscription container
     pub fn subscribe(&self) -> ReactorSubscription<E, Ev> {
         let broadcast = ankurah_signals::broadcast::Broadcast::new();
-        let subscription = SubscriptionState {
-            id: ReactorSubscriptionId::new(),
-            queries: HashMap::new(),
-            entity_subscriptions: HashSet::new(),
-            entities: HashMap::new(),
-            broadcast: broadcast.clone(),
-        };
-        let subscription_id = subscription.id;
+        let subscription = Subscription::new(broadcast.clone());
+        let subscription_id = subscription.id();
         self.0.subscriptions.lock().unwrap().insert(subscription_id, subscription);
         ReactorSubscription(Arc::new(ReactorSubInner { subscription_id, reactor: self.clone(), broadcast }))
     }
-}
 
-impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, Ev: Clone + Send + 'static> Reactor<E, Ev> {
     /// Remove a subscription and all its predicates
     pub(crate) fn unsubscribe(&self, sub_id: ReactorSubscriptionId) -> Result<(), SubscriptionError> {
-        let mut subscriptions = self.0.subscriptions.lock().unwrap();
+        let subscription = {
+            let mut subscriptions = self.0.subscriptions.lock().unwrap();
+            subscriptions.remove(&sub_id).ok_or(SubscriptionError::SubscriptionNotFound)?
+        };
+
+        // Get all queries for cleanup
+        let queries = subscription.take_all_queries();
+
+        // Remove all predicates from watchers
         let mut watcher_set = self.0.watcher_set.lock().unwrap();
+        for (query_id, query_state) in queries {
+            // Remove from index watcher
+            watcher_set.recurse_predicate_watchers(
+                &query_state.collection_id,
+                &query_state.selection.predicate,
+                (sub_id, query_id),
+                WatcherOp::Remove,
+            );
 
-        if let Some(sub) = subscriptions.remove(&sub_id) {
-            // Remove all predicates from watchers
-            for (query_id, query_state) in sub.queries {
-                // Remove from index watcher
-                watcher_set.recurse_predicate_watchers(
-                    &query_state.collection_id,
-                    &query_state.selection.predicate,
-                    (sub_id, query_id),
-                    WatcherOp::Remove,
-                );
-
-                // Remove from entity watchers using predicate's matching entities
-                for entity_id in query_state.resultset.keys() {
-                    if let Some(watchers) = watcher_set.entity_watchers.get_mut(&entity_id) {
-                        // only remove the subscription watcher, not the entity watchers based on currently matching predicates
-                        watchers.remove(&EntityWatcherId::Subscription(sub_id));
-                    }
-                }
-            }
-        } else {
-            return Err(SubscriptionError::SubscriptionNotFound);
+            // Remove from entity watchers using predicate's matching entities
+            let entity_ids: Vec<_> = query_state.resultset.keys().collect();
+            watcher_set.remove_entity_subscriptions(sub_id, entity_ids);
         }
 
         Ok(())
     }
 
     /// Remove a predicate from a subscription
-    pub fn remove_predicate(&self, subscription_id: ReactorSubscriptionId, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
-        let mut subscriptions = self.0.subscriptions.lock().unwrap();
-        let mut watcher_state = self.0.watcher_set.lock().unwrap();
-
-        // remove the predicate from the subscription
-        let query_state = match subscriptions.get_mut(&subscription_id) {
-            Some(sub) => match sub.queries.remove(&query_id) {
-                Some(p) => p,
-                None => return Err(SubscriptionError::PredicateNotFound),
-            },
-            None => return Err(SubscriptionError::SubscriptionNotFound),
+    pub fn remove_query(&self, subscription_id: ReactorSubscriptionId, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
+        let subscription = {
+            let subscriptions = self.0.subscriptions.lock().unwrap();
+            subscriptions.get(&subscription_id).cloned().ok_or(SubscriptionError::SubscriptionNotFound)?
         };
 
+        // Remove the query from the subscription
+        let query_state = subscription.remove_query(query_id).ok_or(SubscriptionError::PredicateNotFound)?;
+
         // Remove from watchers
+        let mut watcher_set = self.0.watcher_set.lock().unwrap();
         let watcher_id = (subscription_id, query_id);
-        watcher_state.recurse_predicate_watchers(
-            &query_state.collection_id,
-            &query_state.selection.predicate,
-            watcher_id,
-            WatcherOp::Remove,
-        );
+        watcher_set.recurse_predicate_watchers(&query_state.collection_id, &query_state.selection.predicate, watcher_id, WatcherOp::Remove);
 
         Ok(())
     }
 
     /// Add entity subscriptions to a subscription
     pub fn add_entity_subscriptions(&self, subscription_id: ReactorSubscriptionId, entity_ids: impl IntoIterator<Item = proto::EntityId>) {
-        let mut subscriptions = self.0.subscriptions.lock().unwrap();
-        let mut watcher_state = self.0.watcher_set.lock().unwrap();
+        let subscription = {
+            let subscriptions = self.0.subscriptions.lock().unwrap();
+            subscriptions.get(&subscription_id).cloned()
+        };
 
-        if let Some(subscription) = subscriptions.get_mut(&subscription_id) {
+        if let Some(subscription) = subscription {
+            let mut watcher_set = self.0.watcher_set.lock().unwrap();
             for entity_id in entity_ids {
-                subscription.entity_subscriptions.insert(entity_id);
-                watcher_state.entity_watchers.entry(entity_id).or_default().insert(EntityWatcherId::Subscription(subscription_id));
+                subscription.add_entity_subscription(entity_id);
+                watcher_set.add_entity_subscription(subscription_id, entity_id);
             }
         }
     }
@@ -239,62 +175,26 @@ impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, 
         entity_ids: impl IntoIterator<Item = proto::EntityId>,
     ) {
         let mut subscriptions = self.0.subscriptions.lock().unwrap();
-        let mut watcher_state = self.0.watcher_set.lock().unwrap();
+        let mut watcher_set = self.0.watcher_set.lock().unwrap();
 
         if let Some(subscription) = subscriptions.get_mut(&subscription_id) {
             for entity_id in entity_ids {
-                subscription.entity_subscriptions.remove(&entity_id);
+                subscription.remove_entity_subscription(entity_id);
 
                 // TODO: Check if any predicates match this entity before removing from entity_watchers
                 // For now, only remove if no predicates match
-                let should_remove = !subscription.queries.values().any(|p| p.resultset.contains_key(&entity_id));
+                let should_remove = !subscription.any_query_matches(&entity_id);
 
                 if should_remove {
-                    if let Some(watchers) = watcher_state.entity_watchers.get_mut(&entity_id) {
-                        watchers.remove(&EntityWatcherId::Subscription(subscription_id));
-                        if watchers.is_empty() {
-                            watcher_state.entity_watchers.remove(&entity_id);
-                        }
-                    }
+                    watcher_set.remove_entity_subscription(subscription_id, entity_id);
                 }
-            }
-        }
-    }
-
-    /// Update predicate matching entities when an entity's matching status changes
-    /// We need to keep a list of matching entities for subscription / predicate in order to keep the entity resident in memory
-    /// so we don't have to re-fetch it from storage every time (later, make this an LRU cached Entity, but just hold the Entity for now)
-    fn update_query_matching_entities(subscription: &mut SubscriptionState<E, Ev>, query_id: proto::QueryId, entity: &E, matching: bool) {
-        if let Some(predicate_state) = subscription.queries.get_mut(&query_id) {
-            let entity_id = AbstractEntity::id(entity);
-            let did_match = predicate_state.resultset.contains_key(entity_id);
-
-            match (did_match, matching) {
-                (false, true) => {
-                    // Entity now matches - add to matching set and cache the entity
-                    tracing::info!(
-                        "PUSH entity {} to predicate resultset {} len: {}",
-                        entity_id,
-                        query_id,
-                        predicate_state.resultset.len()
-                    );
-                    predicate_state.resultset.write().add(entity.clone());
-                    subscription.entities.insert(*entity_id, entity.clone());
-                }
-                (true, false) => {
-                    tracing::info!("REMOVE entity {} from predicate resultset {}", entity_id, query_id);
-                    // Entity no longer matches - remove from matching set
-                    // (but keep in entity cache for now - it might still be needed by other predicates)
-                    predicate_state.resultset.write().remove(*entity_id);
-                }
-                _ => {} // No change needed
             }
         }
     }
 }
 
 /// Build KeySpec from Selection's ORDER BY clause with type inference from sample entities
-fn build_key_spec_from_selection<E: AbstractEntity>(
+pub(crate) fn build_key_spec_from_selection<E: AbstractEntity>(
     order_by: &[ankql::ast::OrderByItem],
     resultset: &EntityResultSet<E>,
 ) -> anyhow::Result<KeySpec> {
@@ -334,76 +234,39 @@ impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, 
         resultset: EntityResultSet<E>,
         gap_fetcher: std::sync::Arc<dyn GapFetcher<E>>,
     ) -> anyhow::Result<()> {
-        let mut reactor_update_items: Vec<ReactorUpdateItem<E, Ev>> = Vec::new();
-
-        // Create new predicate state and process entities in single subscriptions lock
-        let mut subscriptions = self.0.subscriptions.lock().expect("failed to lock subscriptions");
-        let subscription =
-            subscriptions.get_mut(&subscription_id).ok_or_else(|| anyhow::anyhow!("Subscription {:?} not found", subscription_id))?;
-
-        // Fail if predicate already exists, otherwise insert and get mutable reference
-        use std::collections::hash_map::Entry;
-        let pred_state = match subscription.queries.entry(query_id) {
-            Entry::Vacant(v) => v.insert(QueryState {
-                collection_id: collection_id.clone(),
-                selection: selection.clone(),
-                gap_fetcher,
-                paused: false,
-                resultset: resultset.clone(),
-                version: 0,
-            }),
-            Entry::Occupied(_) => return Err(anyhow::anyhow!("Predicate {:?} already exists", query_id)),
+        // Get subscription reference
+        let subscription = {
+            let subscriptions = self.0.subscriptions.lock().unwrap();
+            subscriptions.get(&subscription_id).cloned().ok_or_else(|| anyhow::anyhow!("Subscription {:?} not found", subscription_id))?
         };
 
-        pred_state
-            .resultset
-            .order_by(selection.order_by.map(|ob| build_key_spec_from_selection(ob.as_slice(), &pred_state.resultset)).transpose()?);
-        pred_state.resultset.limit(selection.limit.map(|l| l as usize));
+        // Add query to subscription and get entities for watcher setup
+        let entities = subscription.add_query(query_id, collection_id.clone(), selection.clone(), resultset, gap_fetcher)?;
 
-        // Set up predicate watchers
-        let mut watcher_state = self.0.watcher_set.lock().unwrap();
+        // Set up watchers
+        let mut watcher_set = self.0.watcher_set.lock().unwrap();
         let watcher_id = (subscription_id, query_id);
-        watcher_state.recurse_predicate_watchers(&collection_id, &selection.predicate, watcher_id, WatcherOp::Add);
+        watcher_set.recurse_predicate_watchers(&collection_id, &selection.predicate, watcher_id, WatcherOp::Add);
+        watcher_set.add_predicate_entity_watchers(subscription_id, query_id, entities.iter().map(|(id, _)| *id));
+        drop(watcher_set);
 
-        // Process entities from the pre-populated resultset
-        let read_guard = pred_state.resultset.read();
-        for (entity_id, entity) in read_guard.iter_entities() {
-            subscription.entity_subscriptions.insert(entity_id);
-            let entity_watcher = watcher_state.entity_watchers.entry(entity_id).or_default();
-            // entity_watcher.insert(EntityWatcherId::Subscription(subscription_id)); // Uncomment this when we have unsubscribe on drop from the peer
-            entity_watcher.insert(EntityWatcherId::Predicate(subscription_id, query_id));
-            reactor_update_items.push(ReactorUpdateItem {
-                entity: entity.clone(),
-                events: vec![],
-                entity_subscribed: true,
-                predicate_relevance: vec![(query_id, MembershipChange::Initial)],
-            });
-        }
-        drop(watcher_state);
-        drop(read_guard);
-
-        // pred_state.paused = false; // Unpause now that initialization is complete
-
-        let broadcast = subscription.broadcast.clone(); // clone the broadcast to eliminate the potential deadlock
-        drop(subscriptions); // Drop subscriptions lock
-
-        resultset.set_loaded(true);
-        broadcast.send(ReactorUpdate { items: reactor_update_items, initialized_query: Some((query_id, 0)) });
+        // Send initialization update
+        subscription.send_add_query_update(query_id, entities);
 
         Ok(())
     }
 
     /// Pause a predicate from receiving notifications - gets unpaused by update_query
-    pub fn pause_query(&self, query_id: proto::QueryId) {
-        let mut subscriptions = self.0.subscriptions.lock().unwrap();
-
-        // Find the subscription that has this predicate
-        for subscription in subscriptions.values_mut() {
-            if let Some(pred_state) = subscription.queries.get_mut(&query_id) {
-                pred_state.paused = true;
-            }
-        }
-    }
+    // fn pause_query(&self, query_id: proto::QueryId) {
+    //     // is this actually used?
+    //     let subscriptions = self.0.subscriptions.lock().unwrap();
+    //     // Find the subscription that has this predicate and pause it
+    //     for subscription in subscriptions.values() {
+    //         if subscription.pause_query(query_id) {
+    //             break;
+    //         }
+    //     }
+    // }
 
     /// Update an existing predicate (v>0)
     /// Does diffing against the current resultset
@@ -417,258 +280,77 @@ impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, 
         version: u32,
         emit_removes: bool, // Whether to emit Remove events for entities that no longer match
     ) -> anyhow::Result<()> {
-        let mut subscriptions = self.0.subscriptions.lock().unwrap();
-        let mut watcher_state = self.0.watcher_set.lock().unwrap();
+        // Get subscription reference
+        let subscription = {
+            let subscriptions = self.0.subscriptions.lock().unwrap();
+            subscriptions.get(&subscription_id).cloned().ok_or_else(|| anyhow::anyhow!("Subscription {:?} not found", subscription_id))?
+        };
 
-        // Get the subscription
-        let subscription =
-            subscriptions.get_mut(&subscription_id).ok_or_else(|| anyhow::anyhow!("Subscription {:?} not found", subscription_id))?;
+        // Update query and get results
+        let (old_predicate, newly_added, removed_entities, reactor_update_items) =
+            subscription.update_query(query_id, collection_id.clone(), selection.clone(), included_entities, version, emit_removes)?;
 
-        // Get mutable reference to predicate state (must exist for v>0)
-        let query_state = subscription.queries.get_mut(&query_id).ok_or_else(|| anyhow::anyhow!("Predicate not found for update"))?;
-
-        // Update the predicate AST
-        let old_query = query_state.selection.clone();
-        query_state.selection = selection.clone();
-
-        query_state
-            .resultset
-            .order_by(selection.order_by.map(|ob| build_key_spec_from_selection(ob.as_slice(), &query_state.resultset)).transpose()?);
-
-        // Check if LIMIT changed
-        if old_query.limit != selection.limit {
-            query_state.resultset.limit(selection.limit.map(|l| l as usize));
-        }
+        // Update watchers
+        let mut watcher_set = self.0.watcher_set.lock().unwrap();
+        let watcher_id = (subscription_id, query_id);
 
         // Update index watchers if predicate changed
-        let watcher_id = (subscription_id, query_id);
-        watcher_state.recurse_predicate_watchers(&collection_id, &old_query.predicate, watcher_id, WatcherOp::Remove);
-        watcher_state.recurse_predicate_watchers(&collection_id, &selection.predicate, watcher_id, WatcherOp::Add);
+        watcher_set.recurse_predicate_watchers(&collection_id, &old_predicate, watcher_id, WatcherOp::Remove);
+        watcher_set.recurse_predicate_watchers(&collection_id, &selection.predicate, watcher_id, WatcherOp::Add);
 
-        // Create write guard for atomic updates
-        let mut rw_resultset = query_state.resultset.write();
-        let mut reactor_update_items = Vec::new();
+        // Add watchers for newly added entities
+        watcher_set.add_predicate_entity_watchers(subscription_id, query_id, newly_added.iter().map(|(id, _)| *id));
 
-        // Mark all entities dirty for re-evaluation on every update_query
-        rw_resultset.mark_all_dirty();
+        // Clean up watchers for removed entities
+        watcher_set.cleanup_removed_predicate_watchers(subscription_id, query_id, &removed_entities);
 
-        // Process included entities (only truly new ones from remote)
-        for entity in included_entities {
-            // I think we can trust that the included_entities are already known to match the predicate, so we probably don't need to evaluate it here?
-            // it would be nice to not assume that though in case of race conditions - but that gets tricky with order by + limit scenarios
-            // We know that the server doesn't presently include the full set of entities that match when updating a predicate.
-            // I don't know if we can get away with that or not. I suspect that we may need to fully re-query in LiveQuery.update_selection when an orderby/limit is involved.
-            if ankql::selection::filter::evaluate_predicate(&entity, &selection.predicate).unwrap_or(false) {
-                let entity_id = AbstractEntity::id(&entity);
-
-                // Check if this is truly new to the resultset
-                if !rw_resultset.contains(entity_id) {
-                    // Add to write guard
-                    rw_resultset.add(entity.clone());
-
-                    // Add to subscription entities map
-                    subscription.entities.insert(*entity_id, entity.clone());
-
-                    // Set up entity watchers
-                    subscription.entity_subscriptions.insert(*entity_id);
-                    let entity_watcher = watcher_state.entity_watchers.entry(*entity_id).or_default();
-                    entity_watcher.insert(EntityWatcherId::Subscription(subscription_id));
-                    entity_watcher.insert(EntityWatcherId::Predicate(subscription_id, query_id));
-
-                    // Create reactor update item (Initial for truly new entities)
-                    reactor_update_items.push(ReactorUpdateItem {
-                        entity,
-                        events: vec![],
-                        entity_subscribed: true,
-                        predicate_relevance: vec![(query_id, MembershipChange::Initial)],
-                    });
-                }
-            }
-        }
-
-        // Remove entities that were not covered by the included_entities and no longer match the new predicate using retain_dirty
-        rw_resultset.retain_dirty(|entity| {
-            if let Ok(true) = ankql::selection::filter::evaluate_predicate(entity, &selection.predicate) {
-                return true;
-            };
-            let entity_id = entity.id();
-            tracing::debug!("Entity {:?} no longer matches predicate", entity_id);
-
-            // If emit_removes is true, create a Remove event for local subscriptions
-            if emit_removes {
-                tracing::debug!("Creating Remove event for entity {:?}", entity_id);
-                reactor_update_items.push(ReactorUpdateItem {
-                    entity: entity.clone(),
-                    events: vec![],
-                    entity_subscribed: false,
-                    predicate_relevance: vec![(query_id, MembershipChange::Remove)],
-                });
-            }
-
-            // Clean up entity predicate watcher (but keep subscription watcher)
-            if let Some(entity_watcher) = watcher_state.entity_watchers.get_mut(entity_id) {
-                entity_watcher.remove(&EntityWatcherId::Predicate(subscription_id, query_id));
-
-                // TODO: Investigate if subscription.entities is being correctly populated and used
-                // If no more predicates are watching this entity, remove it from subscription.entities
-                // (but only if it's not explicitly subscribed)
-                if !subscription.entity_subscriptions.contains(entity_id) {
-                    let has_other_predicates =
-                        entity_watcher.iter().any(|w| matches!(w, EntityWatcherId::Predicate(sub_id, _) if *sub_id == subscription_id));
-                    if !has_other_predicates {
-                        subscription.entities.remove(entity_id);
-                    }
-                }
-            }
-
-            false
-        });
-
-        // Unpause now that update is complete
-        query_state.paused = false;
-        query_state.version = version;
-        query_state.resultset.set_loaded(true);
-
-        // Drop write guard to apply changes
-        drop(rw_resultset);
+        drop(watcher_set);
 
         // Send reactor update
-        let reactor_update = ReactorUpdate::<E, Ev> { items: reactor_update_items, initialized_query: Some((query_id, version)) };
-        subscription.notify(reactor_update);
+        subscription.send_update_query_update(query_id, version, reactor_update_items);
 
         Ok(())
     }
 
     /// Notify subscriptions about an entity change
-    pub fn notify_change<C: ChangeNotification<Entity = E, Event = Ev>>(&self, changes: Vec<C>) {
-        let mut watcher_set = self.0.watcher_set.lock().unwrap();
+    pub async fn notify_change<C: ChangeNotification<Entity = E, Event = Ev> + Clone>(&self, changes: Vec<C>) {
+        // Serialize notify_change invocations
+        let _notify_guard = self.0.notify_lock.lock().await;
 
-        let mut items: std::collections::HashMap<ReactorSubscriptionId, IndexMap<proto::EntityId, ReactorUpdateItem<E, Ev>>> =
-            std::collections::HashMap::new();
+        // Wrap changes in Arc for sharing across subscriptions
+        let changes: Arc<Vec<C>> = Arc::from(changes);
 
-        debug!("Reactor.notify_change({:?})", changes);
-        for change in changes {
-            let (entity, events) = change.into_parts();
+        tracing::info!("Reactor.notify_change({} changes)", changes.len());
 
-            // Collect all potentially interested (subscription_id, query_id) pairs
-            let mut possibly_interested_watchers: HashSet<(ReactorSubscriptionId, proto::QueryId)> = HashSet::new();
-
-            debug!("Reactor - index watchers: {:?}", watcher_set.index_watchers);
-            // Find subscriptions that might be interested based on index watchers
-            for ((collection_id, field_id), index_ref) in &watcher_set.index_watchers {
-                // Get the field value from the entity
-                if *collection_id == AbstractEntity::collection(&entity) {
-                    if let Some(field_value) = AbstractEntity::value(&entity, &field_id.0) {
-                        possibly_interested_watchers.extend(index_ref.find_matching(field_value));
-                    }
-                }
-            }
-
-            // Also check wildcard watchers for this collection
-            if let Some(watchers) = watcher_set.wildcard_watchers.get(&AbstractEntity::collection(&entity)) {
-                for watcher in watchers.iter() {
-                    possibly_interested_watchers.insert(*watcher);
-                }
-            }
-
-            // Check entity watchers - these are subscription-level, not predicate-level
-            // We'll need to expand these to all predicates for the subscription
-
-            let mut entity_subscribed = HashSet::new();
-            if let Some(subscription_ids) = watcher_set.entity_watchers.get(AbstractEntity::id(&entity)) {
-                for sub_id in subscription_ids.iter() {
-                    // Get all predicates for this subscription
-                    if let Some(sub) = self.0.subscriptions.lock().unwrap().get(&sub_id.subscription_id()) {
-                        for query_id in sub.queries.keys() {
-                            possibly_interested_watchers.insert((sub_id.subscription_id(), *query_id));
-                            entity_subscribed.insert(*query_id);
-                        }
-                    }
-                }
-            }
-
-            debug!(" possibly_interested_watchers: {possibly_interested_watchers:?}");
-            let mut subscriptions = self.0.subscriptions.lock().unwrap();
-            // Check each possibly interested subscription-predicate pair with full predicate evaluation
-            for (subscription_id, query_id) in possibly_interested_watchers {
-                if let Some(subscription) = subscriptions.get_mut(&subscription_id) {
-                    // Get the predicate state
-                    let (did_match, matches) = {
-                        if let Some(query_state) = subscription.queries.get(&query_id) {
-                            // Skip paused predicates
-                            if query_state.paused {
-                                continue;
-                            }
-
-                            debug!("\tnotify_change predicate: {} {:?}", query_id, query_state.selection);
-                            // So the other calls to evaluate_predicate probably require re-querying the local storage after all relevant events/states have
-                            // been applied by the applier - but this one I'm not so clear about. we do need to know if the entity matches the predicate,
-                            // but when limit is involved, that means we may need to go re-query when one of the previously matching entities is no longer matching
-                            // This is the hardest part to do right.
-                            let matches =
-                                ankql::selection::filter::evaluate_predicate(&entity, &query_state.selection.predicate).unwrap_or(false);
-                            let did_match = query_state.resultset.contains_key(AbstractEntity::id(&entity));
-
-                            (did_match, matches)
-                        } else {
-                            continue; // Predicate not found
-                        }
-                    };
-
-                    tracing::info!(
-                        "\tnotify_change matches: {matches} did_match: {did_match} {}: {:?}",
-                        AbstractEntity::id(&entity),
-                        AbstractEntity::value(&entity, "status")
-                    );
-
-                    let entity_watcher = watcher_set.entity_watchers.entry(*entity.id()).or_default();
-                    if matches {
-                        // Entity subscriptions are implicit / sticky...
-                        // Register one for the predicate that gets removed when the predicate no longer matches
-                        entity_watcher.insert(EntityWatcherId::Predicate(subscription_id, query_id));
-                        // and one for the subscription itself, which lingers until the user expressly tells us they want to stop watching
-                        // entity_watcher.insert(EntityWatcherId::Subscription(subscription_id));
-                    } else {
-                        // When the predicate no longer matches, only remove the predicate watcher, not the subscription watcher
-                        entity_watcher.remove(&EntityWatcherId::Predicate(subscription_id, query_id));
-                    }
-                    Self::update_query_matching_entities(subscription, query_id, &entity, matches);
-
-                    let sub_entities = items.entry(subscription_id).or_default();
-
-                    let membership_change = match (did_match, matches) {
-                        (true, false) => Some(MembershipChange::Remove),
-                        (false, true) => Some(MembershipChange::Add),
-                        _ => None,
-                    };
-
-                    let entity_subscribed = entity_subscribed.contains(&query_id);
-                    if membership_change.is_some() || entity_subscribed {
-                        tracing::info!("Reactor SENDING UPDATE to subscription {}", subscription_id);
-                        match sub_entities.entry(*AbstractEntity::id(&entity)) {
-                            indexmap::map::Entry::Vacant(v) => {
-                                v.insert(ReactorUpdateItem {
-                                    entity: entity.clone(),
-                                    events: events.clone(),
-                                    entity_subscribed,
-                                    predicate_relevance: membership_change.map(|mc| (query_id, mc)).into_iter().collect(),
-                                });
-                            }
-                            indexmap::map::Entry::Occupied(mut o) => {
-                                if let Some(mc) = membership_change {
-                                    o.get_mut().predicate_relevance.push((query_id, mc));
-                                }
-                            }
-                        }
-                    }
-                }
+        // Build per-subscription candidate accumulators (first lock of watcher_set)
+        let mut candidates_by_sub: HashMap<ReactorSubscriptionId, CandidateChanges<C>> = HashMap::new();
+        {
+            let watcher_set = self.0.watcher_set.lock().unwrap();
+            for (offset, change) in changes.iter().enumerate() {
+                watcher_set.accumulate_interested_watchers(change.entity(), offset, &changes, &mut candidates_by_sub);
             }
         }
 
-        for (sub_id, sub_items) in items {
-            if let Some(subscription) = self.0.subscriptions.lock().unwrap().get(&sub_id) {
-                subscription.notify(ReactorUpdate { items: sub_items.into_values().collect(), initialized_query: None });
-            }
+        // Parallelize evaluate_changes calls across subscriptions
+        // First, collect all the evaluation futures while holding the lock
+        let evaluations = {
+            let subscriptions = self.0.subscriptions.lock().unwrap();
+            candidates_by_sub
+                .into_iter()
+                .filter_map(|(sub_id, candidates)| {
+                    subscriptions.get(&sub_id).map(|subscription| subscription.clone().evaluate_changes(candidates))
+                })
+                .collect::<Vec<_>>()
+        };
+
+        // Now await all evaluations (lock is dropped)
+        let all_watcher_changes: Vec<WatcherChange> = join_all(evaluations).await.into_iter().flatten().collect();
+
+        // Apply all watcher changes to watcher_set (second lock of watcher_set)
+
+        let mut watcher_set = self.0.watcher_set.lock().unwrap();
+        for change in all_watcher_changes {
+            watcher_set.apply_watcher_change(change);
         }
     }
 
@@ -677,44 +359,13 @@ impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, 
         // Clear entity watchers first - no entities are being watched after reset, because any previously existing entities "stopped existing"
         // as part of the system reset.
         {
-            let mut watcher_state = self.0.watcher_set.lock().unwrap();
-            watcher_state.entity_watchers.clear();
+            let mut watcher_set = self.0.watcher_set.lock().unwrap();
+            watcher_set.clear_entity_watchers();
         }
 
-        let mut subscriptions = self.0.subscriptions.lock().unwrap();
-
-        for (_, subscription_state) in subscriptions.iter_mut() {
-            let mut update_items: Vec<ReactorUpdateItem<E, Ev>> = Vec::new();
-
-            // For each predicate in this subscription
-            for (query_id, predicate_state) in &mut subscription_state.queries {
-                // For each entity that was matching this predicate
-                for entity_id in predicate_state.resultset.keys() {
-                    // Try to get the entity from the subscription's cache
-                    if let Some(entity) = subscription_state.entities.get(&entity_id) {
-                        update_items.push(ReactorUpdateItem {
-                            entity: entity.clone(),
-                            events: vec![], // No events for system reset, because it's not a "change", its Thanos snapping his fingers
-                            entity_subscribed: false, // All entities "stopped existing" and thus cannot be subscribed to
-                            predicate_relevance: vec![(*query_id, MembershipChange::Remove)], // The predicates still exist, but all previous matching entities are unmatched
-                        });
-                    }
-                }
-
-                // Clear the matching entities for this predicate
-                predicate_state.resultset.clear();
-                predicate_state.resultset.set_loaded(false);
-            }
-
-            // Clear entity subscriptions and cached entities
-            subscription_state.entity_subscriptions.clear();
-            subscription_state.entities.clear();
-
-            // Send the notification if there were any updates
-            if !update_items.is_empty() {
-                let reactor_update = ReactorUpdate { items: update_items, initialized_query: None };
-                subscription_state.notify(reactor_update);
-            }
+        let subscriptions = self.0.subscriptions.lock().unwrap();
+        for subscription in subscriptions.values() {
+            subscription.system_reset();
         }
     }
 }
@@ -725,88 +376,20 @@ impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, 
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let watcher_set = self.0.watcher_set.lock().unwrap();
         let subscriptions = self.0.subscriptions.lock().unwrap();
+        let (index_watchers, wildcard_watchers, entity_watchers) = watcher_set.debug_data();
         write!(
             f,
             "Reactor {{ subscriptions: {:?}, index_watchers: {:?}, wildcard_watchers: {:?}, entity_watchers: {:?} }}",
-            subscriptions, watcher_set.index_watchers, watcher_set.wildcard_watchers, watcher_set.entity_watchers
+            subscriptions, index_watchers, wildcard_watchers, entity_watchers
         )
     }
 }
 
-impl WatcherSet {
-    fn recurse_predicate_watchers(
-        &mut self,
-        collection_id: &proto::CollectionId,
-        predicate: &ankql::ast::Predicate,
-        watcher_id: (ReactorSubscriptionId, proto::QueryId), // Should this be a tuple of (subscription_id, query_id) or just subscription_id?
-        op: WatcherOp,
-    ) {
-        use ankql::ast::{Expr, Identifier, Predicate};
-        match predicate {
-            Predicate::Comparison { left, operator, right } => {
-                if let (Expr::Identifier(field), Expr::Literal(literal)) | (Expr::Literal(literal), Expr::Identifier(field)) =
-                    (&**left, &**right)
-                {
-                    let field_name = match field {
-                        Identifier::Property(name) => name.clone(),
-                        Identifier::CollectionProperty(_, name) => name.clone(),
-                    };
-
-                    let field_id = FieldId(field_name);
-                    let index = self.index_watchers.entry((collection_id.clone(), field_id)).or_default();
-
-                    match op {
-                        WatcherOp::Add => {
-                            index.add((*literal).clone(), operator.clone(), watcher_id);
-                        }
-                        WatcherOp::Remove => {
-                            index.remove((*literal).clone(), operator.clone(), watcher_id);
-                        }
-                    }
-                } else {
-                    // warn!("Unsupported predicate: {:?}", predicate);
-                }
-            }
-            Predicate::And(left, right) | Predicate::Or(left, right) => {
-                self.recurse_predicate_watchers(collection_id, left, watcher_id, op);
-                self.recurse_predicate_watchers(collection_id, right, watcher_id, op);
-            }
-            Predicate::Not(pred) => {
-                self.recurse_predicate_watchers(collection_id, pred, watcher_id, op);
-            }
-            Predicate::IsNull(_) => {
-                unimplemented!("Not sure how to implement this")
-            }
-            Predicate::True => {
-                let set = self.wildcard_watchers.entry(collection_id.clone()).or_default();
-
-                match op {
-                    WatcherOp::Add => {
-                        set.insert(watcher_id);
-                    }
-                    WatcherOp::Remove => {
-                        set.remove(&watcher_id);
-                    }
-                }
-            }
-            Predicate::False => {
-                unimplemented!("Not sure how to implement this")
-            }
-            // Placeholder should be transformed before reaching this point
-            Predicate::Placeholder => {
-                // This should not happen in normal operation as Placeholder should be transformed
-                // before being used in subscriptions
-                unimplemented!("Placeholder should be transformed before reactor processing")
-            }
-        }
-    }
-}
-
 impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, Ev: Clone + Send + 'static> std::fmt::Debug
-    for SubscriptionState<E, Ev>
+    for Subscription<E, Ev>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Subscription {{ id: {:?}, predicates: {} }}", self.id, self.queries.len())
+        write!(f, "Subscription {{ id: {:?}, queries: {} }}", self.id(), self.queries_len())
     }
 }
 

--- a/core/src/reactor/candidate_changes.rs
+++ b/core/src/reactor/candidate_changes.rs
@@ -1,0 +1,111 @@
+use ankurah_proto::QueryId;
+use std::{collections::HashMap, sync::Arc};
+
+use crate::util::IVec;
+
+/// Wraps an Arc-shared list of changes with per-query offsets to avoid cloning events
+pub struct CandidateChanges<C> {
+    changes: Arc<Vec<C>>,
+    query_offsets: HashMap<QueryId, IVec<usize, 8>>,
+    entity_offsets: IVec<usize, 8>,
+}
+
+/// A query-specific view of candidates that borrows from CandidateChanges
+pub struct QueryCandidate<'a, C> {
+    pub query_id: &'a QueryId,
+    changes: &'a Arc<Vec<C>>,
+    offsets: &'a [usize],
+}
+
+impl<C> CandidateChanges<C> {
+    /// Create a new candidate list from a shared change batch
+    pub fn new(changes: Arc<Vec<C>>) -> Self { Self { changes, query_offsets: HashMap::new(), entity_offsets: IVec::new() } }
+
+    /// Add an offset for an entity-level subscription (not tied to any query)
+    pub fn add_entity(&mut self, offset: usize) { self.entity_offsets.push(offset); }
+
+    /// Add an offset to the candidate list for a specific query
+    pub fn add_query(&mut self, query_id: QueryId, offset: usize) { self.query_offsets.entry(query_id).or_default().add(offset); }
+
+    /// Returns true if there are no candidates
+    pub fn is_empty(&self) -> bool { self.query_offsets.is_empty() && self.entity_offsets.is_empty() }
+
+    /// Returns the number of query candidates
+    pub fn query_count(&self) -> usize { self.query_offsets.len() }
+
+    /// Iterate over query candidates
+    pub fn query_iter(&self) -> impl Iterator<Item = QueryCandidate<'_, C>> + '_ {
+        self.query_offsets.iter().map(|(query_id, offsets)| QueryCandidate {
+            query_id,
+            changes: &self.changes,
+            offsets: offsets.as_slice(),
+        })
+    }
+
+    /// Iterate over entity-level candidates
+    pub fn entity_iter(&self) -> impl Iterator<Item = &C> + '_ { self.entity_offsets.iter().map(move |&offset| &self.changes[offset]) }
+
+    /// Get direct access to the shared changes array
+    pub fn changes(&self) -> &Arc<Vec<C>> { &self.changes }
+}
+
+impl<'a, C> QueryCandidate<'a, C> {
+    /// Iterate over the candidate changes for this query
+    pub fn iter(&self) -> impl Iterator<Item = &C> + '_ { self.offsets.iter().map(move |&offset| &self.changes[offset]) }
+}
+
+impl<C> Clone for CandidateChanges<C> {
+    fn clone(&self) -> Self {
+        Self { changes: self.changes.clone(), query_offsets: self.query_offsets.clone(), entity_offsets: self.entity_offsets.clone() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_candidate_changes_empty() {
+        let changes: Arc<Vec<i32>> = Arc::from(vec![]);
+        let candidates = CandidateChanges::new(changes);
+        assert!(candidates.is_empty());
+        assert_eq!(candidates.query_count(), 0);
+    }
+
+    #[test]
+    fn test_candidate_changes_add_query() {
+        let changes: Arc<Vec<i32>> = Arc::from(vec![10, 20, 30, 40, 50]);
+        let mut candidates = CandidateChanges::new(changes);
+
+        let q1 = QueryId::new();
+        let q2 = QueryId::new();
+
+        candidates.add_query(q1, 1); // 20
+        candidates.add_query(q1, 3); // 40
+        candidates.add_query(q2, 0); // 10
+
+        assert_eq!(candidates.query_count(), 2);
+        assert!(!candidates.is_empty());
+
+        let mut query_map: HashMap<QueryId, Vec<i32>> = HashMap::new();
+        for qc in candidates.query_iter() {
+            let values: Vec<i32> = qc.iter().copied().collect();
+            query_map.insert(*qc.query_id, values);
+        }
+
+        assert_eq!(query_map[&q1], vec![20, 40]);
+        assert_eq!(query_map[&q2], vec![10]);
+    }
+
+    #[test]
+    fn test_candidate_changes_entity_level() {
+        let changes: Arc<Vec<i32>> = Arc::from(vec![10, 20, 30]);
+        let mut candidates = CandidateChanges::new(changes);
+
+        candidates.add_entity(0);
+        candidates.add_entity(2);
+
+        let entities: Vec<i32> = candidates.entity_iter().copied().collect();
+        assert_eq!(entities, vec![10, 30]);
+    }
+}

--- a/core/src/reactor/subscription.rs
+++ b/core/src/reactor/subscription.rs
@@ -50,6 +50,8 @@ pub struct ReactorSubscription<
     Ev: Clone + Send + 'static = ankurah_proto::Attested<ankurah_proto::Event>,
 >(pub(super) Arc<ReactorSubInner<E, Ev>>);
 
+// TODO Consider adding a weak ref and combining this with subscription_state::Subscription
+
 impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, Ev: Clone + Send + 'static> ReactorSubscription<E, Ev> {
     /// Get the subscription ID
     pub fn id(&self) -> ReactorSubscriptionId { self.0.subscription_id }
@@ -60,7 +62,7 @@ impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, 
 
     /// Remove a predicate from this subscription
     pub fn remove_predicate(&self, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
-        self.0.reactor.remove_predicate(self.0.subscription_id, query_id)?;
+        self.0.reactor.remove_query(self.0.subscription_id, query_id)?;
         Ok(())
     }
 

--- a/core/src/reactor/subscription_state.rs
+++ b/core/src/reactor/subscription_state.rs
@@ -1,10 +1,19 @@
 use crate::{
-    reactor::{AbstractEntity, MembershipChange, ReactorSubscriptionId, ReactorUpdate, ReactorUpdateItem},
+    reactor::{
+        AbstractEntity, CandidateChanges, ChangeNotification, MembershipChange, ReactorSubscriptionId, ReactorUpdate, ReactorUpdateItem,
+        WatcherChange,
+    },
     resultset::EntityResultSet,
 };
+use ankql::selection::filter::evaluate_predicate;
 use ankurah_proto::{self as proto};
 use futures::future;
-use std::collections::{HashMap, HashSet};
+use indexmap::IndexMap;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use tracing::debug;
 
 type GapFillData<E> = (
     proto::QueryId,
@@ -28,8 +37,29 @@ pub struct QueryState<E: AbstractEntity + ankql::selection::filter::Filterable> 
     pub(crate) version: u32,
 }
 
-pub struct SubscriptionState<E: AbstractEntity + ankql::selection::filter::Filterable, Ev> {
-    pub(crate) id: ReactorSubscriptionId,
+// We would call this ReactorSubscription, but that name is reserved for the public API
+// so instead we will call it Subscription and just scope it to the reactor package
+pub(super) struct Subscription<E: AbstractEntity + ankql::selection::filter::Filterable, Ev>(Arc<Inner<E, Ev>>);
+
+impl<E: AbstractEntity + ankql::selection::filter::Filterable, Ev> Clone for Subscription<E, Ev> {
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+impl<E: AbstractEntity + ankql::selection::filter::Filterable, Ev> std::ops::Deref for Subscription<E, Ev> {
+    type Target = Inner<E, Ev>;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl<E: AbstractEntity + ankql::selection::filter::Filterable, Ev> Subscription<E, Ev> {
+    /// Get the subscription ID
+    pub fn id(&self) -> ReactorSubscriptionId { self.0.id }
+}
+
+pub(super) struct Inner<E: AbstractEntity + ankql::selection::filter::Filterable, Ev> {
+    pub(super) id: ReactorSubscriptionId,
+    state: std::sync::Mutex<State<E, Ev>>,
+}
+struct State<E: AbstractEntity + ankql::selection::filter::Filterable, Ev> {
     pub(crate) queries: HashMap<proto::QueryId, QueryState<E>>,
     /// The set of entities that are subscribed to by this subscription
     pub(crate) entity_subscriptions: HashSet<proto::EntityId>,
@@ -38,19 +68,417 @@ pub struct SubscriptionState<E: AbstractEntity + ankql::selection::filter::Filte
     pub(crate) broadcast: ankurah_signals::broadcast::Broadcast<ReactorUpdate<E, Ev>>,
 }
 
-impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, Ev: Clone + Send + 'static> SubscriptionState<E, Ev> {
-    pub fn notify(&self, update: ReactorUpdate<E, Ev>) {
-        let gaps_to_fill = self.collect_gaps_to_fill();
+impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, Ev: Clone + Send + 'static> Subscription<E, Ev> {
+    pub fn new(broadcast: ankurah_signals::broadcast::Broadcast<ReactorUpdate<E, Ev>>) -> Self {
+        Self(Arc::new(Inner {
+            id: ReactorSubscriptionId::new(),
+            state: std::sync::Mutex::new(State {
+                queries: HashMap::new(),
+                entity_subscriptions: HashSet::new(),
+                entities: HashMap::new(),
+                broadcast,
+            }),
+        }))
+    }
 
-        if gaps_to_fill.is_empty() {
-            self.broadcast.send(update);
-        } else {
-            self.spawn_gap_filling_task(update, gaps_to_fill);
+    /// Add entity subscription
+    pub fn add_entity_subscription(&self, entity_id: proto::EntityId) {
+        let mut state = self.state.lock().unwrap();
+        state.entity_subscriptions.insert(entity_id);
+    }
+
+    /// Remove entity subscription
+    pub fn remove_entity_subscription(&self, entity_id: proto::EntityId) {
+        let mut state = self.state.lock().unwrap();
+        state.entity_subscriptions.remove(&entity_id);
+    }
+
+    /// Check if any queries match this entity (for determining if entity watcher should be removed)
+    pub fn any_query_matches(&self, entity_id: &proto::EntityId) -> bool {
+        let state = self.state.lock().unwrap();
+        state.queries.values().any(|q| q.resultset.contains_key(entity_id))
+    }
+
+    /// System reset - clear all matching entities and notify
+    pub fn system_reset(&self) {
+        let state = &mut *self.state.lock().unwrap();
+        let mut update_items: Vec<ReactorUpdateItem<E, Ev>> = Vec::new();
+
+        // For each query in this subscription
+        for (query_id, query_state) in &mut state.queries {
+            // For each entity that was matching this query
+            for entity_id in query_state.resultset.keys() {
+                // Try to get the entity from the subscription's cache
+                if let Some(entity) = state.entities.get(&entity_id) {
+                    update_items.push(ReactorUpdateItem {
+                        entity: entity.clone(),
+                        events: vec![], // No events for system reset
+                        entity_subscribed: false,
+                        predicate_relevance: vec![(*query_id, MembershipChange::Remove)],
+                    });
+                }
+            }
+
+            // Clear the matching entities for this query
+            query_state.resultset.clear();
+            query_state.resultset.set_loaded(false);
+        }
+
+        // Clear entity subscriptions and cached entities
+        state.entity_subscriptions.clear();
+        state.entities.clear();
+
+        // Send the notification if there were any updates
+        if !update_items.is_empty() {
+            let reactor_update = ReactorUpdate { items: update_items, initialized_query: None };
+            state.broadcast.send(reactor_update);
         }
     }
 
-    fn collect_gaps_to_fill(&self) -> Vec<GapFillData<E>> {
-        self.queries.iter().filter_map(|(query_id, query_state)| self.extract_gap_data(*query_id, query_state)).collect()
+    /// Get the number of queries for debugging
+    pub fn queries_len(&self) -> usize {
+        let state = self.state.lock().unwrap();
+        state.queries.len()
+    }
+
+    /// Add a new query to the subscription
+    /// Returns the list of entities from the resultset for setting up watchers
+    pub fn add_query(
+        &self,
+        query_id: proto::QueryId,
+        collection_id: proto::CollectionId,
+        selection: ankql::ast::Selection,
+        resultset: EntityResultSet<E>,
+        gap_fetcher: std::sync::Arc<dyn crate::reactor::fetch_gap::GapFetcher<E>>,
+    ) -> Result<Vec<(proto::EntityId, E)>, anyhow::Error> {
+        let state = &mut *self.state.lock().unwrap();
+
+        // Fail if query already exists
+        use std::collections::hash_map::Entry;
+        let query_state = match state.queries.entry(query_id) {
+            Entry::Vacant(v) => v.insert(QueryState {
+                collection_id,
+                selection: selection.clone(),
+                gap_fetcher,
+                paused: false,
+                resultset: resultset.clone(),
+                version: 0,
+            }),
+            Entry::Occupied(_) => return Err(anyhow::anyhow!("Query {:?} already exists", query_id)),
+        };
+
+        // Configure resultset ordering and limit
+        query_state.resultset.order_by(
+            selection
+                .order_by
+                .map(|ob| crate::reactor::build_key_spec_from_selection(ob.as_slice(), &query_state.resultset))
+                .transpose()?,
+        );
+        query_state.resultset.limit(selection.limit.map(|l| l as usize));
+
+        // Collect entities for watcher setup
+        let read_guard = query_state.resultset.read();
+        let entities: Vec<(proto::EntityId, E)> = read_guard.iter_entities().map(|(id, e)| (id, e.clone())).collect();
+
+        // Add to entity subscriptions
+        for (entity_id, _) in &entities {
+            state.entity_subscriptions.insert(*entity_id);
+        }
+
+        drop(read_guard);
+        resultset.set_loaded(true);
+
+        Ok(entities)
+    }
+
+    /// Send initialization ReactorUpdate for add_query
+    pub fn send_add_query_update(&self, query_id: proto::QueryId, entities: Vec<(proto::EntityId, E)>) {
+        let state = self.state.lock().unwrap();
+        let reactor_update_items: Vec<ReactorUpdateItem<E, Ev>> = entities
+            .into_iter()
+            .map(|(_, entity)| ReactorUpdateItem {
+                entity,
+                events: vec![],
+                entity_subscribed: true,
+                predicate_relevance: vec![(query_id, MembershipChange::Initial)],
+            })
+            .collect();
+
+        state.broadcast.send(ReactorUpdate { items: reactor_update_items, initialized_query: Some((query_id, 0)) });
+    }
+
+    /// Update an existing query
+    /// Returns (old_predicate, newly_added_entities, removed_entities)
+    pub fn update_query(
+        &self,
+        query_id: proto::QueryId,
+        _collection_id: proto::CollectionId,
+        selection: ankql::ast::Selection,
+        included_entities: Vec<E>,
+        version: u32,
+        emit_removes: bool,
+    ) -> anyhow::Result<(ankql::ast::Predicate, Vec<(proto::EntityId, E)>, Vec<proto::EntityId>, Vec<ReactorUpdateItem<E, Ev>>)> {
+        let state = &mut *self.state.lock().unwrap();
+
+        // Get mutable reference to query state (must exist for v>0)
+        let query_state = state.queries.get_mut(&query_id).ok_or_else(|| anyhow::anyhow!("Query not found for update"))?;
+
+        // Save old predicate for watcher updates
+        let old_predicate = query_state.selection.predicate.clone();
+
+        // Update the query AST
+        query_state.selection = selection.clone();
+        query_state.resultset.order_by(
+            selection
+                .order_by
+                .map(|ob| crate::reactor::build_key_spec_from_selection(ob.as_slice(), &query_state.resultset))
+                .transpose()?,
+        );
+
+        // Check if LIMIT changed
+        if query_state.selection.limit != selection.limit {
+            query_state.resultset.limit(selection.limit.map(|l| l as usize));
+        }
+
+        // Create write guard for atomic updates
+        let mut rw_resultset = query_state.resultset.write();
+        let mut reactor_update_items = Vec::new();
+        let mut newly_added = Vec::new();
+
+        // Mark all entities dirty for re-evaluation
+        rw_resultset.mark_all_dirty();
+
+        // Process included entities (only truly new ones from remote)
+        for entity in included_entities {
+            if ankql::selection::filter::evaluate_predicate(&entity, &selection.predicate).unwrap_or(false) {
+                let entity_id = *AbstractEntity::id(&entity);
+
+                // Check if this is truly new to the resultset
+                if !rw_resultset.contains(&entity_id) {
+                    // Add to write guard
+                    rw_resultset.add(entity.clone());
+
+                    // Add to subscription entities map
+                    state.entities.insert(entity_id, entity.clone());
+
+                    // Track for entity watcher setup
+                    state.entity_subscriptions.insert(entity_id);
+                    newly_added.push((entity_id, entity.clone()));
+
+                    // Create reactor update item (Initial for truly new entities)
+                    reactor_update_items.push(ReactorUpdateItem {
+                        entity,
+                        events: vec![],
+                        entity_subscribed: true,
+                        predicate_relevance: vec![(query_id, MembershipChange::Initial)],
+                    });
+                }
+            }
+        }
+
+        // Remove entities that no longer match the new predicate
+        let mut removed_entities = Vec::new();
+        rw_resultset.retain_dirty(|entity| {
+            if let Ok(true) = ankql::selection::filter::evaluate_predicate(entity, &selection.predicate) {
+                return true;
+            };
+            let entity_id = *entity.id();
+            tracing::debug!("Entity {:?} no longer matches predicate", entity_id);
+
+            removed_entities.push(entity_id);
+
+            // If emit_removes is true, create a Remove event
+            if emit_removes {
+                tracing::debug!("Creating Remove event for entity {:?}", entity_id);
+                reactor_update_items.push(ReactorUpdateItem {
+                    entity: entity.clone(),
+                    events: vec![],
+                    entity_subscribed: false,
+                    predicate_relevance: vec![(query_id, MembershipChange::Remove)],
+                });
+            }
+
+            false
+        });
+
+        // Unpause now that update is complete
+        query_state.paused = false;
+        query_state.version = version;
+        query_state.resultset.set_loaded(true);
+
+        // Drop write guard to apply changes
+        drop(rw_resultset);
+
+        Ok((old_predicate, newly_added, removed_entities, reactor_update_items))
+    }
+
+    /// Send update query ReactorUpdate
+    pub fn send_update_query_update(&self, query_id: proto::QueryId, version: u32, items: Vec<ReactorUpdateItem<E, Ev>>) {
+        let state = self.state.lock().unwrap();
+        state.broadcast.send(ReactorUpdate { items, initialized_query: Some((query_id, version)) });
+    }
+
+    /// Remove a query and return its state for cleanup
+    pub fn remove_query(&self, query_id: proto::QueryId) -> Option<QueryState<E>> {
+        let mut state = self.state.lock().unwrap();
+        state.queries.remove(&query_id)
+    }
+
+    /// Get all queries for cleanup (used by unsubscribe)
+    pub fn take_all_queries(&self) -> HashMap<proto::QueryId, QueryState<E>> {
+        let mut state = self.state.lock().unwrap();
+        std::mem::take(&mut state.queries)
+    }
+
+    /// Evaluate candidate changes for this subscription and spawn gap filling/notification task
+    /// Returns watcher changes that need to be applied to the global WatcherSet
+    pub async fn evaluate_changes<C: ChangeNotification<Entity = E, Event = Ev> + Clone>(
+        self,
+        candidates: CandidateChanges<C>,
+    ) -> Vec<WatcherChange> {
+        let mut watcher_changes = Vec::new();
+        let mut items: IndexMap<proto::EntityId, ReactorUpdateItem<E, Ev>> = IndexMap::new();
+
+        // Take the state lock once for all evaluations
+        let mut state_guard = self.state.lock().unwrap();
+        let state = &mut *state_guard;
+
+        // Process query-specific candidates using direct lookup
+        for query_candidate in candidates.query_iter() {
+            let query_id = *query_candidate.query_id;
+
+            // Direct lookup - skip if query doesn't exist or is paused
+            let query_state = match state.queries.get_mut(&query_id) {
+                Some(qs) if !qs.paused => qs,
+                _ => continue,
+            };
+
+            debug!("\tevaluate_changes query: {} {:?}", query_id, query_state.selection);
+
+            // Process all candidate changes for this query
+            for change in query_candidate.iter() {
+                let entity = change.entity();
+                let entity_id = *AbstractEntity::id(entity);
+
+                debug!("Subscription {} evaluating entity {} for query {}", self.id(), entity_id, query_id);
+
+                let matches = evaluate_predicate(entity, &query_state.selection.predicate).unwrap_or(false);
+                let did_match = query_state.resultset.contains_key(&entity_id);
+                let entity_subscribed = state.entity_subscriptions.contains(&entity_id);
+
+                // Process membership change in one match
+                let membership_change = match (did_match, matches) {
+                    (false, true) => {
+                        // Entity now matches - add to matching set
+                        let entity_clone = entity.clone();
+                        query_state.resultset.write().add(entity_clone.clone());
+                        state.entities.insert(entity_id, entity_clone);
+                        watcher_changes.push(WatcherChange::add(entity_id, self.id, query_id));
+                        Some(MembershipChange::Add)
+                    }
+                    (true, false) => {
+                        // Entity no longer matches - remove from matching set
+                        query_state.resultset.write().remove(entity_id);
+                        watcher_changes.push(WatcherChange::remove(entity_id, self.id, query_id));
+                        Some(MembershipChange::Remove)
+                    }
+                    _ => {
+                        // No membership change - just track watcher state
+                        watcher_changes.push(if matches {
+                            WatcherChange::add(entity_id, self.id, query_id)
+                        } else {
+                            WatcherChange::remove(entity_id, self.id, query_id)
+                        });
+                        None
+                    }
+                };
+
+                // Emit if matches, matched before, or explicitly subscribed
+                if matches || did_match || entity_subscribed {
+                    let item = items.entry(entity_id).or_insert_with(|| ReactorUpdateItem {
+                        entity: entity.clone(),
+                        events: change.events().to_vec(),
+                        entity_subscribed: false, // Hardcoded - will be removed
+                        predicate_relevance: Vec::new(),
+                    });
+
+                    if let Some(mc) = membership_change {
+                        item.predicate_relevance.push((query_id, mc));
+                    }
+                }
+            }
+        }
+
+        // Process entity-level subscriptions not covered by query processing
+        for change in candidates.entity_iter() {
+            let entity = change.entity();
+            let entity_id = *AbstractEntity::id(entity);
+
+            if state.entity_subscriptions.contains(&entity_id) {
+                // !items.contains_key(&entity_id) {
+                items.entry(entity_id).or_insert(ReactorUpdateItem {
+                    entity: entity.clone(),
+                    events: change.events().to_vec(),
+                    entity_subscribed: false, // Hardcoded - will be removed
+                    predicate_relevance: Vec::new(),
+                });
+            }
+        }
+
+        // Collect gap fill data while we have the state lock
+        let gaps_to_fill = self.collect_gaps_to_fill_internal(&state);
+        let broadcast = state.broadcast.clone();
+
+        // Drop the state lock before spawning
+        drop(state_guard);
+
+        // Spawn background task for gap filling and notification
+        let update_items: Vec<ReactorUpdateItem<E, Ev>> = items.into_values().collect();
+        if !gaps_to_fill.is_empty() {
+            crate::task::spawn(self.clone().fill_gaps_and_notify(update_items, gaps_to_fill, broadcast, None));
+        } else if !update_items.is_empty() {
+            broadcast.send(ReactorUpdate { items: update_items, initialized_query: None });
+        }
+
+        watcher_changes
+    }
+
+    /// Collect gaps to fill (internal version that works with locked state)
+    fn collect_gaps_to_fill_internal(&self, state: &State<E, Ev>) -> Vec<GapFillData<E>> {
+        state.queries.iter().filter_map(|(query_id, query_state)| self.extract_gap_data(*query_id, query_state)).collect()
+    }
+
+    /// Fill gaps and send notification
+    /// Combined method to handle gap filling and notification in a single task
+    async fn fill_gaps_and_notify(
+        self,
+        mut items: Vec<ReactorUpdateItem<E, Ev>>,
+        gaps_to_fill: Vec<GapFillData<E>>,
+        broadcast: ankurah_signals::broadcast::Broadcast<ReactorUpdate<E, Ev>>,
+        initialized_query: Option<(proto::QueryId, u32)>,
+    ) {
+        // Clear gap_dirty flags immediately for all queries
+        for (_, _, _, _, ref resultset, _, _) in &gaps_to_fill {
+            resultset.clear_gap_dirty();
+        }
+
+        // Process all gap fills concurrently
+        let gap_fill_futures =
+            gaps_to_fill.into_iter().map(|(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size)| {
+                Self::process_gap_fill(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size)
+            });
+
+        let gap_results = future::join_all(gap_fill_futures).await;
+
+        // Collect all the new items from gap filling
+        for gap_items in gap_results {
+            items.extend(gap_items);
+        }
+
+        // Send the consolidated update
+        if !items.is_empty() {
+            broadcast.send(ReactorUpdate { items, initialized_query });
+        }
     }
 
     fn extract_gap_data(&self, query_id: proto::QueryId, query_state: &QueryState<E>) -> Option<GapFillData<E>> {
@@ -79,36 +507,6 @@ impl<E: AbstractEntity + ankql::selection::filter::Filterable + Send + 'static, 
             last_entity,
             gap_size,
         ))
-    }
-
-    fn spawn_gap_filling_task(&self, update: ReactorUpdate<E, Ev>, gaps_to_fill: Vec<GapFillData<E>>) {
-        let broadcast = self.broadcast.clone();
-        let initial_items = update.items;
-        let initialized_query = update.initialized_query;
-
-        crate::task::spawn(async move {
-            let mut all_items = initial_items;
-
-            // Clear gap_dirty flags immediately for all queries
-            for (_, _, _, _, ref resultset, _, _) in &gaps_to_fill {
-                resultset.clear_gap_dirty();
-            }
-
-            // Process all gap fills concurrently
-            let gap_fill_futures =
-                gaps_to_fill.into_iter().map(|(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size)| {
-                    Self::process_gap_fill(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size)
-                });
-
-            let gap_results = future::join_all(gap_fill_futures).await;
-
-            // Collect all the new items from gap filling
-            for gap_items in gap_results {
-                all_items.extend(gap_items);
-            }
-
-            broadcast.send(ReactorUpdate { items: all_items, initialized_query });
-        });
     }
 
     async fn process_gap_fill(

--- a/core/src/reactor/watcherset.rs
+++ b/core/src/reactor/watcherset.rs
@@ -1,0 +1,275 @@
+use crate::reactor::comparison_index::ComparisonIndex;
+use crate::reactor::{AbstractEntity, ReactorSubscriptionId};
+use ankurah_proto as proto;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use crate::reactor::candidate_changes::CandidateChanges;
+
+pub struct WatcherSet {
+    /// Each field has a ComparisonIndex so we can quickly find all subscriptions that care if a given value CHANGES (creation and deletion also count as change
+    index_watchers: HashMap<(proto::CollectionId, FieldId), ComparisonIndex<(ReactorSubscriptionId, proto::QueryId)>>,
+    /// The set of watchers who want to be notified of any changes to a given collection
+    wildcard_watchers: HashMap<proto::CollectionId, HashSet<(ReactorSubscriptionId, proto::QueryId)>>,
+    /// Index of subscriptions that presently match each entity, either by predicate or by entity subscription.
+    /// This is used to quickly find all subscriptions that need to be notified when an entity changes.
+    /// We have to maintain this to add and remove subscriptions when their matching state changes.
+    entity_watchers: HashMap<ankurah_proto::EntityId, HashSet<EntityWatcherId>>,
+}
+
+impl WatcherSet {
+    pub fn new() -> Self { Self { index_watchers: HashMap::new(), wildcard_watchers: HashMap::new(), entity_watchers: HashMap::new() } }
+    /// Accumulate interested watchers for an entity change into CandidateChanges
+    pub fn accumulate_interested_watchers<E: AbstractEntity, C>(
+        &self,
+        entity: &E,
+        offset: usize,
+        changes_arc: &Arc<Vec<C>>,
+        candidates_by_sub: &mut HashMap<ReactorSubscriptionId, CandidateChanges<C>>,
+    ) {
+        let entity_id = AbstractEntity::id(entity);
+
+        // Find subscriptions interested based on index watchers
+        for ((collection_id, field_id), index_ref) in &self.index_watchers {
+            if *collection_id == AbstractEntity::collection(entity) {
+                if let Some(field_value) = AbstractEntity::value(entity, &field_id.0) {
+                    for (subscription_id, query_id) in index_ref.find_matching(field_value) {
+                        candidates_by_sub
+                            .entry(subscription_id)
+                            .or_insert_with(|| CandidateChanges::new(changes_arc.clone()))
+                            .add_query(query_id, offset);
+                    }
+                }
+            }
+        }
+
+        // Check wildcard watchers for this collection
+        if let Some(watchers) = self.wildcard_watchers.get(&AbstractEntity::collection(entity)) {
+            for (subscription_id, query_id) in watchers.iter() {
+                candidates_by_sub
+                    .entry(*subscription_id)
+                    .or_insert_with(|| CandidateChanges::new(changes_arc.clone()))
+                    .add_query(*query_id, offset);
+            }
+        }
+
+        // Check entity watchers
+        if let Some(subscription_ids) = self.entity_watchers.get(entity_id) {
+            for sub_id in subscription_ids.iter() {
+                match sub_id {
+                    EntityWatcherId::Predicate(subscription_id, query_id) => {
+                        candidates_by_sub
+                            .entry(*subscription_id)
+                            .or_insert_with(|| CandidateChanges::new(changes_arc.clone()))
+                            .add_query(*query_id, offset);
+                    }
+                    EntityWatcherId::Subscription(subscription_id) => {
+                        candidates_by_sub
+                            .entry(*subscription_id)
+                            .or_insert_with(|| CandidateChanges::new(changes_arc.clone()))
+                            .add_entity(offset);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Apply a watcher change
+    pub fn apply_watcher_change(&mut self, change: WatcherChange) {
+        match change {
+            WatcherChange::Add { entity_id, subscription_id, query_id } => {
+                self.entity_watchers.entry(entity_id).or_default().insert(EntityWatcherId::Predicate(subscription_id, query_id));
+            }
+            WatcherChange::Remove { entity_id, subscription_id, query_id } => {
+                if let Some(watchers) = self.entity_watchers.get_mut(&entity_id) {
+                    watchers.remove(&EntityWatcherId::Predicate(subscription_id, query_id));
+                    if watchers.is_empty() {
+                        self.entity_watchers.remove(&entity_id);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Add entity subscription watcher for a subscription
+    pub fn add_entity_subscription(&mut self, subscription_id: ReactorSubscriptionId, entity_id: proto::EntityId) {
+        self.entity_watchers.entry(entity_id).or_default().insert(EntityWatcherId::Subscription(subscription_id));
+    }
+
+    /// Remove entity subscription watcher for a subscription
+    pub fn remove_entity_subscription(&mut self, subscription_id: ReactorSubscriptionId, entity_id: proto::EntityId) {
+        if let Some(watchers) = self.entity_watchers.get_mut(&entity_id) {
+            watchers.remove(&EntityWatcherId::Subscription(subscription_id));
+            if watchers.is_empty() {
+                self.entity_watchers.remove(&entity_id);
+            }
+        }
+    }
+
+    /// Remove all entity subscription watchers for multiple entities
+    pub fn remove_entity_subscriptions(
+        &mut self,
+        subscription_id: ReactorSubscriptionId,
+        entity_ids: impl IntoIterator<Item = proto::EntityId>,
+    ) {
+        for entity_id in entity_ids {
+            self.remove_entity_subscription(subscription_id, entity_id);
+        }
+    }
+
+    /// Clear all entity watchers
+    pub fn clear_entity_watchers(&mut self) { self.entity_watchers.clear(); }
+
+    /// Get references to internal data for debugging
+    pub fn debug_data(
+        &self,
+    ) -> (
+        &HashMap<(proto::CollectionId, FieldId), ComparisonIndex<(ReactorSubscriptionId, proto::QueryId)>>,
+        &HashMap<proto::CollectionId, HashSet<(ReactorSubscriptionId, proto::QueryId)>>,
+        &HashMap<ankurah_proto::EntityId, HashSet<EntityWatcherId>>,
+    ) {
+        (&self.index_watchers, &self.wildcard_watchers, &self.entity_watchers)
+    }
+
+    /// Add predicate entity watcher for multiple entities
+    pub fn add_predicate_entity_watchers(
+        &mut self,
+        subscription_id: ReactorSubscriptionId,
+        query_id: proto::QueryId,
+        entity_ids: impl IntoIterator<Item = proto::EntityId>,
+    ) {
+        for entity_id in entity_ids {
+            self.entity_watchers.entry(entity_id).or_default().insert(EntityWatcherId::Predicate(subscription_id, query_id));
+        }
+    }
+
+    /// Remove predicate entity watchers for entities that no longer match
+    /// Returns list of entity_ids that should be removed from the entity cache
+    pub fn cleanup_removed_predicate_watchers(
+        &mut self,
+        subscription_id: ReactorSubscriptionId,
+        query_id: proto::QueryId,
+        removed_entities: &[proto::EntityId],
+    ) {
+        for entity_id in removed_entities {
+            if let Some(entity_watcher) = self.entity_watchers.get_mut(entity_id) {
+                entity_watcher.remove(&EntityWatcherId::Predicate(subscription_id, query_id));
+            }
+        }
+    }
+    pub fn recurse_predicate_watchers(
+        &mut self,
+        collection_id: &proto::CollectionId,
+        predicate: &ankql::ast::Predicate,
+        watcher_id: (ReactorSubscriptionId, proto::QueryId), // Should this be a tuple of (subscription_id, query_id) or just subscription_id?
+        op: WatcherOp,
+    ) {
+        use ankql::ast::{Expr, Identifier, Predicate};
+        match predicate {
+            Predicate::Comparison { left, operator, right } => {
+                if let (Expr::Identifier(field), Expr::Literal(literal)) | (Expr::Literal(literal), Expr::Identifier(field)) =
+                    (&**left, &**right)
+                {
+                    let field_name = match field {
+                        Identifier::Property(name) => name.clone(),
+                        Identifier::CollectionProperty(_, name) => name.clone(),
+                    };
+
+                    let field_id = FieldId(field_name);
+                    let index = self.index_watchers.entry((collection_id.clone(), field_id)).or_default();
+
+                    match op {
+                        WatcherOp::Add => {
+                            index.add((*literal).clone(), operator.clone(), watcher_id);
+                        }
+                        WatcherOp::Remove => {
+                            index.remove((*literal).clone(), operator.clone(), watcher_id);
+                        }
+                    }
+                } else {
+                    // warn!("Unsupported predicate: {:?}", predicate);
+                }
+            }
+            Predicate::And(left, right) | Predicate::Or(left, right) => {
+                self.recurse_predicate_watchers(collection_id, left, watcher_id, op);
+                self.recurse_predicate_watchers(collection_id, right, watcher_id, op);
+            }
+            Predicate::Not(pred) => {
+                self.recurse_predicate_watchers(collection_id, pred, watcher_id, op);
+            }
+            Predicate::IsNull(_) => {
+                unimplemented!("Not sure how to implement this")
+            }
+            Predicate::True => {
+                let set = self.wildcard_watchers.entry(collection_id.clone()).or_default();
+
+                match op {
+                    WatcherOp::Add => {
+                        set.insert(watcher_id);
+                    }
+                    WatcherOp::Remove => {
+                        set.remove(&watcher_id);
+                    }
+                }
+            }
+            Predicate::False => {
+                unimplemented!("Not sure how to implement this")
+            }
+            // Placeholder should be transformed before reaching this point
+            Predicate::Placeholder => {
+                // This should not happen in normal operation as Placeholder should be transformed
+                // before being used in subscriptions
+                unimplemented!("Placeholder should be transformed before reactor processing")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum EntityWatcherId {
+    Predicate(ReactorSubscriptionId, proto::QueryId),
+    Subscription(ReactorSubscriptionId),
+}
+
+impl EntityWatcherId {
+    pub fn subscription_id(&self) -> ReactorSubscriptionId {
+        match self {
+            EntityWatcherId::Predicate(sub_id, _) => *sub_id,
+            EntityWatcherId::Subscription(sub_id) => *sub_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FieldId(String);
+
+impl From<&str> for FieldId {
+    fn from(val: &str) -> Self { FieldId(val.to_string()) }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum WatcherOp {
+    Add,
+    Remove,
+}
+
+/// Represents a change to entity watchers that needs to be applied to the WatcherSet
+#[derive(Debug, Clone)]
+pub enum WatcherChange {
+    /// Add an entity watcher (notify_change decides EntityWatcherId variant)
+    Add { entity_id: proto::EntityId, subscription_id: ReactorSubscriptionId, query_id: proto::QueryId },
+    /// Remove an entity watcher
+    Remove { entity_id: proto::EntityId, subscription_id: ReactorSubscriptionId, query_id: proto::QueryId },
+}
+
+impl WatcherChange {
+    /// Create a watcher change for adding an entity watcher
+    pub fn add(entity_id: proto::EntityId, subscription_id: ReactorSubscriptionId, query_id: proto::QueryId) -> Self {
+        Self::Add { entity_id, subscription_id, query_id }
+    }
+
+    /// Create a watcher change for removing an entity watcher
+    pub fn remove(entity_id: proto::EntityId, subscription_id: ReactorSubscriptionId, query_id: proto::QueryId) -> Self {
+        Self::Remove { entity_id, subscription_id, query_id }
+    }
+}

--- a/core/src/util/ivec.rs
+++ b/core/src/util/ivec.rs
@@ -1,0 +1,316 @@
+use std::mem::MaybeUninit;
+
+/// Inline vector - uses fixed array for small collections, Vec for larger ones
+#[derive(Debug)]
+pub enum IVec<T, const N: usize> {
+    /// Small collections stored in fixed array with length tracker
+    Small { data: [MaybeUninit<T>; N], len: usize },
+    /// Large collections stored in Vec
+    Large(Vec<T>),
+}
+
+impl<T, const N: usize> IVec<T, N> {
+    /// Creates an empty IVec
+    pub fn new() -> Self { Self::Small { data: unsafe { MaybeUninit::uninit().assume_init() }, len: 0 } }
+
+    /// Returns the number of elements
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Small { len, .. } => *len,
+            Self::Large(vec) => vec.len(),
+        }
+    }
+
+    /// Returns true if empty
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
+
+    /// Pushes a value to the collection
+    pub fn push(&mut self, value: T) {
+        match self {
+            Self::Small { data, len } if *len < N => {
+                data[*len].write(value);
+                *len += 1;
+            }
+            Self::Small { data, len } => {
+                // Transition to Large
+                let mut vec = Vec::with_capacity(N + 1);
+                for i in 0..*len {
+                    // SAFETY: We know indices 0..len are initialized
+                    unsafe {
+                        vec.push(data[i].assume_init_read());
+                    }
+                }
+                vec.push(value);
+                *self = Self::Large(vec);
+            }
+            Self::Large(vec) => {
+                vec.push(value);
+            }
+        }
+    }
+
+    /// Returns an iterator over the elements
+    pub fn iter(&self) -> Iter<'_, T, N> { Iter { ivec: self, index: 0 } }
+
+    /// Returns a slice view of the elements
+    pub fn as_slice(&self) -> &[T] {
+        match self {
+            Self::Small { data, len } => {
+                // SAFETY: We know indices 0..len are initialized
+                unsafe { std::slice::from_raw_parts(data.as_ptr() as *const T, *len) }
+            }
+            Self::Large(vec) => vec.as_slice(),
+        }
+    }
+}
+
+impl<T: PartialEq, const N: usize> IVec<T, N> {
+    /// Checks if the collection contains a value
+    pub fn contains(&self, value: &T) -> bool {
+        match self {
+            Self::Small { data, len } => {
+                for i in 0..*len {
+                    // SAFETY: We know indices 0..len are initialized
+                    unsafe {
+                        if data[i].assume_init_ref() == value {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            Self::Large(vec) => vec.contains(value),
+        }
+    }
+
+    /// Adds a value if not already present, returns true if added
+    pub fn add(&mut self, value: T) -> bool {
+        if self.contains(&value) {
+            false
+        } else {
+            self.push(value);
+            true
+        }
+    }
+}
+
+impl<T, const N: usize> Default for IVec<T, N> {
+    fn default() -> Self { Self::new() }
+}
+
+impl<T: Clone, const N: usize> Clone for IVec<T, N> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Small { data, len } => {
+                let mut new_data: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+                for i in 0..*len {
+                    // SAFETY: We know indices 0..len are initialized
+                    unsafe {
+                        new_data[i].write(data[i].assume_init_ref().clone());
+                    }
+                }
+                Self::Small { data: new_data, len: *len }
+            }
+            Self::Large(vec) => Self::Large(vec.clone()),
+        }
+    }
+}
+
+impl<T, const N: usize> Drop for IVec<T, N> {
+    fn drop(&mut self) {
+        match self {
+            Self::Small { data, len } => {
+                // Drop initialized elements
+                for i in 0..*len {
+                    // SAFETY: We know indices 0..len are initialized
+                    unsafe {
+                        data[i].assume_init_drop();
+                    }
+                }
+            }
+            Self::Large(_) => {
+                // Vec handles its own drop
+            }
+        }
+    }
+}
+
+pub struct Iter<'a, T, const N: usize> {
+    ivec: &'a IVec<T, N>,
+    index: usize,
+}
+
+impl<'a, T, const N: usize> Iterator for Iter<'a, T, N> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.ivec {
+            IVec::Small { data, len } => {
+                if self.index < *len {
+                    // SAFETY: We know indices 0..len are initialized
+                    let item = unsafe { data[self.index].assume_init_ref() };
+                    self.index += 1;
+                    Some(item)
+                } else {
+                    None
+                }
+            }
+            IVec::Large(vec) => {
+                if self.index < vec.len() {
+                    let item = &vec[self.index];
+                    self.index += 1;
+                    Some(item)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+impl<'a, T, const N: usize> IntoIterator for &'a IVec<T, N> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T, N>;
+
+    fn into_iter(self) -> Self::IntoIter { self.iter() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_small_push() {
+        let mut ivec: IVec<i32, 4> = IVec::new();
+        assert_eq!(ivec.len(), 0);
+        assert!(ivec.is_empty());
+
+        ivec.push(1);
+        ivec.push(2);
+        ivec.push(3);
+
+        assert_eq!(ivec.len(), 3);
+        assert!(!ivec.is_empty());
+        assert!(matches!(ivec, IVec::Small { .. }));
+    }
+
+    #[test]
+    fn test_transition_to_large() {
+        let mut ivec: IVec<i32, 2> = IVec::new();
+        ivec.push(1);
+        ivec.push(2);
+        assert!(matches!(ivec, IVec::Small { .. }));
+
+        ivec.push(3);
+        assert!(matches!(ivec, IVec::Large(_)));
+        assert_eq!(ivec.len(), 3);
+    }
+
+    #[test]
+    fn test_contains() {
+        let mut ivec: IVec<i32, 4> = IVec::new();
+        ivec.push(1);
+        ivec.push(2);
+        ivec.push(3);
+
+        assert!(ivec.contains(&1));
+        assert!(ivec.contains(&2));
+        assert!(ivec.contains(&3));
+        assert!(!ivec.contains(&4));
+    }
+
+    #[test]
+    fn test_contains_large() {
+        let mut ivec: IVec<i32, 2> = IVec::new();
+        ivec.push(1);
+        ivec.push(2);
+        ivec.push(3);
+        ivec.push(4);
+
+        assert!(matches!(ivec, IVec::Large(_)));
+        assert!(ivec.contains(&1));
+        assert!(ivec.contains(&4));
+        assert!(!ivec.contains(&5));
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut ivec: IVec<i32, 4> = IVec::new();
+        ivec.push(1);
+        ivec.push(2);
+        ivec.push(3);
+
+        let items: Vec<_> = ivec.iter().copied().collect();
+        assert_eq!(items, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_iter_large() {
+        let mut ivec: IVec<i32, 2> = IVec::new();
+        ivec.push(1);
+        ivec.push(2);
+        ivec.push(3);
+        ivec.push(4);
+
+        let items: Vec<_> = ivec.iter().copied().collect();
+        assert_eq!(items, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_drop() {
+        use std::sync::Arc;
+
+        // Test that Drop is called properly for Small variant
+        let mut ivec: IVec<Arc<i32>, 4> = IVec::new();
+        let a1 = Arc::new(1);
+        let a2 = Arc::new(2);
+
+        ivec.push(Arc::clone(&a1));
+        ivec.push(Arc::clone(&a2));
+
+        assert_eq!(Arc::strong_count(&a1), 2);
+        assert_eq!(Arc::strong_count(&a2), 2);
+
+        drop(ivec);
+
+        assert_eq!(Arc::strong_count(&a1), 1);
+        assert_eq!(Arc::strong_count(&a2), 1);
+    }
+
+    #[test]
+    fn test_add() {
+        let mut ivec: IVec<i32, 4> = IVec::new();
+
+        assert!(ivec.add(1));
+        assert!(ivec.add(2));
+        assert!(ivec.add(3));
+        assert_eq!(ivec.len(), 3);
+
+        // Adding duplicate should return false
+        assert!(!ivec.add(2));
+        assert_eq!(ivec.len(), 3);
+
+        // Verify contents
+        let items: Vec<_> = ivec.iter().copied().collect();
+        assert_eq!(items, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_add_large() {
+        let mut ivec: IVec<i32, 2> = IVec::new();
+
+        assert!(ivec.add(1));
+        assert!(ivec.add(2));
+        assert!(ivec.add(3));
+        assert!(matches!(ivec, IVec::Large(_)));
+
+        // Adding duplicate should return false even in Large variant
+        assert!(!ivec.add(1));
+        assert!(!ivec.add(2));
+        assert_eq!(ivec.len(), 3);
+
+        // Can still add new items
+        assert!(ivec.add(4));
+        assert_eq!(ivec.len(), 4);
+    }
+}

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -1,7 +1,9 @@
 pub mod iterable;
+pub mod ivec;
 pub mod safemap;
 pub mod safeset;
 pub use iterable::Iterable;
+pub use ivec::IVec;
 
 /// Formats an action log with consistent styling.
 /// First argument is always a "thing" that performed the action (in bold blue)

--- a/specs/misc/reactor_hot_path_serialization_plan.md
+++ b/specs/misc/reactor_hot_path_serialization_plan.md
@@ -1,0 +1,126 @@
+### Reactor Hot Path Serialization - Implementation Summary
+
+**Completed:** October 2025
+
+## Goals Achieved
+
+- Minimized time under global locks on the hot path (`notify_change`)
+- Batched per-subscription work at the subscription level
+- Parallelized predicate evaluation across subscriptions
+- Enabled future gap filling serialization by making `Subscription` clonable with interior mutability
+- Gap filling now consolidated into single `ReactorUpdate` per invocation
+
+## Architecture Changes
+
+### Subscription Internal State
+
+- Renamed `SubscriptionState` to `Subscription` and made it clonable via `Arc<Inner>` wrapper
+- Changed from exterior mutability (accessed via reactor lock) to interior mutability (`std::sync::Mutex<State>`)
+- Kept `Subscriptions: Mutex<HashMap<ReactorSubscriptionId, Subscription<E, Ev>>>` unchanged (only for insert/remove/fetch)
+- Added `notify_lock: tokio::sync::Mutex<()>` to `ReactorInner` to serialize `notify_change` invocations
+
+### Change Batching (`CandidateChanges`)
+
+Implemented in `core/src/reactor/candidate_changes.rs`:
+
+```rust
+pub struct CandidateChanges<C> {
+    changes: Arc<Vec<C>>,
+    query_offsets: BTreeMap<QueryId, HashSet<usize>>,
+    entity_offsets: HashSet<usize>,
+}
+```
+
+- Wraps changes in `Arc<Vec<C>>` to avoid cloning per subscription
+- Tracks offsets separately for query-specific and entity-level candidates
+- Provides `query_iter()` and `entity_iter()` for efficient iteration
+
+### notify_change Flow (Implemented)
+
+1. **Acquire notify_lock** (async mutex, serializes invocations)
+2. **Under watcher_set lock** (std mutex, no await):
+   - Scan watchers for all changed entities
+   - Build `HashMap<ReactorSubscriptionId, CandidateChanges<C>>`
+   - Drop lock
+3. **Parallel evaluation**:
+   - Lock subscriptions map, collect evaluation futures (cloning `Subscription` Arc)
+   - Drop subscriptions lock
+   - `join_all` on `subscription.evaluate_changes(candidates)` across all subscriptions
+4. **Apply watcher changes**:
+   - Re-lock watcher_set
+   - Apply all returned `WatcherChange`s
+   - Drop lock
+
+### Subscription::evaluate_changes (async)
+
+- **Signature**: `async fn evaluate_changes(self, candidates: CandidateChanges<C>) -> Vec<WatcherChange>`
+- Takes ownership of `self` (cheap Arc clone)
+- Locks internal state once for entire evaluation
+- For each query candidate:
+  - Evaluates predicate
+  - Detects membership changes (Add/Remove)
+  - Updates resultset
+  - Accumulates `WatcherChange`s to return
+- Handles entity-level subscriptions
+- Collects gap fill data while holding lock
+- Drops state lock before spawning gap fill task
+- Returns `WatcherChange`s for reactor to apply globally
+
+### Gap Filling
+
+- Integrated into `fill_gaps_and_notify` method
+- Spawned as background task after dropping state lock
+- Processes multiple gap fills in parallel using `join_all`
+- Emits single consolidated `ReactorUpdate` after all gaps filled
+
+### Watcher Management (`WatcherSet`)
+
+Extracted to `core/src/reactor/watcherset.rs`:
+
+- Encapsulates index watchers, wildcard watchers, and entity watchers
+- Key method: `accumulate_interested_watchers()` - identifies subscriptions interested in each change
+- Critical fix: Distinguish `EntityWatcherId::Predicate` from `EntityWatcherId::Subscription`:
+  - Predicate watchers → route to query evaluation loop (for membership change detection)
+  - Subscription watchers → route to entity-only updates
+
+### Locking Discipline
+
+- `notify_lock`: Held for entire `notify_change` execution (async)
+- `watcher_set`: Two brief std mutex locks per `notify_change` (accumulate, then apply)
+- `subscriptions`: Brief std mutex lock to fetch subscriptions (no await)
+- `Subscription.state`: Std mutex lock for evaluation, dropped before any await
+- No std mutex held across await points
+
+## Key Implementation Details
+
+### Removed Functionality
+
+- Deleted `update_query_matching_entities` (logic inlined into `evaluate_changes`)
+- Deleted standalone `pause_query` (only used internally by `update_query`)
+
+### Refactored Methods
+
+- `add_query`: Sets up watchers, sends initialization update
+- `update_query`: Updates predicates, handles adds/removes, updates watchers atomically
+- `remove_query`: Cleans up watchers for removed query
+- `unsubscribe`: Cleans up all watchers for subscription
+- `system_reset`: Clears entity watchers and notifies all subscriptions
+
+### Critical Bug Fixed
+
+In `WatcherSet::accumulate_interested_watchers`: Entity watchers for predicates (`EntityWatcherId::Predicate`) must call `add_query()` not `add_entity()` to route changes through query evaluation loop where membership changes are detected. This was the root cause of gap filling test failures.
+
+## Testing
+
+All tests pass including:
+
+- Basic reactor tests
+- Gap filling tests (single and multi-node, ascending and descending)
+- Inter-node tests
+- Property backend tests
+
+## Future Considerations
+
+- **Gap filling serialization**: Currently gap fill tasks can be spawned concurrently if `notify_change` is called again before previous gap fill completes. Architecture now supports adding per-subscription serialization (e.g., mutex or pending flag) to prevent concurrent gap fills
+- Possible merge of `reactor::subscription_state::Subscription` and `reactor::subscription::ReactorSubscription` (would require weak ref to break cycle)
+- Coalescing semantics for batching multiple change notifications when one change notification is in progress and another one is received

--- a/tests/tests/inter_node.rs
+++ b/tests/tests/inter_node.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use ankurah::signals::Subscribe;
-use ankurah::{changes::ChangeKind, policy::DEFAULT_CONTEXT as c, EntityId, Mutable, Node, PermissiveAgent, ResultSet};
+use ankurah::{changes::ChangeKind, policy::DEFAULT_CONTEXT as c, EntityId, Mutable, Node, PermissiveAgent};
 use ankurah_connector_local_process::LocalProcessConnection;
 use ankurah_storage_sled::SledStorageEngine;
 use anyhow::Result;

--- a/tests/tests/update_predicate.rs
+++ b/tests/tests/update_predicate.rs
@@ -3,15 +3,13 @@ use crate::common::TestWatcher;
 use ankurah::changes::ChangeKind;
 use ankurah::signals::Subscribe;
 use ankurah::{policy::DEFAULT_CONTEXT as c, Node, PermissiveAgent};
-use ankurah_connector_local_process::LocalProcessConnection;
 use ankurah_storage_sled::SledStorageEngine;
 use anyhow::Result;
+use common::*;
 use std::sync::Arc;
 
 #[tokio::test]
 async fn test_predicate_update() -> Result<()> {
-    use common::*;
-
     let storage_engine = SledStorageEngine::new_test()?;
     let node = Node::new_durable(Arc::new(storage_engine), PermissiveAgent::new());
 


### PR DESCRIPTION
Refactored the Reactor's change notification pipeline to minimize global lock contention, enable parallel per-subscription evaluation, and lay groundwork for proper gap filling serialization.

### Motivation

This refactoring was driven by requirements from PR #139 (`peer_known_matches_and_attested_head_relation`), which needs to use the gap filling logic in `add_query` and `update_query`. The previous architecture held the reactor lock during gap filling operations, making dispatch from other code paths impractical.

**Key enabler**: `reactor::subscription_state::Subscription` (renamed from `SubscriptionState`) is now clonable (cheap `Arc` clone) with interior mutability (`std::sync::Mutex<State>`), replacing the previous exterior mutability accessed via reactor lock. This allows gap filling logic to be dispatched without holding the reactor lock and enables future per-subscription gap filling serialization.

### Key Changes

**Architecture**
- Renamed `SubscriptionState` to `Subscription` and changed from exterior mutability to interior mutability via `Arc<Inner>` wrapper
- Serialized `notify_change` invocations using `tokio::sync::Mutex<()>` to prevent watcher state races
- Extracted `WatcherSet` into dedicated module with helper methods for watcher management
- Improved separation of concerns between `Reactor` and `Subscription`

**Batching & Parallelization**
- Introduced `CandidateChanges<C>` to efficiently batch changes per subscription using `Arc<Vec<C>>` and offset tracking
- Parallelized `evaluate_changes` calls across subscriptions using `futures::join_all`
- `notify_change` now locks `watcher_set` twice briefly (accumulate → evaluate → apply) instead of holding throughout

**Subscription Evaluation**
- Added `async fn evaluate_changes(self, candidates: CandidateChanges<C>)` as main entrypoint for per-subscription processing
- Consolidated predicate evaluation, resultset updates, gap filling, and notification into single async method
- Drops internal state lock before spawning gap fill task to avoid blocking other operations
- Gap filling now emitted as part of consolidated `ReactorUpdate` per invocation

**Bug Fix**
- Fixed critical bug in `WatcherSet::accumulate_interested_watchers`: predicate entity watchers now correctly route to query evaluation loop via `add_query()` instead of `add_entity()`, enabling proper membership change detection (Add/Remove) and gap filling

### Locking Discipline
- `notify_lock`: Serializes `notify_change` (async)
- `watcher_set`: Two brief std locks per change batch
- `subscriptions`: Brief std lock for lookups only
- `Subscription.state`: Std lock for evaluation, dropped before awaits
- ✅ No std mutex held across await points

### Testing
All tests passing including gap filling (single/multi-node, asc/desc) and inter-node synchronization.

### Future Considerations
- **Gap filling serialization**: Architecture now supports adding per-subscription serialization to prevent concurrent gap fills (not implemented in this PR)
- Possible merge of `reactor::subscription_state::Subscription` and `reactor::subscription::ReactorSubscription` (would require weak ref to break cycle)
- Coalescing semantics for batching multiple change notifications when one is in progress