### PR TITLE
Fix: Schema-based filtering for undefined columns in postgres queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "ankql"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "ankurah-connector-local-process",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-connector-local-process"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "ankurah-derive",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-derive"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "maplit",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-example-server"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankurah",
  "ankurah-storage-sled",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-proto"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "anyhow",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-signals"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "js-sys",
  "reactive_graph",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-common"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-indexeddb-wasm"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "ankurah",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-postgres"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-sled"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "ankurah",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankql",
  "ankurah",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client-wasm"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-server"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "example-model"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankurah",
  "chrono",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "example-wasm-bindings"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ankurah",
  "ankurah-signals",

--- a/RELEASES
+++ b/RELEASES
@@ -1,3 +1,4 @@
+0.7.6  Fix assume_null to filter ORDER BY columns referencing missing columns, preventing retry loops
 0.7.5  Fix concurrent DDL race conditions with PostgreSQL advisory locks; improved postgres error logging
 0.7.4  Memo signal for cached transformations; WebsocketClientBuilder for connection options
 0.7.3  Fix postgres get_state returning StorageError instead of EntityNotFound for non-existent entities; WebsocketServer route_handler() for custom routing; JsValueRead trait object flexibility

--- a/ankql/Cargo.toml
+++ b/ankql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankql"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Ankurah Query Language - Aspirational query language for Ankurah in the style of Open Cypher and GQL (ISO/IEC 39075:2024)"
 license       = "MIT OR Apache-2.0"

--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Observable, event-driven state management for native and web"
 license       = "MIT OR Apache-2.0"
@@ -27,11 +27,11 @@ derive = ["dep:ankurah-derive"]
 instrument = ["ankurah-core/instrument"]
 
 [dependencies]
-ankurah-core    = { path = "../core", version = "^0.7.5" }
-ankurah-proto   = { path = "../proto", version = "^0.7.5" }
-ankurah-derive  = { path = "../derive", version = "^0.7.5", optional = true }
-ankurah-signals = { path = "../signals", version = "^0.7.5" }
-ankql           = { path = "../ankql", version = "^0.7.5" }
+ankurah-core    = { path = "../core", version = "^0.7.6" }
+ankurah-proto   = { path = "../proto", version = "^0.7.6" }
+ankurah-derive  = { path = "../derive", version = "^0.7.6", optional = true }
+ankurah-signals = { path = "../signals", version = "^0.7.6" }
+ankql           = { path = "../ankql", version = "^0.7.6" }
 serde_json      = { version = "1.0" }
 serde           = { version = "1.0" }
 tracing         = { version = "0.1.40" }

--- a/connectors/local-process/Cargo.toml
+++ b/connectors/local-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-connector-local-process"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Ankurah connector for local processes"
 license       = "MIT OR Apache-2.0"
@@ -9,8 +9,8 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core  = { path = "../../core", version = "^0.7.5" }
-ankurah-proto = { path = "../../proto", version = "^0.7.5" }
+ankurah-core  = { path = "../../core", version = "^0.7.6" }
+ankurah-proto = { path = "../../proto", version = "^0.7.6" }
 
 tokio       = { version = "1.40", features = ["full"] }
 async-trait = "0.1"

--- a/connectors/websocket-client-wasm/Cargo.toml
+++ b/connectors/websocket-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client-wasm"
-version       = "0.7.5"
+version       = "0.7.6"
 authors       = ["Daniel Norman <daniel@danielnorman.net>"]
 edition       = "2021"
 description   = "Ankurah WebSocket Client - A WebSocket client for Ankurah"
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.5" }
-ankurah-core       = { path = "../../core", version = "^0.7.5" }
-ankurah-proto      = { path = "../../proto", version = "^0.7.5", features = ["wasm"] }
-ankurah-derive     = { path = "../../derive", version = "^0.7.5" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.6" }
+ankurah-core       = { path = "../../core", version = "^0.7.6" }
+ankurah-proto      = { path = "../../proto", version = "^0.7.6", features = ["wasm"] }
+ankurah-derive     = { path = "../../derive", version = "^0.7.6" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 

--- a/connectors/websocket-client/Cargo.toml
+++ b/connectors/websocket-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Ankurah WebSocket Client - Native WebSocket client for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -9,9 +9,9 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core    = { path = "../../core", version = "^0.7.5" }
-ankurah-proto   = { path = "../../proto", version = "^0.7.5" }
-ankurah-signals = { path = "../../signals", version = "^0.7.5" }
+ankurah-core    = { path = "../../core", version = "^0.7.6" }
+ankurah-proto   = { path = "../../proto", version = "^0.7.6" }
+ankurah-signals = { path = "../../signals", version = "^0.7.6" }
 
 # WebSocket implementation
 tokio-tungstenite = { version = "0.27", features = ["native-tls"] }
@@ -33,6 +33,6 @@ url       = "2.0"
 strum     = { version = "0.27", features = ["derive"] }
 
 [dev-dependencies]
-ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.7.5" }
-ankurah-websocket-server = { path = "../websocket-server", version = "^0.7.5" }
-ankurah                  = { path = "../../ankurah", version = "^0.7.5", features = ["derive"] }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.7.6" }
+ankurah-websocket-server = { path = "../websocket-server", version = "^0.7.6" }
+ankurah                  = { path = "../../ankurah", version = "^0.7.6", features = ["derive"] }

--- a/connectors/websocket-server/Cargo.toml
+++ b/connectors/websocket-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-server"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Ankurah WebSocket Server - A WebSocket server for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ instrument = []
 [dependencies]
 
 # Base dependencies
-ankurah-proto          = { path = "../../proto", version = "^0.7.5" }
-ankurah-core           = { path = "../../core", version = "^0.7.5" }
+ankurah-proto          = { path = "../../proto", version = "^0.7.6" }
+ankurah-core           = { path = "../../core", version = "^0.7.6" }
 anyhow                 = "1.0"
 bincode                = "1.3"
 serde                  = { version = "1.0.203", features = ["derive", "serde_derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-core"
 description   = "Core state management functionality for Ankurah"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-core"
@@ -24,10 +24,10 @@ instrument = []
 
 [dependencies]
 # Internal dependencies
-ankurah-derive  = { path = "../derive", optional = true, version = "^0.7.5" }
-ankql           = { path = "../ankql", version = "^0.7.5" }
-ankurah-proto   = { path = "../proto", version = "^0.7.5" }
-ankurah-signals = { path = "../signals", version = "^0.7.5" }
+ankurah-derive  = { path = "../derive", optional = true, version = "^0.7.6" }
+ankql           = { path = "../ankql", version = "^0.7.6" }
+ankurah-proto   = { path = "../proto", version = "^0.7.6" }
+ankurah-signals = { path = "../signals", version = "^0.7.6" }
 
 rand                 = "0.8"
 anyhow               = "1.0"
@@ -58,4 +58,4 @@ base64               = { version = "0.22" }
 
 [dev-dependencies]
 maplit         = "1.0"
-ankurah-derive = { path = "../derive", version = "^0.7.5" }
+ankurah-derive = { path = "../derive", version = "^0.7.6" }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-derive"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Ankurah Derive - Derive macros for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ syn = { version = "2.0", default-features = false, features = [
     "extra-traits",
 ] }
 serde_derive_internals = "0.29"
-ankql = { path = "../ankql", version = "^0.7.5" }
+ankql = { path = "../ankql", version = "^0.7.6" }
 regex = "1.0"
 ron = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/model/Cargo.toml
+++ b/examples/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "example-model"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 publish = false
 
@@ -9,7 +9,7 @@ default = []
 wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/react"]
 
 [dependencies]
-ankurah      = { path = "../../ankurah", features = ["derive"], version = "^0.7.5" }
+ankurah      = { path = "../../ankurah", features = ["derive"], version = "^0.7.6" }
 serde        = { version = "1.0", features = ["derive"] }
 serde_json   = "1.0"
 wasm-bindgen = { version = "0.2", optional = true }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name    = "ankurah-example-server"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 publish = false
 
 [dependencies]
-ankurah                  = { path = "../../ankurah", version = "^0.7.5" }
-ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "^0.7.5" }
-ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.7.5" }
+ankurah                  = { path = "../../ankurah", version = "^0.7.6" }
+ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "^0.7.6" }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.7.6" }
 example-model            = { path = "../model" }
 tracing                  = "0.1"
 tracing-subscriber       = "0.3"

--- a/examples/wasm-bindings/Cargo.toml
+++ b/examples/wasm-bindings/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name    = "example-wasm-bindings"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.5" }
-ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "^0.7.5" }
-ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "^0.7.5" }
-ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "^0.7.5" }
-example-model                  = { path = "../model", features = ["wasm"], version = "0.7.5" }
+ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.6" }
+ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "^0.7.6" }
+ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "^0.7.6" }
+ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "^0.7.6" }
+example-model                  = { path = "../model", features = ["wasm"], version = "0.7.6" }
 wasm-bindgen                   = "0.2.84"
 wasm-bindgen-futures           = "0.4.42"
 wasm-logger                    = "0.2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-proto"
 description   = "Inter-node communication protocol for Ankurah"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-proto"
@@ -22,7 +22,7 @@ serde              = { version = "1.0.204", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 ulid               = { version = "1.1.3", features = ["serde"] }
 base64             = { version = "0.22" }
-ankql              = { path = "../ankql", version = "^0.7.5" }
+ankql              = { path = "../ankql", version = "^0.7.6" }
 sha2               = "0.10.8"
 postgres-types     = { version = "0.2", optional = true }
 postgres-protocol  = { version = "0.6", optional = true }

--- a/signals/Cargo.toml
+++ b/signals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-signals"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2024"
 description   = "Ankurah Signals"
 license       = "MIT OR Apache-2.0"

--- a/storage/common/Cargo.toml
+++ b/storage/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-common"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2024"
 description   = "Ankurah storage engine common libraries"
 license       = "MIT OR Apache-2.0"
@@ -9,12 +9,12 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankql         = { path = "../../ankql", version = "^0.7.5" }
-ankurah-core  = { path = "../../core", version = "^0.7.5" }
-ankurah-proto = { path = "../../proto", version = "^0.7.5" }
+ankql         = { path = "../../ankql", version = "^0.7.6" }
+ankurah-core  = { path = "../../core", version = "^0.7.6" }
+ankurah-proto = { path = "../../proto", version = "^0.7.6" }
 indexmap      = "2.0"
 serde         = { version = "1.0", features = ["derive"] }
 tracing       = { version = "0.1.40" }
 
 [dev-dependencies]
-ankurah-derive = { path = "../../derive", version = "^0.7.5" }
+ankurah-derive = { path = "../../derive", version = "^0.7.6" }

--- a/storage/indexeddb-wasm/Cargo.toml
+++ b/storage/indexeddb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-indexeddb-wasm"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Ankurah storage engine using IndexedDB in the browser"
 license       = "MIT OR Apache-2.0"
@@ -15,11 +15,11 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah-core           = { path = "../../core", version = "^0.7.5", features = ["wasm"] }
-ankurah-proto          = { path = "../../proto", version = "^0.7.5", features = ["wasm"] }
-ankql                  = { path = "../../ankql", version = "^0.7.5" }
-ankurah-derive         = { path = "../../derive", version = "^0.7.5", features = ["wasm"] }
-ankurah-storage-common = { path = "../common", version = "^0.7.5" }
+ankurah-core           = { path = "../../core", version = "^0.7.6", features = ["wasm"] }
+ankurah-proto          = { path = "../../proto", version = "^0.7.6", features = ["wasm"] }
+ankql                  = { path = "../../ankql", version = "^0.7.6" }
+ankurah-derive         = { path = "../../derive", version = "^0.7.6", features = ["wasm"] }
+ankurah-storage-common = { path = "../common", version = "^0.7.6" }
 serde                  = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen     = "0.6"
 tokio                  = { version = "1.39", features = ["sync"] }
@@ -80,7 +80,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 #[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 [dev-dependencies]
 wasm-bindgen-test  = "0.3"
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.5" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.6" }
 tracing-subscriber = "0.3"
 
     [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/storage/postgres/Cargo.toml
+++ b/storage/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-postgres"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Ankurah storage engine using Postgres"
 license       = "MIT OR Apache-2.0"
@@ -18,9 +18,9 @@ anyhow         = "1.0"
 thiserror      = "2.0"
 tokio          = { version = "1.36", features = ["full"] }
 
-ankql         = { path = "../../ankql", version = "^0.7.5" }
-ankurah-core  = { path = "../../core", version = "^0.7.5" }
-ankurah-proto = { path = "../../proto", version = "^0.7.5", features = ["postgres"] }
+ankql         = { path = "../../ankql", version = "^0.7.6" }
+ankurah-core  = { path = "../../core", version = "^0.7.6" }
+ankurah-proto = { path = "../../proto", version = "^0.7.6", features = ["postgres"] }
 tracing       = "0.1"
 async-trait   = "0.1"
 futures-util  = "0.3"

--- a/storage/sled/Cargo.toml
+++ b/storage/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-sled"
-version       = "0.7.5"
+version       = "0.7.6"
 edition       = "2021"
 description   = "Ankurah storage engine using Sled"
 license       = "MIT OR Apache-2.0"
@@ -9,10 +9,10 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-proto          = { path = "../../proto", version = "^0.7.5" }
-ankurah-core           = { path = "../../core", version = "^0.7.5" }
-ankql                  = { path = "../../ankql", version = "^0.7.5" }
-ankurah-storage-common = { path = "../common", version = "^0.7.5" }
+ankurah-proto          = { path = "../../proto", version = "^0.7.6" }
+ankurah-core           = { path = "../../core", version = "^0.7.6" }
+ankql                  = { path = "../../ankql", version = "^0.7.6" }
+ankurah-storage-common = { path = "../common", version = "^0.7.6" }
 anyhow                 = "1.0"
 async-trait            = "0.1"
 sled                   = "0.34"
@@ -27,6 +27,6 @@ tracing                = "0.1"
 thiserror              = "2.0"
 
 [dev-dependencies]
-ankurah            = { path = "../../ankurah", version = "^0.7.5", features = ["derive"] }
+ankurah            = { path = "../../ankurah", version = "^0.7.6", features = ["derive"] }
 ctor               = "0.5"
 tracing-subscriber = "0.3"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-tests"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 publish = false
 
@@ -11,15 +11,15 @@ postgres = ["ankurah-storage-postgres", "tokio-postgres", "bb8", "bb8-postgres"]
 [dependencies]
 anyhow                          = "1.0"
 tracing                         = "0.1"
-ankql                           = { path = "../ankql", version = "^0.7.5" }
-ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "^0.7.5" }
-ankurah-storage-sled            = { path = "../storage/sled", version = "^0.7.5" }
-ankurah-connector-local-process = { path = "../connectors/local-process", version = "^0.7.5" }
-ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "^0.7.5" }
-ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "^0.7.5" }
-ankurah-storage-common          = { path = "../storage/common", version = "^0.7.5" }
+ankql                           = { path = "../ankql", version = "^0.7.6" }
+ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "^0.7.6" }
+ankurah-storage-sled            = { path = "../storage/sled", version = "^0.7.6" }
+ankurah-connector-local-process = { path = "../connectors/local-process", version = "^0.7.6" }
+ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "^0.7.6" }
+ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "^0.7.6" }
+ankurah-storage-common          = { path = "../storage/common", version = "^0.7.6" }
 tokio-postgres                  = { version = "0.7", optional = true }
-ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "^0.7.5" }
+ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "^0.7.6" }
 bb8                             = { version = "0.9", optional = true }
 bb8-postgres                    = { version = "0.9", optional = true }
 tokio                           = { version = "1.40", features = ["full"] }

--- a/tests/tests/pg_undefined_column.rs
+++ b/tests/tests/pg_undefined_column.rs
@@ -1,0 +1,115 @@
+//! Test for undefined column handling in postgres queries
+//!
+//! Tests that queries referencing columns that don't exist yet are handled gracefully
+//! by treating missing columns as NULL via schema-based filtering.
+
+#![cfg(feature = "postgres")]
+
+mod common;
+mod pg_common;
+
+use ankurah::{policy::DEFAULT_CONTEXT as c, Model, Node, PermissiveAgent};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Model with status and created fields to test missing column handling
+#[derive(Model, Debug, Serialize, Deserialize)]
+pub struct Task {
+    pub name: String,
+    pub status: String,
+    pub created: String,
+}
+
+/// Test that queries handle undefined columns in WHERE clause
+#[tokio::test]
+async fn test_undefined_column_in_where() -> Result<()> {
+    let (_container, storage_engine) = pg_common::create_postgres_container().await?;
+    let node = Node::new_durable(Arc::new(storage_engine), PermissiveAgent::new());
+    node.system.create().await?;
+    let ctx = node.context_async(c).await;
+
+    // Query for tasks with status filter - but no tasks exist yet, so the column doesn't exist
+    // This should return empty results, not error
+    let results = ctx.fetch::<TaskView>("status = 'active'").await?;
+    assert!(results.is_empty(), "Expected empty results for query on non-existent column");
+
+    Ok(())
+}
+
+/// Test that queries handle undefined columns in ORDER BY clause
+#[tokio::test]
+async fn test_undefined_column_in_order_by() -> Result<()> {
+    let (_container, storage_engine) = pg_common::create_postgres_container().await?;
+    let node = Node::new_durable(Arc::new(storage_engine), PermissiveAgent::new());
+    node.system.create().await?;
+    let ctx = node.context_async(c).await;
+
+    // Query with ORDER BY on a column that doesn't exist yet
+    let results = ctx.fetch::<TaskView>("name = 'nonexistent' ORDER BY created DESC").await?;
+    assert!(results.is_empty(), "Expected empty results for query with ORDER BY on non-existent column");
+
+    Ok(())
+}
+
+/// Test WHERE on one missing column, ORDER BY on another (both handled upfront)
+#[tokio::test]
+async fn test_undefined_columns_where_and_order_by() -> Result<()> {
+    let (_container, storage_engine) = pg_common::create_postgres_container().await?;
+    let node = Node::new_durable(Arc::new(storage_engine), PermissiveAgent::new());
+    node.system.create().await?;
+    let ctx = node.context_async(c).await;
+
+    // Both "status" (WHERE) and "created" (ORDER BY) don't exist
+    // Schema-based filtering treats both as NULL upfront (no retry needed)
+    let results = ctx.fetch::<TaskView>("status = 'pending' OR status = 'active' ORDER BY created DESC").await?;
+    assert!(results.is_empty(), "Expected empty results");
+
+    Ok(())
+}
+
+/// Test that after writing data, subsequent queries work
+#[tokio::test]
+async fn test_columns_exist_after_write() -> Result<()> {
+    let (_container, storage_engine) = pg_common::create_postgres_container().await?;
+    let node = Node::new_durable(Arc::new(storage_engine), PermissiveAgent::new());
+    node.system.create().await?;
+    let ctx = node.context_async(c).await;
+
+    // First, create a task - this should create the columns
+    let trx = ctx.begin();
+    let _task = trx.create(&Task { name: "Test task".to_owned(), status: "pending".to_owned(), created: "2024-01-01".to_owned() }).await?;
+    trx.commit().await?;
+
+    // Now the query should work
+    let results = ctx.fetch::<TaskView>("status = 'pending' ORDER BY created DESC").await?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name().unwrap(), "Test task");
+
+    Ok(())
+}
+
+/// Test cache refresh: query before columns exist, write (creates columns), query again
+/// This validates that the schema cache gets refreshed when columns are added.
+#[tokio::test]
+async fn test_cache_refresh_after_column_creation() -> Result<()> {
+    let (_container, storage_engine) = pg_common::create_postgres_container().await?;
+    let node = Node::new_durable(Arc::new(storage_engine), PermissiveAgent::new());
+    node.system.create().await?;
+    let ctx = node.context_async(c).await;
+
+    // Query before any data - columns don't exist, should get empty results
+    let results = ctx.fetch::<TaskView>("status = 'pending'").await?;
+    assert!(results.is_empty(), "Expected empty before write");
+
+    // Write creates the columns
+    let trx = ctx.begin();
+    trx.create(&Task { name: "Task 1".to_owned(), status: "pending".to_owned(), created: "2024-01-01".to_owned() }).await?;
+    trx.commit().await?;
+
+    // Query again - cache should refresh and find the column now exists
+    let results = ctx.fetch::<TaskView>("status = 'pending'").await?;
+    assert_eq!(results.len(), 1, "Should find the task after column was created");
+
+    Ok(())
+}


### PR DESCRIPTION
### Problem
Queries referencing columns that don't exist yet (common during schema evolution) were causing:
1. Recursive retry loops when `UndefinedColumn` errors occurred
2. Connection pool exhaustion due to connections held during recursion
3. `bb8` timeouts under concurrent load

### Solution
Replace error-driven retries with proactive schema-based filtering:

1. **Check cached schema upfront** - Extract all column names from the selection (WHERE + ORDER BY)
2. **Refresh cache on unknown columns** - If we see columns not in our cache, refresh from `information_schema` (they may have been added by another node)
3. **Treat missing columns as NULL** - Use `assume_null()` on columns confirmed not to exist after refresh

Also replaced recursive retry patterns with bounded loops that retry exactly once for table creation.

### Changes
- `ankql/src/ast.rs`: Added `referenced_columns()` to `Selection` and `Predicate` for extracting column names
- `storage/postgres/src/lib.rs`: Schema-based filtering in `fetch_states`, bounded retry loops in `set_state` and `add_event`
- `tests/tests/pg_undefined_column.rs`: New test suite covering undefined columns in WHERE, ORDER BY, and cache refresh scenarios

### Testing
5 new tests covering:
- Undefined column in WHERE clause
- Undefined column in ORDER BY clause  
- Both WHERE and ORDER BY with undefined columns
- Columns work after write creates them
- Cache refresh picks up newly-created columns