### PR TITLE
WASM: accept JsValue in create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "ankql"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "ankurah-connector-local-process",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-connector-local-process"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-core"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "ankurah-derive",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-derive"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "maplit",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-model"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "getrandom 0.3.4",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-server"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "ankurah-doc-example-model",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-wasm-bindings"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "ankurah-doc-example-model",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-example-server"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "ankurah-storage-sled",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-proto"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "anyhow",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-signals"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "js-sys",
  "reactive_graph",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-common"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-indexeddb-wasm"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "ankurah",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-postgres"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "ankurah",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-sled"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "ankurah",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-sqlite"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "ankurah",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankql",
  "ankurah",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests-wasm-bindings"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "ankurah-storage-indexeddb-wasm",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client-wasm"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-server"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "example-model"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "chrono",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "example-wasm-bindings"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "ankurah",
  "ankurah-signals",

--- a/RELEASES
+++ b/RELEASES
@@ -1,3 +1,4 @@
+0.7.17  WASM create/create_one accept JsValue with catchable deserialization errors
 0.7.16  SQLite Storage Engine; move postgres tests to storage/postgres/tests/; use default-members for wasm crates in workspace
 0.7.15  UniFFI support for React Native: derive macro generates wrapper types mirroring wasm-bindgen API; multithread observer stack; QueryValue for FFI-safe query parameters
 0.7.14  Fix DESC inequality bounds for composite indexes; fix TopKStream heap comparison; unify Sled and IndexedDB on Stream-based combinators for partition-aware sorting

--- a/ankql/Cargo.toml
+++ b/ankql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankql"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah Query Language - Aspirational query language for Ankurah in the style of Open Cypher and GQL (ISO/IEC 39075:2024)"
 license       = "MIT OR Apache-2.0"

--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Observable, event-driven state management for native and web"
 license       = "MIT OR Apache-2.0"
@@ -36,11 +36,11 @@ derive = ["dep:ankurah-derive"]
 instrument = ["ankurah-core/instrument"]
 
 [dependencies]
-ankurah-core    = { path = "../core", version = "=0.7.16" }
-ankurah-proto   = { path = "../proto", version = "=0.7.16" }
-ankurah-derive  = { path = "../derive", version = "=0.7.16", optional = true }
-ankurah-signals = { path = "../signals", version = "=0.7.16" }
-ankql           = { path = "../ankql", version = "=0.7.16" }
+ankurah-core    = { path = "../core", version = "=0.7.17" }
+ankurah-proto   = { path = "../proto", version = "=0.7.17" }
+ankurah-derive  = { path = "../derive", version = "=0.7.17", optional = true }
+ankurah-signals = { path = "../signals", version = "=0.7.17" }
+ankql           = { path = "../ankql", version = "=0.7.17" }
 serde_json      = { version = "1.0" }
 serde           = { version = "1.0" }
 tracing         = { version = "0.1.40" }

--- a/connectors/local-process/Cargo.toml
+++ b/connectors/local-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-connector-local-process"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah connector for local processes"
 license       = "MIT OR Apache-2.0"
@@ -9,8 +9,8 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core  = { path = "../../core", version = "=0.7.16" }
-ankurah-proto = { path = "../../proto", version = "=0.7.16" }
+ankurah-core  = { path = "../../core", version = "=0.7.17" }
+ankurah-proto = { path = "../../proto", version = "=0.7.17" }
 
 tokio       = { version = "1.40", features = ["full"] }
 async-trait = "0.1"

--- a/connectors/websocket-client-wasm/Cargo.toml
+++ b/connectors/websocket-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client-wasm"
-version       = "0.7.16"
+version       = "0.7.17"
 authors       = ["Daniel Norman <daniel@danielnorman.net>"]
 edition       = "2021"
 description   = "Ankurah WebSocket Client - A WebSocket client for Ankurah"
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.16" }
-ankurah-core       = { path = "../../core", version = "=0.7.16" }
-ankurah-proto      = { path = "../../proto", version = "=0.7.16", features = ["wasm"] }
-ankurah-derive     = { path = "../../derive", version = "=0.7.16" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.17" }
+ankurah-core       = { path = "../../core", version = "=0.7.17" }
+ankurah-proto      = { path = "../../proto", version = "=0.7.17", features = ["wasm"] }
+ankurah-derive     = { path = "../../derive", version = "=0.7.17" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 

--- a/connectors/websocket-client/Cargo.toml
+++ b/connectors/websocket-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah WebSocket Client - Native WebSocket client for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -9,9 +9,9 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core    = { path = "../../core", version = "=0.7.16" }
-ankurah-proto   = { path = "../../proto", version = "=0.7.16" }
-ankurah-signals = { path = "../../signals", version = "=0.7.16" }
+ankurah-core    = { path = "../../core", version = "=0.7.17" }
+ankurah-proto   = { path = "../../proto", version = "=0.7.17" }
+ankurah-signals = { path = "../../signals", version = "=0.7.17" }
 
 # WebSocket implementation
 tokio-tungstenite = { version = "0.27", features = ["native-tls"] }
@@ -33,6 +33,6 @@ url       = "2.0"
 strum     = { version = "0.27", features = ["derive"] }
 
 [dev-dependencies]
-ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.7.16" }
-ankurah-websocket-server = { path = "../websocket-server", version = "=0.7.16" }
-ankurah                  = { path = "../../ankurah", version = "=0.7.16", features = ["derive"] }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.7.17" }
+ankurah-websocket-server = { path = "../websocket-server", version = "=0.7.17" }
+ankurah                  = { path = "../../ankurah", version = "=0.7.17", features = ["derive"] }

--- a/connectors/websocket-server/Cargo.toml
+++ b/connectors/websocket-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-server"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah WebSocket Server - A WebSocket server for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ instrument = []
 [dependencies]
 
 # Base dependencies
-ankurah-proto          = { path = "../../proto", version = "=0.7.16" }
-ankurah-core           = { path = "../../core", version = "=0.7.16" }
+ankurah-proto          = { path = "../../proto", version = "=0.7.17" }
+ankurah-core           = { path = "../../core", version = "=0.7.17" }
 anyhow                 = "1.0"
 bincode                = "1.3"
 serde                  = { version = "1.0.203", features = ["derive", "serde_derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-core"
 description   = "Core state management functionality for Ankurah"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-core"
@@ -25,10 +25,10 @@ instrument = []
 
 [dependencies]
 # Internal dependencies
-ankurah-derive  = { path = "../derive", optional = true, version = "=0.7.16" }
-ankql           = { path = "../ankql", version = "=0.7.16" }
-ankurah-proto   = { path = "../proto", version = "=0.7.16" }
-ankurah-signals = { path = "../signals", version = "=0.7.16" }
+ankurah-derive  = { path = "../derive", optional = true, version = "=0.7.17" }
+ankql           = { path = "../ankql", version = "=0.7.17" }
+ankurah-proto   = { path = "../proto", version = "=0.7.17" }
+ankurah-signals = { path = "../signals", version = "=0.7.17" }
 
 rand                 = "0.8"
 anyhow               = "1.0"
@@ -60,4 +60,4 @@ uniffi               = { version = "0.29", optional = true }
 
 [dev-dependencies]
 maplit         = "1.0"
-ankurah-derive = { path = "../derive", version = "=0.7.16" }
+ankurah-derive = { path = "../derive", version = "=0.7.17" }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-derive"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah Derive - Derive macros for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ syn = { version = "2.0", default-features = false, features = [
     "extra-traits",
 ] }
 serde_derive_internals = "0.29"
-ankql = { path = "../ankql", version = "=0.7.16" }
+ankql = { path = "../ankql", version = "=0.7.17" }
 regex = "1.0"
 ron = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/derive/src/model/wasm.rs
+++ b/derive/src/model/wasm.rs
@@ -73,8 +73,7 @@ pub fn wasm_impl(input: &syn::DeriveInput, model: &crate::model::description::Mo
     let tsify_impl = expand_ts_model_type(input, pojo_interface.to_string()).unwrap_or_else(syn::Error::into_compile_error);
 
     // Generate WASM wrapper code
-    let namespace_class =
-        wasm_model_namespace(&namespace_struct, model, &model.view_name(), &model.livequery_name(), &pojo_interface);
+    let namespace_class = wasm_model_namespace(&namespace_struct, model, &model.view_name(), &model.livequery_name(), &pojo_interface);
     let resultset_wrapper = wasm_resultset_wrapper(&model.resultset_name(), &model.view_name());
     let changeset_wrapper = wasm_changeset_wrapper(&model.changeset_name(), &model.view_name(), &model.resultset_name());
     let livequery_wrapper =
@@ -380,8 +379,7 @@ pub fn wasm_model_namespace(
     pojo_interface: &Ident,
 ) -> TokenStream {
     let name = model.name();
-    let ref_field_names: Vec<String> =
-        model.ref_fields().iter().map(|(field, _)| field.ident.as_ref().unwrap().to_string()).collect();
+    let ref_field_names: Vec<String> = model.ref_fields().iter().map(|(field, _)| field.ident.as_ref().unwrap().to_string()).collect();
     let preprocess_calls: Vec<TokenStream> = ref_field_names
         .iter()
         .map(|field_name| {

--- a/docs/example/model/Cargo.toml
+++ b/docs/example/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-model"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 
 [features]

--- a/docs/example/server/Cargo.toml
+++ b/docs/example/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-server"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 
 [dependencies]

--- a/docs/example/wasm-bindings/Cargo.toml
+++ b/docs/example/wasm-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-wasm-bindings"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 
 [lib]

--- a/examples/model/Cargo.toml
+++ b/examples/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "example-model"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 publish = false
 
@@ -9,7 +9,7 @@ default = []
 wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/react"]
 
 [dependencies]
-ankurah      = { path = "../../ankurah", features = ["derive"], version = "=0.7.16" }
+ankurah      = { path = "../../ankurah", features = ["derive"], version = "=0.7.17" }
 serde        = { version = "1.0", features = ["derive"] }
 serde_json   = "1.0"
 wasm-bindgen = { version = "0.2", optional = true }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name    = "ankurah-example-server"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 publish = false
 
 [dependencies]
-ankurah                  = { path = "../../ankurah", version = "=0.7.16" }
-ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "=0.7.16" }
-ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.7.16" }
+ankurah                  = { path = "../../ankurah", version = "=0.7.17" }
+ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "=0.7.17" }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.7.17" }
 example-model            = { path = "../model" }
 tracing                  = "0.1"
 tracing-subscriber       = "0.3"

--- a/examples/wasm-bindings/Cargo.toml
+++ b/examples/wasm-bindings/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name    = "example-wasm-bindings"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.16" }
-ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "=0.7.16" }
-ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "=0.7.16" }
-ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "=0.7.16" }
-example-model                  = { path = "../model", features = ["wasm"], version = "=0.7.16" }
+ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.17" }
+ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "=0.7.17" }
+ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "=0.7.17" }
+ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "=0.7.17" }
+example-model                  = { path = "../model", features = ["wasm"], version = "=0.7.17" }
 wasm-bindgen                   = "0.2.84"
 wasm-bindgen-futures           = "0.4.42"
 wasm-logger                    = "0.2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-proto"
 description   = "Inter-node communication protocol for Ankurah"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-proto"
@@ -23,7 +23,7 @@ serde              = { version = "1.0.204", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 ulid               = { version = "1.1.3", features = ["serde"] }
 base64             = { version = "0.22" }
-ankql              = { path = "../ankql", version = "=0.7.16" }
+ankql              = { path = "../ankql", version = "=0.7.17" }
 sha2               = "0.10.8"
 postgres-types     = { version = "0.2", optional = true }
 postgres-protocol  = { version = "0.6", optional = true }

--- a/signals/Cargo.toml
+++ b/signals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-signals"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2024"
 description   = "Ankurah Signals"
 license       = "MIT OR Apache-2.0"

--- a/storage/common/Cargo.toml
+++ b/storage/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-common"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2024"
 description   = "Ankurah storage engine common libraries"
 license       = "MIT OR Apache-2.0"
@@ -9,13 +9,13 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankql         = { path = "../../ankql", version = "=0.7.16" }
-ankurah-core  = { path = "../../core", version = "=0.7.16" }
-ankurah-proto = { path = "../../proto", version = "=0.7.16" }
+ankql         = { path = "../../ankql", version = "=0.7.17" }
+ankurah-core  = { path = "../../core", version = "=0.7.17" }
+ankurah-proto = { path = "../../proto", version = "=0.7.17" }
 futures       = "0.3"
 indexmap      = "2.0"
 serde         = { version = "1.0", features = ["derive"] }
 tracing       = { version = "0.1.40" }
 
 [dev-dependencies]
-ankurah-derive = { path = "../../derive", version = "=0.7.16" }
+ankurah-derive = { path = "../../derive", version = "=0.7.17" }

--- a/storage/indexeddb-wasm/Cargo.toml
+++ b/storage/indexeddb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-indexeddb-wasm"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah storage engine using IndexedDB in the browser"
 license       = "MIT OR Apache-2.0"
@@ -15,11 +15,11 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah-core           = { path = "../../core", version = "=0.7.16", features = ["wasm"] }
-ankurah-proto          = { path = "../../proto", version = "=0.7.16", features = ["wasm"] }
-ankql                  = { path = "../../ankql", version = "=0.7.16" }
-ankurah-derive         = { path = "../../derive", version = "=0.7.16", features = ["wasm"] }
-ankurah-storage-common = { path = "../common", version = "=0.7.16" }
+ankurah-core           = { path = "../../core", version = "=0.7.17", features = ["wasm"] }
+ankurah-proto          = { path = "../../proto", version = "=0.7.17", features = ["wasm"] }
+ankql                  = { path = "../../ankql", version = "=0.7.17" }
+ankurah-derive         = { path = "../../derive", version = "=0.7.17", features = ["wasm"] }
+ankurah-storage-common = { path = "../common", version = "=0.7.17" }
 serde                  = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen     = "0.6"
 tokio                  = { version = "1.39", features = ["sync"] }
@@ -80,7 +80,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 #[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 [dev-dependencies]
 wasm-bindgen-test  = "0.3"
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.16" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.7.17" }
 tracing-subscriber = "0.3"
 
     [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/storage/postgres/Cargo.toml
+++ b/storage/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-postgres"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah storage engine using Postgres"
 license       = "MIT OR Apache-2.0"
@@ -19,16 +19,16 @@ anyhow         = "1.0"
 thiserror      = "2.0"
 tokio          = { version = "1.36", features = ["full"] }
 
-ankql         = { path = "../../ankql", version = "=0.7.16" }
-ankurah-core  = { path = "../../core", version = "=0.7.16" }
-ankurah-proto = { path = "../../proto", version = "=0.7.16", features = ["postgres"] }
+ankql         = { path = "../../ankql", version = "=0.7.17" }
+ankurah-core  = { path = "../../core", version = "=0.7.17" }
+ankurah-proto = { path = "../../proto", version = "=0.7.17", features = ["postgres"] }
 tracing       = "0.1"
 async-trait   = "0.1"
 futures-util  = "0.3"
 bytes         = "1.5"
 
 [dev-dependencies]
-ankurah                = { path = "../../ankurah", version = "=0.7.16", features = ["derive"] }
+ankurah                = { path = "../../ankurah", version = "=0.7.17", features = ["derive"] }
 tokio                  = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber     = "0.3"
 ctor                   = "0.2"

--- a/storage/sled/Cargo.toml
+++ b/storage/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-sled"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah storage engine using Sled"
 license       = "MIT OR Apache-2.0"
@@ -9,10 +9,10 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-proto          = { path = "../../proto", version = "=0.7.16" }
-ankurah-core           = { path = "../../core", version = "=0.7.16" }
-ankql                  = { path = "../../ankql", version = "=0.7.16" }
-ankurah-storage-common = { path = "../common", version = "=0.7.16" }
+ankurah-proto          = { path = "../../proto", version = "=0.7.17" }
+ankurah-core           = { path = "../../core", version = "=0.7.17" }
+ankql                  = { path = "../../ankql", version = "=0.7.17" }
+ankurah-storage-common = { path = "../common", version = "=0.7.17" }
 anyhow                 = "1.0"
 async-trait            = "0.1"
 futures                = "0.3"
@@ -28,6 +28,6 @@ tracing                = "0.1"
 thiserror              = "2.0"
 
 [dev-dependencies]
-ankurah            = { path = "../../ankurah", version = "=0.7.16", features = ["derive"] }
+ankurah            = { path = "../../ankurah", version = "=0.7.17", features = ["derive"] }
 ctor               = "0.5"
 tracing-subscriber = "0.3"

--- a/storage/sqlite/Cargo.toml
+++ b/storage/sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-sqlite"
-version       = "0.7.16"
+version       = "0.7.17"
 edition       = "2021"
 description   = "Ankurah storage engine using SQLite"
 license       = "MIT OR Apache-2.0"
@@ -29,13 +29,13 @@ serde       = { version = "1.0", features = ["derive"] }
 serde_json  = "1"
 
 # Ankurah workspace dependencies
-ankql                  = { path = "../../ankql", version = "=0.7.16" }
-ankurah-core           = { path = "../../core", version = "=0.7.16" }
-ankurah-proto          = { path = "../../proto", version = "=0.7.16" }
-ankurah-storage-common = { path = "../common", version = "=0.7.16" }
+ankql                  = { path = "../../ankql", version = "=0.7.17" }
+ankurah-core           = { path = "../../core", version = "=0.7.17" }
+ankurah-proto          = { path = "../../proto", version = "=0.7.17" }
+ankurah-storage-common = { path = "../common", version = "=0.7.17" }
 
 [dev-dependencies]
 tokio              = { version = "1", features = ["rt-multi-thread", "macros"] }
-ankurah            = { path = "../../ankurah", version = "=0.7.16", features = ["derive"] }
+ankurah            = { path = "../../ankurah", version = "=0.7.17", features = ["derive"] }
 tracing-subscriber = "0.3"
 ctor               = "0.2"

--- a/tests-wasm/bindings/Cargo.toml
+++ b/tests-wasm/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-tests-wasm-bindings"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 
 [lib]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name    = "ankurah-tests"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2021"
 publish = false
 
 [dependencies]
 anyhow                          = "1.0"
 tracing                         = "0.1"
-ankql                           = { path = "../ankql", version = "=0.7.16" }
-ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "=0.7.16" }
-ankurah-storage-sled            = { path = "../storage/sled", version = "=0.7.16" }
-ankurah-connector-local-process = { path = "../connectors/local-process", version = "=0.7.16" }
-ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "=0.7.16" }
-ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "=0.7.16" }
-ankurah-storage-common          = { path = "../storage/common", version = "=0.7.16" }
+ankql                           = { path = "../ankql", version = "=0.7.17" }
+ankurah                         = { path = "../ankurah", features = ["derive", "instrument"], version = "=0.7.17" }
+ankurah-storage-sled            = { path = "../storage/sled", version = "=0.7.17" }
+ankurah-connector-local-process = { path = "../connectors/local-process", version = "=0.7.17" }
+ankurah-websocket-client        = { path = "../connectors/websocket-client", version = "=0.7.17" }
+ankurah-websocket-server        = { path = "../connectors/websocket-server", version = "=0.7.17" }
+ankurah-storage-common          = { path = "../storage/common", version = "=0.7.17" }
 tokio                           = { version = "1.40", features = ["full"] }
 tracing-subscriber              = "0.3"
 ctor                            = "0.2"


### PR DESCRIPTION
## Summary\n- accept JsValue in generated create/create_one bindings\n- deserialize via Tsify::from_js (with ref field preprocessing) to keep errors catchable\n- keep existing behavior for view/edit flows\n\n## Testing\n- scripts/run-wasm-tests.sh