### PR TITLE
fix: Json WASM serialization returns POJOs instead of Maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "ankql"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "ankurah-connector-local-process",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-connector-local-process"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-core"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "ankurah-derive",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-derive"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "maplit",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-model"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "getrandom 0.3.4",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-server"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "ankurah-doc-example-model",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-wasm-bindings"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "ankurah-doc-example-model",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-example-server"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "ankurah-storage-sled",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-proto"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "anyhow",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-signals"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "js-sys",
  "reactive_graph",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-common"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-indexeddb-wasm"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "ankurah",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-postgres"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-sled"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "ankurah",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankql",
  "ankurah",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests-wasm-bindings"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "ankurah-storage-indexeddb-wasm",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client-wasm"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-server"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "example-model"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "chrono",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "example-wasm-bindings"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "ankurah",
  "ankurah-signals",

--- a/RELEASES
+++ b/RELEASES
@@ -1,3 +1,4 @@
+0.7.11  Fix Json WASM serialization to return plain objects (POJOs) instead of ES2015 Maps
 0.7.10  ChangeSet API: initial(), added(), appeared(), updated(), removed() with deprecation of ambiguous adds()/removes()/updates(); Model.query_nocache() for WASM
 0.7.9  Ref<T> WASM monomorphization: ModelRef wrappers (e.g., UserRef) for proper TypeScript typing; set() accepts ModelRef | ModelView; View.r() returns ModelRef; static ModelRef.from_view(view) factory
 0.7.8  Ref<T> typed entity references with ergonomic traits (Deref, Copy, Borrow, AsRef, Display, TryFrom); Option<Ref<T>> WASM bindings; From<Ref<T>> for ankql::ast::Expr; IndexedDB JSON serialization fix (use plain objects not ES2015 Maps); Sled PropertyManager race condition fix

--- a/ankql/Cargo.toml
+++ b/ankql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankql"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Ankurah Query Language - Aspirational query language for Ankurah in the style of Open Cypher and GQL (ISO/IEC 39075:2024)"
 license       = "MIT OR Apache-2.0"

--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Observable, event-driven state management for native and web"
 license       = "MIT OR Apache-2.0"
@@ -27,11 +27,11 @@ derive = ["dep:ankurah-derive"]
 instrument = ["ankurah-core/instrument"]
 
 [dependencies]
-ankurah-core    = { path = "../core", version = "^0.7.10" }
-ankurah-proto   = { path = "../proto", version = "^0.7.10" }
-ankurah-derive  = { path = "../derive", version = "^0.7.10", optional = true }
-ankurah-signals = { path = "../signals", version = "^0.7.10" }
-ankql           = { path = "../ankql", version = "^0.7.10" }
+ankurah-core    = { path = "../core", version = "^0.7.11" }
+ankurah-proto   = { path = "../proto", version = "^0.7.11" }
+ankurah-derive  = { path = "../derive", version = "^0.7.11", optional = true }
+ankurah-signals = { path = "../signals", version = "^0.7.11" }
+ankql           = { path = "../ankql", version = "^0.7.11" }
 serde_json      = { version = "1.0" }
 serde           = { version = "1.0" }
 tracing         = { version = "0.1.40" }

--- a/connectors/local-process/Cargo.toml
+++ b/connectors/local-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-connector-local-process"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Ankurah connector for local processes"
 license       = "MIT OR Apache-2.0"
@@ -9,8 +9,8 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core  = { path = "../../core", version = "^0.7.10" }
-ankurah-proto = { path = "../../proto", version = "^0.7.10" }
+ankurah-core  = { path = "../../core", version = "^0.7.11" }
+ankurah-proto = { path = "../../proto", version = "^0.7.11" }
 
 tokio       = { version = "1.40", features = ["full"] }
 async-trait = "0.1"

--- a/connectors/websocket-client-wasm/Cargo.toml
+++ b/connectors/websocket-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client-wasm"
-version       = "0.7.10"
+version       = "0.7.11"
 authors       = ["Daniel Norman <daniel@danielnorman.net>"]
 edition       = "2021"
 description   = "Ankurah WebSocket Client - A WebSocket client for Ankurah"
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.10" }
-ankurah-core       = { path = "../../core", version = "^0.7.10" }
-ankurah-proto      = { path = "../../proto", version = "^0.7.10", features = ["wasm"] }
-ankurah-derive     = { path = "../../derive", version = "^0.7.10" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.11" }
+ankurah-core       = { path = "../../core", version = "^0.7.11" }
+ankurah-proto      = { path = "../../proto", version = "^0.7.11", features = ["wasm"] }
+ankurah-derive     = { path = "../../derive", version = "^0.7.11" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 

--- a/connectors/websocket-client/Cargo.toml
+++ b/connectors/websocket-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Ankurah WebSocket Client - Native WebSocket client for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -9,9 +9,9 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core    = { path = "../../core", version = "^0.7.10" }
-ankurah-proto   = { path = "../../proto", version = "^0.7.10" }
-ankurah-signals = { path = "../../signals", version = "^0.7.10" }
+ankurah-core    = { path = "../../core", version = "^0.7.11" }
+ankurah-proto   = { path = "../../proto", version = "^0.7.11" }
+ankurah-signals = { path = "../../signals", version = "^0.7.11" }
 
 # WebSocket implementation
 tokio-tungstenite = { version = "0.27", features = ["native-tls"] }
@@ -33,6 +33,6 @@ url       = "2.0"
 strum     = { version = "0.27", features = ["derive"] }
 
 [dev-dependencies]
-ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.7.10" }
-ankurah-websocket-server = { path = "../websocket-server", version = "^0.7.10" }
-ankurah                  = { path = "../../ankurah", version = "^0.7.10", features = ["derive"] }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.7.11" }
+ankurah-websocket-server = { path = "../websocket-server", version = "^0.7.11" }
+ankurah                  = { path = "../../ankurah", version = "^0.7.11", features = ["derive"] }

--- a/connectors/websocket-server/Cargo.toml
+++ b/connectors/websocket-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-server"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Ankurah WebSocket Server - A WebSocket server for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ instrument = []
 [dependencies]
 
 # Base dependencies
-ankurah-proto          = { path = "../../proto", version = "^0.7.10" }
-ankurah-core           = { path = "../../core", version = "^0.7.10" }
+ankurah-proto          = { path = "../../proto", version = "^0.7.11" }
+ankurah-core           = { path = "../../core", version = "^0.7.11" }
 anyhow                 = "1.0"
 bincode                = "1.3"
 serde                  = { version = "1.0.203", features = ["derive", "serde_derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-core"
 description   = "Core state management functionality for Ankurah"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-core"
@@ -24,10 +24,10 @@ instrument = []
 
 [dependencies]
 # Internal dependencies
-ankurah-derive  = { path = "../derive", optional = true, version = "^0.7.10" }
-ankql           = { path = "../ankql", version = "^0.7.10" }
-ankurah-proto   = { path = "../proto", version = "^0.7.10" }
-ankurah-signals = { path = "../signals", version = "^0.7.10" }
+ankurah-derive  = { path = "../derive", optional = true, version = "^0.7.11" }
+ankql           = { path = "../ankql", version = "^0.7.11" }
+ankurah-proto   = { path = "../proto", version = "^0.7.11" }
+ankurah-signals = { path = "../signals", version = "^0.7.11" }
 
 rand                 = "0.8"
 anyhow               = "1.0"
@@ -58,4 +58,4 @@ base64               = { version = "0.22" }
 
 [dev-dependencies]
 maplit         = "1.0"
-ankurah-derive = { path = "../derive", version = "^0.7.10" }
+ankurah-derive = { path = "../derive", version = "^0.7.11" }

--- a/core/src/property/value/json.rs
+++ b/core/src/property/value/json.rs
@@ -113,7 +113,9 @@ export type Json = any;
 impl From<Json> for JsValue {
     fn from(json: Json) -> Self {
         // Convert serde_json::Value to JsValue using serde-wasm-bindgen
-        serde_wasm_bindgen::to_value(&json.0).unwrap_or(JsValue::NULL)
+        // Use serialize_maps_as_objects to get POJOs instead of Map instances
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        json.0.serialize(&serializer).unwrap_or(JsValue::NULL)
     }
 }
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-derive"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Ankurah Derive - Derive macros for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ syn = { version = "2.0", default-features = false, features = [
     "extra-traits",
 ] }
 serde_derive_internals = "0.29"
-ankql = { path = "../ankql", version = "^0.7.10" }
+ankql = { path = "../ankql", version = "^0.7.11" }
 regex = "1.0"
 ron = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/example/model/Cargo.toml
+++ b/docs/example/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-model"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 
 [features]

--- a/docs/example/server/Cargo.toml
+++ b/docs/example/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-server"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 
 [dependencies]

--- a/docs/example/wasm-bindings/Cargo.toml
+++ b/docs/example/wasm-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-wasm-bindings"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 
 [lib]

--- a/examples/model/Cargo.toml
+++ b/examples/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "example-model"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 publish = false
 
@@ -9,7 +9,7 @@ default = []
 wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/react"]
 
 [dependencies]
-ankurah      = { path = "../../ankurah", features = ["derive"], version = "^0.7.10" }
+ankurah      = { path = "../../ankurah", features = ["derive"], version = "^0.7.11" }
 serde        = { version = "1.0", features = ["derive"] }
 serde_json   = "1.0"
 wasm-bindgen = { version = "0.2", optional = true }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name    = "ankurah-example-server"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 publish = false
 
 [dependencies]
-ankurah                  = { path = "../../ankurah", version = "^0.7.10" }
-ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "^0.7.10" }
-ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.7.10" }
+ankurah                  = { path = "../../ankurah", version = "^0.7.11" }
+ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "^0.7.11" }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "^0.7.11" }
 example-model            = { path = "../model" }
 tracing                  = "0.1"
 tracing-subscriber       = "0.3"

--- a/examples/wasm-bindings/Cargo.toml
+++ b/examples/wasm-bindings/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name    = "example-wasm-bindings"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.10" }
-ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "^0.7.10" }
-ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "^0.7.10" }
-ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "^0.7.10" }
-example-model                  = { path = "../model", features = ["wasm"], version = "^0.7.10" }
+ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.11" }
+ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "^0.7.11" }
+ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "^0.7.11" }
+ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "^0.7.11" }
+example-model                  = { path = "../model", features = ["wasm"], version = "^0.7.11" }
 wasm-bindgen                   = "0.2.84"
 wasm-bindgen-futures           = "0.4.42"
 wasm-logger                    = "0.2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-proto"
 description   = "Inter-node communication protocol for Ankurah"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-proto"
@@ -22,7 +22,7 @@ serde              = { version = "1.0.204", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 ulid               = { version = "1.1.3", features = ["serde"] }
 base64             = { version = "0.22" }
-ankql              = { path = "../ankql", version = "^0.7.10" }
+ankql              = { path = "../ankql", version = "^0.7.11" }
 sha2               = "0.10.8"
 postgres-types     = { version = "0.2", optional = true }
 postgres-protocol  = { version = "0.6", optional = true }

--- a/signals/Cargo.toml
+++ b/signals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-signals"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2024"
 description   = "Ankurah Signals"
 license       = "MIT OR Apache-2.0"

--- a/storage/common/Cargo.toml
+++ b/storage/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-common"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2024"
 description   = "Ankurah storage engine common libraries"
 license       = "MIT OR Apache-2.0"
@@ -9,12 +9,12 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankql         = { path = "../../ankql", version = "^0.7.10" }
-ankurah-core  = { path = "../../core", version = "^0.7.10" }
-ankurah-proto = { path = "../../proto", version = "^0.7.10" }
+ankql         = { path = "../../ankql", version = "^0.7.11" }
+ankurah-core  = { path = "../../core", version = "^0.7.11" }
+ankurah-proto = { path = "../../proto", version = "^0.7.11" }
 indexmap      = "2.0"
 serde         = { version = "1.0", features = ["derive"] }
 tracing       = { version = "0.1.40" }
 
 [dev-dependencies]
-ankurah-derive = { path = "../../derive", version = "^0.7.10" }
+ankurah-derive = { path = "../../derive", version = "^0.7.11" }

--- a/storage/indexeddb-wasm/Cargo.toml
+++ b/storage/indexeddb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-indexeddb-wasm"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Ankurah storage engine using IndexedDB in the browser"
 license       = "MIT OR Apache-2.0"
@@ -15,11 +15,11 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah-core           = { path = "../../core", version = "^0.7.10", features = ["wasm"] }
-ankurah-proto          = { path = "../../proto", version = "^0.7.10", features = ["wasm"] }
-ankql                  = { path = "../../ankql", version = "^0.7.10" }
-ankurah-derive         = { path = "../../derive", version = "^0.7.10", features = ["wasm"] }
-ankurah-storage-common = { path = "../common", version = "^0.7.10" }
+ankurah-core           = { path = "../../core", version = "^0.7.11", features = ["wasm"] }
+ankurah-proto          = { path = "../../proto", version = "^0.7.11", features = ["wasm"] }
+ankql                  = { path = "../../ankql", version = "^0.7.11" }
+ankurah-derive         = { path = "../../derive", version = "^0.7.11", features = ["wasm"] }
+ankurah-storage-common = { path = "../common", version = "^0.7.11" }
 serde                  = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen     = "0.6"
 tokio                  = { version = "1.39", features = ["sync"] }
@@ -80,7 +80,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 #[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 [dev-dependencies]
 wasm-bindgen-test  = "0.3"
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.10" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "^0.7.11" }
 tracing-subscriber = "0.3"
 
     [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/storage/postgres/Cargo.toml
+++ b/storage/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-postgres"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Ankurah storage engine using Postgres"
 license       = "MIT OR Apache-2.0"
@@ -19,9 +19,9 @@ anyhow         = "1.0"
 thiserror      = "2.0"
 tokio          = { version = "1.36", features = ["full"] }
 
-ankql         = { path = "../../ankql", version = "^0.7.10" }
-ankurah-core  = { path = "../../core", version = "^0.7.10" }
-ankurah-proto = { path = "../../proto", version = "^0.7.10", features = ["postgres"] }
+ankql         = { path = "../../ankql", version = "^0.7.11" }
+ankurah-core  = { path = "../../core", version = "^0.7.11" }
+ankurah-proto = { path = "../../proto", version = "^0.7.11", features = ["postgres"] }
 tracing       = "0.1"
 async-trait   = "0.1"
 futures-util  = "0.3"

--- a/storage/sled/Cargo.toml
+++ b/storage/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-sled"
-version       = "0.7.10"
+version       = "0.7.11"
 edition       = "2021"
 description   = "Ankurah storage engine using Sled"
 license       = "MIT OR Apache-2.0"
@@ -9,10 +9,10 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-proto          = { path = "../../proto", version = "^0.7.10" }
-ankurah-core           = { path = "../../core", version = "^0.7.10" }
-ankql                  = { path = "../../ankql", version = "^0.7.10" }
-ankurah-storage-common = { path = "../common", version = "^0.7.10" }
+ankurah-proto          = { path = "../../proto", version = "^0.7.11" }
+ankurah-core           = { path = "../../core", version = "^0.7.11" }
+ankql                  = { path = "../../ankql", version = "^0.7.11" }
+ankurah-storage-common = { path = "../common", version = "^0.7.11" }
 anyhow                 = "1.0"
 async-trait            = "0.1"
 sled                   = "0.34"
@@ -27,6 +27,6 @@ tracing                = "0.1"
 thiserror              = "2.0"
 
 [dev-dependencies]
-ankurah            = { path = "../../ankurah", version = "^0.7.10", features = ["derive"] }
+ankurah            = { path = "../../ankurah", version = "^0.7.11", features = ["derive"] }
 ctor               = "0.5"
 tracing-subscriber = "0.3"

--- a/tests-wasm/bindings/Cargo.toml
+++ b/tests-wasm/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-tests-wasm-bindings"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 
 [lib]

--- a/tests-wasm/bindings/src/lib.rs
+++ b/tests-wasm/bindings/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use ankurah::{policy::DEFAULT_CONTEXT, Context, Model, Node, PermissiveAgent, Ref};
+use ankurah::{policy::DEFAULT_CONTEXT, property::Json, Context, Model, Node, PermissiveAgent, Ref};
 use ankurah_storage_indexeddb_wasm::IndexedDBStorageEngine;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -36,6 +36,13 @@ pub struct TestMessage {
     #[active_type(LWW)]
     pub room: Ref<TestRoom>,
     pub text: String,
+}
+
+/// Entity with Json field - tests Json serialization to JS
+#[derive(Model, Debug, Serialize, Deserialize, Clone)]
+pub struct TestConfig {
+    pub name: String,
+    pub settings: Json,
 }
 
 // ============================================================================

--- a/tests-wasm/src/json-serialization.test.ts
+++ b/tests-wasm/src/json-serialization.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for Json property serialization to JavaScript.
+ *
+ * Verifies that Json fields are serialized as plain objects (POJOs),
+ * not Map instances.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import init, {
+    create_test_context,
+    cleanup_test_db,
+    TestConfig,
+    Context,
+} from "../bindings/pkg/ankurah_tests_wasm_bindings.js";
+
+describe("Json property serialization", () => {
+    let ctx: Context;
+    const dbName = `test_json_serialization_${Date.now()}`;
+
+    beforeAll(async () => {
+        await init();
+        ctx = await create_test_context(dbName);
+    });
+
+    afterAll(async () => {
+        await cleanup_test_db(dbName);
+    });
+
+    it("serializes Json fields as plain objects, not Maps", async () => {
+        // Create entity with nested Json data
+        const config = await TestConfig.create_one(ctx, {
+            name: "test-config",
+            settings: {
+                theme: "dark",
+                notifications: {
+                    email: true,
+                    push: false,
+                },
+                tags: ["important", "work"],
+            },
+        });
+
+        // Fetch it back
+        const fetched = await TestConfig.get(ctx, config.id);
+
+        // The settings should be a plain object, not a Map
+        expect(fetched.settings instanceof Map).toBe(false);
+        expect(typeof fetched.settings).toBe("object");
+
+        // Should be able to access properties directly (not via .get())
+        expect(fetched.settings.theme).toBe("dark");
+        expect(fetched.settings.notifications.email).toBe(true);
+        expect(fetched.settings.notifications.push).toBe(false);
+        expect(fetched.settings.tags).toEqual(["important", "work"]);
+    });
+
+    it("handles nested objects correctly", async () => {
+        const config = await TestConfig.create_one(ctx, {
+            name: "nested-test",
+            settings: {
+                level1: {
+                    level2: {
+                        level3: {
+                            value: "deep",
+                        },
+                    },
+                },
+            },
+        });
+
+        const fetched = await TestConfig.get(ctx, config.id);
+
+        // All nested levels should be plain objects
+        expect(fetched.settings.level1 instanceof Map).toBe(false);
+        expect(fetched.settings.level1.level2 instanceof Map).toBe(false);
+        expect(fetched.settings.level1.level2.level3 instanceof Map).toBe(false);
+        expect(fetched.settings.level1.level2.level3.value).toBe("deep");
+    });
+});
+

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-tests"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 publish = false
 
@@ -11,15 +11,15 @@ postgres = ["ankurah-storage-postgres", "tokio-postgres", "bb8", "bb8-postgres"]
 [dependencies]
 anyhow                          = "1.0"
 tracing                         = "0.1"
-ankql                           = { path = "../ankql", version = "^0.7.10" }
-ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "^0.7.10" }
-ankurah-storage-sled            = { path = "../storage/sled", version = "^0.7.10" }
-ankurah-connector-local-process = { path = "../connectors/local-process", version = "^0.7.10" }
-ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "^0.7.10" }
-ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "^0.7.10" }
-ankurah-storage-common          = { path = "../storage/common", version = "^0.7.10" }
+ankql                           = { path = "../ankql", version = "^0.7.11" }
+ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "^0.7.11" }
+ankurah-storage-sled            = { path = "../storage/sled", version = "^0.7.11" }
+ankurah-connector-local-process = { path = "../connectors/local-process", version = "^0.7.11" }
+ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "^0.7.11" }
+ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "^0.7.11" }
+ankurah-storage-common          = { path = "../storage/common", version = "^0.7.11" }
 tokio-postgres                  = { version = "0.7", optional = true }
-ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "^0.7.10" }
+ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "^0.7.11" }
 bb8                             = { version = "0.9", optional = true }
 bb8-postgres                    = { version = "0.9", optional = true }
 tokio                           = { version = "1.40", features = ["full"] }


### PR DESCRIPTION
Use serde_wasm_bindgen Serializer with `serialize_maps_as_objects(true)` to ensure Json property fields are serialized as plain JavaScript objects rather than ES2015 Map instances.

This fixes an issue where `Json` fields were being returned as JavaScript `Map` objects instead of plain objects, causing property access like `obj.field` to fail (needed `obj.get('field')` instead).

## Changes
- `core/src/property/value/json.rs`: Use explicit Serializer with `serialize_maps_as_objects(true)`
- Added WASM test coverage for Json field serialization

## Testing
- Added `tests-wasm/src/json-serialization.test.ts` that verifies:
  - Json fields are plain objects, not Maps
  - Nested objects are also plain objects
  - All property access works via dot notation