### PR TITLE
fix: return error response when check_request fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "ankql"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "ankurah-connector-local-process",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-connector-local-process"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-core"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "ankurah-derive",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-derive"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "maplit",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-model"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "getrandom 0.3.4",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-server"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "ankurah-doc-example-model",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-wasm-bindings"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "ankurah-doc-example-model",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-example-server"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "ankurah-storage-sled",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-proto"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "anyhow",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-signals"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "js-sys",
  "reactive_graph",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-common"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-indexeddb-wasm"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "ankurah",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-postgres"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-sled"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "ankurah",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankql",
  "ankurah",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests-wasm-bindings"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "ankurah-storage-indexeddb-wasm",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client-wasm"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-server"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "example-model"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "chrono",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "example-wasm-bindings"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "ankurah",
  "ankurah-signals",

--- a/RELEASES
+++ b/RELEASES
@@ -1,3 +1,4 @@
+0.7.13  Fix check_request error handling: errors now return proper error responses to clients instead of causing hangs
 0.7.12  Fix JSON path LiveQuery: predicate re-evaluation and new entity notifications now work correctly for queries like `context.task_id = 'xyz'`
 0.7.11  Fix Json WASM serialization to return plain objects (POJOs) instead of ES2015 Maps
 0.7.10  ChangeSet API: initial(), added(), appeared(), updated(), removed() with deprecation of ambiguous adds()/removes()/updates(); Model.query_nocache() for WASM

--- a/ankql/Cargo.toml
+++ b/ankql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankql"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Ankurah Query Language - Aspirational query language for Ankurah in the style of Open Cypher and GQL (ISO/IEC 39075:2024)"
 license       = "MIT OR Apache-2.0"

--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Observable, event-driven state management for native and web"
 license       = "MIT OR Apache-2.0"
@@ -27,11 +27,11 @@ derive = ["dep:ankurah-derive"]
 instrument = ["ankurah-core/instrument"]
 
 [dependencies]
-ankurah-core    = { path = "../core", version = "=0.7.12" }
-ankurah-proto   = { path = "../proto", version = "=0.7.12" }
-ankurah-derive  = { path = "../derive", version = "=0.7.12", optional = true }
-ankurah-signals = { path = "../signals", version = "=0.7.12" }
-ankql           = { path = "../ankql", version = "=0.7.12" }
+ankurah-core    = { path = "../core", version = "=0.7.13" }
+ankurah-proto   = { path = "../proto", version = "=0.7.13" }
+ankurah-derive  = { path = "../derive", version = "=0.7.13", optional = true }
+ankurah-signals = { path = "../signals", version = "=0.7.13" }
+ankql           = { path = "../ankql", version = "=0.7.13" }
 serde_json      = { version = "1.0" }
 serde           = { version = "1.0" }
 tracing         = { version = "0.1.40" }

--- a/connectors/local-process/Cargo.toml
+++ b/connectors/local-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-connector-local-process"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Ankurah connector for local processes"
 license       = "MIT OR Apache-2.0"
@@ -9,8 +9,8 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core  = { path = "../../core", version = "=0.7.12" }
-ankurah-proto = { path = "../../proto", version = "=0.7.12" }
+ankurah-core  = { path = "../../core", version = "=0.7.13" }
+ankurah-proto = { path = "../../proto", version = "=0.7.13" }
 
 tokio       = { version = "1.40", features = ["full"] }
 async-trait = "0.1"

--- a/connectors/websocket-client-wasm/Cargo.toml
+++ b/connectors/websocket-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client-wasm"
-version       = "0.7.12"
+version       = "0.7.13"
 authors       = ["Daniel Norman <daniel@danielnorman.net>"]
 edition       = "2021"
 description   = "Ankurah WebSocket Client - A WebSocket client for Ankurah"
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.12" }
-ankurah-core       = { path = "../../core", version = "=0.7.12" }
-ankurah-proto      = { path = "../../proto", version = "=0.7.12", features = ["wasm"] }
-ankurah-derive     = { path = "../../derive", version = "=0.7.12" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.13" }
+ankurah-core       = { path = "../../core", version = "=0.7.13" }
+ankurah-proto      = { path = "../../proto", version = "=0.7.13", features = ["wasm"] }
+ankurah-derive     = { path = "../../derive", version = "=0.7.13" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 

--- a/connectors/websocket-client/Cargo.toml
+++ b/connectors/websocket-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Ankurah WebSocket Client - Native WebSocket client for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -9,9 +9,9 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core    = { path = "../../core", version = "=0.7.12" }
-ankurah-proto   = { path = "../../proto", version = "=0.7.12" }
-ankurah-signals = { path = "../../signals", version = "=0.7.12" }
+ankurah-core    = { path = "../../core", version = "=0.7.13" }
+ankurah-proto   = { path = "../../proto", version = "=0.7.13" }
+ankurah-signals = { path = "../../signals", version = "=0.7.13" }
 
 # WebSocket implementation
 tokio-tungstenite = { version = "0.27", features = ["native-tls"] }
@@ -33,6 +33,6 @@ url       = "2.0"
 strum     = { version = "0.27", features = ["derive"] }
 
 [dev-dependencies]
-ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.7.12" }
-ankurah-websocket-server = { path = "../websocket-server", version = "=0.7.12" }
-ankurah                  = { path = "../../ankurah", version = "=0.7.12", features = ["derive"] }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.7.13" }
+ankurah-websocket-server = { path = "../websocket-server", version = "=0.7.13" }
+ankurah                  = { path = "../../ankurah", version = "=0.7.13", features = ["derive"] }

--- a/connectors/websocket-server/Cargo.toml
+++ b/connectors/websocket-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-server"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Ankurah WebSocket Server - A WebSocket server for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ instrument = []
 [dependencies]
 
 # Base dependencies
-ankurah-proto          = { path = "../../proto", version = "=0.7.12" }
-ankurah-core           = { path = "../../core", version = "=0.7.12" }
+ankurah-proto          = { path = "../../proto", version = "=0.7.13" }
+ankurah-core           = { path = "../../core", version = "=0.7.13" }
 anyhow                 = "1.0"
 bincode                = "1.3"
 serde                  = { version = "1.0.203", features = ["derive", "serde_derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-core"
 description   = "Core state management functionality for Ankurah"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-core"
@@ -24,10 +24,10 @@ instrument = []
 
 [dependencies]
 # Internal dependencies
-ankurah-derive  = { path = "../derive", optional = true, version = "=0.7.12" }
-ankql           = { path = "../ankql", version = "=0.7.12" }
-ankurah-proto   = { path = "../proto", version = "=0.7.12" }
-ankurah-signals = { path = "../signals", version = "=0.7.12" }
+ankurah-derive  = { path = "../derive", optional = true, version = "=0.7.13" }
+ankql           = { path = "../ankql", version = "=0.7.13" }
+ankurah-proto   = { path = "../proto", version = "=0.7.13" }
+ankurah-signals = { path = "../signals", version = "=0.7.13" }
 
 rand                 = "0.8"
 anyhow               = "1.0"
@@ -58,4 +58,4 @@ base64               = { version = "0.22" }
 
 [dev-dependencies]
 maplit         = "1.0"
-ankurah-derive = { path = "../derive", version = "=0.7.12" }
+ankurah-derive = { path = "../derive", version = "=0.7.13" }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-derive"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Ankurah Derive - Derive macros for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ syn = { version = "2.0", default-features = false, features = [
     "extra-traits",
 ] }
 serde_derive_internals = "0.29"
-ankql = { path = "../ankql", version = "=0.7.12" }
+ankql = { path = "../ankql", version = "=0.7.13" }
 regex = "1.0"
 ron = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/example/model/Cargo.toml
+++ b/docs/example/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-model"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 
 [features]

--- a/docs/example/server/Cargo.toml
+++ b/docs/example/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-server"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 
 [dependencies]

--- a/docs/example/wasm-bindings/Cargo.toml
+++ b/docs/example/wasm-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-wasm-bindings"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 
 [lib]

--- a/examples/model/Cargo.toml
+++ b/examples/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "example-model"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 publish = false
 
@@ -9,7 +9,7 @@ default = []
 wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/react"]
 
 [dependencies]
-ankurah      = { path = "../../ankurah", features = ["derive"], version = "=0.7.12" }
+ankurah      = { path = "../../ankurah", features = ["derive"], version = "=0.7.13" }
 serde        = { version = "1.0", features = ["derive"] }
 serde_json   = "1.0"
 wasm-bindgen = { version = "0.2", optional = true }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name    = "ankurah-example-server"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 publish = false
 
 [dependencies]
-ankurah                  = { path = "../../ankurah", version = "=0.7.12" }
-ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "=0.7.12" }
-ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.7.12" }
+ankurah                  = { path = "../../ankurah", version = "=0.7.13" }
+ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "=0.7.13" }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.7.13" }
 example-model            = { path = "../model" }
 tracing                  = "0.1"
 tracing-subscriber       = "0.3"

--- a/examples/wasm-bindings/Cargo.toml
+++ b/examples/wasm-bindings/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name    = "example-wasm-bindings"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.12" }
-ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "=0.7.12" }
-ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "=0.7.12" }
-ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "=0.7.12" }
-example-model                  = { path = "../model", features = ["wasm"], version = "=0.7.12" }
+ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.13" }
+ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "=0.7.13" }
+ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "=0.7.13" }
+ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "=0.7.13" }
+example-model                  = { path = "../model", features = ["wasm"], version = "=0.7.13" }
 wasm-bindgen                   = "0.2.84"
 wasm-bindgen-futures           = "0.4.42"
 wasm-logger                    = "0.2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-proto"
 description   = "Inter-node communication protocol for Ankurah"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-proto"
@@ -22,7 +22,7 @@ serde              = { version = "1.0.204", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 ulid               = { version = "1.1.3", features = ["serde"] }
 base64             = { version = "0.22" }
-ankql              = { path = "../ankql", version = "=0.7.12" }
+ankql              = { path = "../ankql", version = "=0.7.13" }
 sha2               = "0.10.8"
 postgres-types     = { version = "0.2", optional = true }
 postgres-protocol  = { version = "0.6", optional = true }

--- a/signals/Cargo.toml
+++ b/signals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-signals"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2024"
 description   = "Ankurah Signals"
 license       = "MIT OR Apache-2.0"

--- a/storage/common/Cargo.toml
+++ b/storage/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-common"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2024"
 description   = "Ankurah storage engine common libraries"
 license       = "MIT OR Apache-2.0"
@@ -9,12 +9,12 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankql         = { path = "../../ankql", version = "=0.7.12" }
-ankurah-core  = { path = "../../core", version = "=0.7.12" }
-ankurah-proto = { path = "../../proto", version = "=0.7.12" }
+ankql         = { path = "../../ankql", version = "=0.7.13" }
+ankurah-core  = { path = "../../core", version = "=0.7.13" }
+ankurah-proto = { path = "../../proto", version = "=0.7.13" }
 indexmap      = "2.0"
 serde         = { version = "1.0", features = ["derive"] }
 tracing       = { version = "0.1.40" }
 
 [dev-dependencies]
-ankurah-derive = { path = "../../derive", version = "=0.7.12" }
+ankurah-derive = { path = "../../derive", version = "=0.7.13" }

--- a/storage/indexeddb-wasm/Cargo.toml
+++ b/storage/indexeddb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-indexeddb-wasm"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Ankurah storage engine using IndexedDB in the browser"
 license       = "MIT OR Apache-2.0"
@@ -15,11 +15,11 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah-core           = { path = "../../core", version = "=0.7.12", features = ["wasm"] }
-ankurah-proto          = { path = "../../proto", version = "=0.7.12", features = ["wasm"] }
-ankql                  = { path = "../../ankql", version = "=0.7.12" }
-ankurah-derive         = { path = "../../derive", version = "=0.7.12", features = ["wasm"] }
-ankurah-storage-common = { path = "../common", version = "=0.7.12" }
+ankurah-core           = { path = "../../core", version = "=0.7.13", features = ["wasm"] }
+ankurah-proto          = { path = "../../proto", version = "=0.7.13", features = ["wasm"] }
+ankql                  = { path = "../../ankql", version = "=0.7.13" }
+ankurah-derive         = { path = "../../derive", version = "=0.7.13", features = ["wasm"] }
+ankurah-storage-common = { path = "../common", version = "=0.7.13" }
 serde                  = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen     = "0.6"
 tokio                  = { version = "1.39", features = ["sync"] }
@@ -80,7 +80,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 #[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 [dev-dependencies]
 wasm-bindgen-test  = "0.3"
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.12" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.13" }
 tracing-subscriber = "0.3"
 
     [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/storage/postgres/Cargo.toml
+++ b/storage/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-postgres"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Ankurah storage engine using Postgres"
 license       = "MIT OR Apache-2.0"
@@ -19,9 +19,9 @@ anyhow         = "1.0"
 thiserror      = "2.0"
 tokio          = { version = "1.36", features = ["full"] }
 
-ankql         = { path = "../../ankql", version = "=0.7.12" }
-ankurah-core  = { path = "../../core", version = "=0.7.12" }
-ankurah-proto = { path = "../../proto", version = "=0.7.12", features = ["postgres"] }
+ankql         = { path = "../../ankql", version = "=0.7.13" }
+ankurah-core  = { path = "../../core", version = "=0.7.13" }
+ankurah-proto = { path = "../../proto", version = "=0.7.13", features = ["postgres"] }
 tracing       = "0.1"
 async-trait   = "0.1"
 futures-util  = "0.3"

--- a/storage/sled/Cargo.toml
+++ b/storage/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-sled"
-version       = "0.7.12"
+version       = "0.7.13"
 edition       = "2021"
 description   = "Ankurah storage engine using Sled"
 license       = "MIT OR Apache-2.0"
@@ -9,10 +9,10 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-proto          = { path = "../../proto", version = "=0.7.12" }
-ankurah-core           = { path = "../../core", version = "=0.7.12" }
-ankql                  = { path = "../../ankql", version = "=0.7.12" }
-ankurah-storage-common = { path = "../common", version = "=0.7.12" }
+ankurah-proto          = { path = "../../proto", version = "=0.7.13" }
+ankurah-core           = { path = "../../core", version = "=0.7.13" }
+ankql                  = { path = "../../ankql", version = "=0.7.13" }
+ankurah-storage-common = { path = "../common", version = "=0.7.13" }
 anyhow                 = "1.0"
 async-trait            = "0.1"
 sled                   = "0.34"
@@ -27,6 +27,6 @@ tracing                = "0.1"
 thiserror              = "2.0"
 
 [dev-dependencies]
-ankurah            = { path = "../../ankurah", version = "=0.7.12", features = ["derive"] }
+ankurah            = { path = "../../ankurah", version = "=0.7.13", features = ["derive"] }
 ctor               = "0.5"
 tracing-subscriber = "0.3"

--- a/tests-wasm/bindings/Cargo.toml
+++ b/tests-wasm/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-tests-wasm-bindings"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 
 [lib]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-tests"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 publish = false
 
@@ -11,15 +11,15 @@ postgres = ["ankurah-storage-postgres", "tokio-postgres", "bb8", "bb8-postgres"]
 [dependencies]
 anyhow                          = "1.0"
 tracing                         = "0.1"
-ankql                           = { path = "../ankql", version = "=0.7.12" }
-ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "=0.7.12" }
-ankurah-storage-sled            = { path = "../storage/sled", version = "=0.7.12" }
-ankurah-connector-local-process = { path = "../connectors/local-process", version = "=0.7.12" }
-ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "=0.7.12" }
-ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "=0.7.12" }
-ankurah-storage-common          = { path = "../storage/common", version = "=0.7.12" }
+ankql                           = { path = "../ankql", version = "=0.7.13" }
+ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "=0.7.13" }
+ankurah-storage-sled            = { path = "../storage/sled", version = "=0.7.13" }
+ankurah-connector-local-process = { path = "../connectors/local-process", version = "=0.7.13" }
+ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "=0.7.13" }
+ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "=0.7.13" }
+ankurah-storage-common          = { path = "../storage/common", version = "=0.7.13" }
 tokio-postgres                  = { version = "0.7", optional = true }
-ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "=0.7.12" }
+ankurah-storage-postgres        = { path = "../storage/postgres", optional = true, version = "=0.7.13" }
 bb8                             = { version = "0.9", optional = true }
 bb8-postgres                    = { version = "0.9", optional = true }
 tokio                           = { version = "1.40", features = ["full"] }

--- a/tests/tests/check_request_error.rs
+++ b/tests/tests/check_request_error.rs
@@ -1,0 +1,181 @@
+//! Tests that check_request errors are properly propagated back to the client.
+//!
+//! This test ensures that when the server's PolicyAgent rejects a request via check_request,
+//! the client receives an error response rather than hanging indefinitely.
+
+mod common;
+
+use ankql::ast::Predicate;
+use ankurah::core::node::ContextData;
+use ankurah::core::util::Iterable;
+use ankurah::error::ValidationError;
+use ankurah::policy::{AccessDenied, PolicyAgent, DEFAULT_CONTEXT};
+use ankurah::proto::{self, AuthData};
+use ankurah::storage::StorageEngine;
+use ankurah::{Node, PermissiveAgent};
+use ankurah_connector_local_process::LocalProcessConnection;
+use ankurah_storage_sled::SledStorageEngine;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use common::Album;
+
+/// A PolicyAgent that rejects all incoming requests at the check_request stage.
+/// Used to test that check_request errors are properly propagated to clients.
+#[derive(Clone, Default)]
+pub struct RejectingAgent;
+
+/// Marker type for RejectingAgent's context data
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct RejectingContext;
+
+impl ContextData for RejectingContext {}
+
+#[async_trait]
+impl PolicyAgent for RejectingAgent {
+    type ContextData = RejectingContext;
+
+    fn sign_request<SE: StorageEngine, C>(
+        &self,
+        _node: &ankurah::core::node::NodeInner<SE, Self>,
+        _cdata: &C,
+        _request: &proto::NodeRequest,
+    ) -> std::result::Result<Vec<AuthData>, AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
+        Ok(vec![AuthData(vec![])])
+    }
+
+    async fn check_request<SE: StorageEngine, A>(
+        &self,
+        _node: &Node<SE, Self>,
+        _auth: &A,
+        _request: &proto::NodeRequest,
+    ) -> std::result::Result<Vec<Self::ContextData>, ValidationError>
+    where
+        A: Iterable<AuthData> + Send + Sync,
+    {
+        // Always reject - this simulates invalid credentials or authorization failure
+        Err(ValidationError::ValidationFailed("Request rejected by RejectingAgent".to_string()))
+    }
+
+    fn check_event<SE: StorageEngine>(
+        &self,
+        _node: &Node<SE, Self>,
+        _cdata: &Self::ContextData,
+        _entity_before: &ankurah::entity::Entity,
+        _entity_after: &ankurah::entity::Entity,
+        _event: &proto::Event,
+    ) -> std::result::Result<Option<proto::Attestation>, AccessDenied> {
+        Ok(None)
+    }
+
+    fn validate_received_event<SE: StorageEngine>(
+        &self,
+        _node: &Node<SE, Self>,
+        _received_from_node: &proto::EntityId,
+        _event: &proto::Attested<proto::Event>,
+    ) -> std::result::Result<(), AccessDenied> {
+        Ok(())
+    }
+
+    fn attest_state<SE: StorageEngine>(&self, _node: &Node<SE, Self>, _state: &proto::EntityState) -> Option<proto::Attestation> { None }
+
+    fn validate_received_state<SE: StorageEngine>(
+        &self,
+        _node: &Node<SE, Self>,
+        _received_from_node: &proto::EntityId,
+        _state: &proto::Attested<proto::EntityState>,
+    ) -> std::result::Result<(), AccessDenied> {
+        Ok(())
+    }
+
+    fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId) -> std::result::Result<(), AccessDenied>
+    where C: Iterable<Self::ContextData> {
+        Ok(())
+    }
+
+    fn filter_predicate<C>(
+        &self,
+        _data: &C,
+        _collection: &proto::CollectionId,
+        predicate: Predicate,
+    ) -> std::result::Result<Predicate, AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
+        Ok(predicate)
+    }
+
+    fn check_read<C>(
+        &self,
+        _data: &C,
+        _id: &proto::EntityId,
+        _collection: &proto::CollectionId,
+        _state: &proto::State,
+    ) -> std::result::Result<(), AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
+        Ok(())
+    }
+
+    fn check_read_event<C>(&self, _data: &C, _event: &proto::Attested<proto::Event>) -> std::result::Result<(), AccessDenied>
+    where C: Iterable<Self::ContextData> {
+        Ok(())
+    }
+
+    fn check_write(
+        &self,
+        _context: &Self::ContextData,
+        _entity: &ankurah::entity::Entity,
+        _event: Option<&proto::Event>,
+    ) -> std::result::Result<(), AccessDenied> {
+        Ok(())
+    }
+
+    fn validate_causal_assertion<SE: StorageEngine>(
+        &self,
+        _node: &Node<SE, Self>,
+        _peer_id: &proto::EntityId,
+        _head_relation: &proto::CausalAssertion,
+    ) -> std::result::Result<(), AccessDenied> {
+        Ok(())
+    }
+}
+
+/// Test that when the server's check_request fails, the client receives an error
+/// rather than hanging indefinitely waiting for a response.
+#[tokio::test]
+async fn check_request_error_returns_to_client() -> Result<()> {
+    // Server uses RejectingAgent - will reject all incoming requests
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test().unwrap()), RejectingAgent);
+    server.system.create().await?;
+
+    // Client uses PermissiveAgent - allows local operations
+    let client = Node::new(Arc::new(SledStorageEngine::new_test().unwrap()), PermissiveAgent::new());
+
+    // Connect client to server
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let client_ctx = client.context(DEFAULT_CONTEXT)?;
+
+    // Try to create an entity on the client - this should fail when relaying to server
+    // because the server's check_request will reject it
+    let trx = client_ctx.begin();
+    trx.create(&Album { name: "Test Album".into(), year: "2024".into() }).await?;
+
+    // The commit should return an error (not hang!) because the server rejected the request
+    let result = trx.commit().await;
+
+    assert!(result.is_err(), "Commit should fail when server rejects the request");
+
+    // Verify the error message contains our rejection reason
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("rejected") || err_msg.contains("Request rejected"), "Error should indicate rejection, got: {}", err_msg);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

When a `PolicyAgent::check_request` returned an error, the client would hang indefinitely because the error was propagated with `?` instead of being converted to an error response.

This PR:
- Restructures the request handling to convert `check_request` errors into `NodeResponseBody::Error` responses
- Adds a test that verifies clients receive errors when the server rejects their requests

## Details

Before this fix:
```rust
let cdata = self.policy_agent.check_request(self, &auth, &request).await?;  // Error propagates OUT

// Response sending code only runs if check_request succeeds:
let body = match self.handle_request(&cdata, request).await { ... };
sender.send_message(...);  // Never reached on check_request error
```

After this fix:
```rust
let body = match self.policy_agent.check_request(self, &auth, &request).await {
    Ok(cdata) => match self.handle_request(&cdata, request).await {
        Ok(result) => result,
        Err(e) => proto::NodeResponseBody::Error(e.to_string()),
    },
    Err(e) => proto::NodeResponseBody::Error(e.to_string()),  // Now properly converted
};
sender.send_message(...);  // Always sends a response
```

## Test plan

- [x] Added `check_request_error_returns_to_client` test that creates a rejecting server and verifies the client receives an error (not a hang)
- [x] Existing ankurah tests pass