### PR TITLE
Add Option<Ref<T>> support for UniFFI bindings

### DIFF
--- a/derive/src/model/description.rs
+++ b/derive/src/model/description.rs
@@ -221,7 +221,7 @@ impl ModelDescription {
     }
 
     /// Extract the inner type from Ref<T>, returning the T as a syn::Type
-    #[cfg(feature = "wasm")]
+    #[cfg(any(feature = "wasm", feature = "uniffi"))]
     fn extract_ref_inner_type(ty: &Type) -> Option<Type> {
         if let Type::Path(type_path) = ty {
             let segment = type_path.path.segments.last()?;
@@ -237,7 +237,7 @@ impl ModelDescription {
     }
 
     /// Extract the inner model type from Option<Ref<T>>, returning T as a syn::Type
-    #[cfg(feature = "wasm")]
+    #[cfg(any(feature = "wasm", feature = "uniffi"))]
     fn extract_option_ref_inner_type(ty: &Type) -> Option<Type> {
         if let Type::Path(type_path) = ty {
             let segment = type_path.path.segments.last()?;
@@ -267,23 +267,22 @@ impl ModelDescription {
                 let uniffi_method_name = format_ident!("uniffi_{}", field_name);
                 let field_name_str = field_name.to_string();
                 let projected_type = &field.ty;
-                let type_str = quote!(#projected_type).to_string();
 
-                // Check if it's a Ref<T> type
-                if type_str.contains("Ref <") || type_str.starts_with("Ref<") {
-                    // Ref<T> -> return base64 String
-                    quote! {
-                        #[uniffi::method(name = #field_name_str)]
-                        pub fn #uniffi_method_name(&self) -> Result<String, ::ankurah::property::PropertyError> {
-                            self.#field_name().map(|r| r.id().to_base64())
-                        }
-                    }
-                } else if type_str.contains("Option < Ref") || type_str.contains("Option<Ref") {
+                // Check if it's Option<Ref<T>> using AST matching (must check before Ref<T>)
+                if Self::extract_option_ref_inner_type(&field.ty).is_some() {
                     // Option<Ref<T>> -> return Option<String>
                     quote! {
                         #[uniffi::method(name = #field_name_str)]
                         pub fn #uniffi_method_name(&self) -> Result<Option<String>, ::ankurah::property::PropertyError> {
                             self.#field_name().map(|opt| opt.map(|r| r.id().to_base64()))
+                        }
+                    }
+                } else if Self::extract_ref_inner_type(&field.ty).is_some() {
+                    // Ref<T> -> return base64 String
+                    quote! {
+                        #[uniffi::method(name = #field_name_str)]
+                        pub fn #uniffi_method_name(&self) -> Result<String, ::ankurah::property::PropertyError> {
+                            self.#field_name().map(|r| r.id().to_base64())
                         }
                     }
                 } else {


### PR DESCRIPTION
## Summary

Adds full support for `Option<Ref<T>>` types in UniFFI-generated bindings. Previously, only required `Ref<T>` fields were handled, but many data models need optional foreign key relationships.

## Changes

### derive/src/model/backend.rs
- Handle setter methods with `Option<Ref<T>>` parameter - converts `Option<String>` (base64) to `Option<Ref<T>>`
- Handle return types for methods returning `Option<Ref<T>>` or `Result<Option<Ref<T>>, E>`
- Check `Option<Ref<T>>` before `Ref<T>` to handle the more specific case first

### derive/src/model/description.rs
- Enable `extract_ref_inner_type` and `extract_option_ref_inner_type` helpers for both wasm and uniffi features
- Use AST matching instead of string matching for more reliable Ref type detection
- Fix precedence: check `Option<Ref<T>>` before `Ref<T>`

### derive/src/model/uniffi.rs
- Add `is_option_ref_type` helper function for detecting `Option<Ref<T>>` types
- Avoid generating duplicate wrappers for the same type within a model
- Handle `Option<Ref<T>>` fields in input records - converts `Option<String>` to `Option<Ref<T>>`

## Use Case

This enables models with optional relationships like:

```rust
#[derive(Model)]
pub struct Property {
    pub customer: Ref<Customer>,              // Required - every property has a customer
    pub billing_override: Option<Ref<BillingAccount>>,  // Optional - may inherit from customer
}
```

At the UniFFI boundary:
- `Ref<T>` → `String` (base64 EntityId)
- `Option<Ref<T>>` → `Option<String>` (optional base64 EntityId)

## Testing

Tested with React Native app using models with both required and optional Ref fields.