### PR TITLE
Fix empty string missing property via property registration

### DIFF
--- a/core/src/value/mod.rs
+++ b/core/src/value/mod.rs
@@ -168,6 +168,41 @@ impl ValueType {
     }
 }
 
+// Conversions between core::ValueType and proto::sys::ValueType
+impl From<proto::sys::ValueType> for ValueType {
+    fn from(v: proto::sys::ValueType) -> Self {
+        match v {
+            proto::sys::ValueType::I16 => ValueType::I16,
+            proto::sys::ValueType::I32 => ValueType::I32,
+            proto::sys::ValueType::I64 => ValueType::I64,
+            proto::sys::ValueType::F64 => ValueType::F64,
+            proto::sys::ValueType::Bool => ValueType::Bool,
+            proto::sys::ValueType::String => ValueType::String,
+            proto::sys::ValueType::EntityId => ValueType::EntityId,
+            proto::sys::ValueType::Object => ValueType::Object,
+            proto::sys::ValueType::Binary => ValueType::Binary,
+            proto::sys::ValueType::Json => ValueType::Json,
+        }
+    }
+}
+
+impl From<ValueType> for proto::sys::ValueType {
+    fn from(v: ValueType) -> Self {
+        match v {
+            ValueType::I16 => proto::sys::ValueType::I16,
+            ValueType::I32 => proto::sys::ValueType::I32,
+            ValueType::I64 => proto::sys::ValueType::I64,
+            ValueType::F64 => proto::sys::ValueType::F64,
+            ValueType::Bool => proto::sys::ValueType::Bool,
+            ValueType::String => proto::sys::ValueType::String,
+            ValueType::EntityId => proto::sys::ValueType::EntityId,
+            ValueType::Object => proto::sys::ValueType::Object,
+            ValueType::Binary => proto::sys::ValueType::Binary,
+            ValueType::Json => proto::sys::ValueType::Json,
+        }
+    }
+}
+
 impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match (self, other) {

--- a/proto/src/sys.rs
+++ b/proto/src/sys.rs
@@ -1,11 +1,61 @@
 use serde::{Deserialize, Serialize};
 
+use crate::EntityId;
+
+/// Backend kind for property storage - language agnostic
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendKind {
+    /// Last-write-wins scalar value
+    Lww,
+    /// Collaborative text (Yrs Text type)
+    YrsText,
+    /// Collaborative map (future)
+    YrsMap,
+    /// Collaborative array (future)
+    YrsArray,
+}
+
+/// Value type for property registration - mirrors core::value::ValueType exactly
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum ValueType {
+    I16,
+    I32,
+    I64,
+    F64,
+    Bool,
+    String,
+    EntityId,
+    Object,
+    Binary,
+    Json,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Item {
     /// The genesis clock for the system - this serves as the root of the clock tree for all entities in the system
     SysRoot,
     Collection {
         name: String,
+    },
+    /// A registered model (schema definition)
+    Model {
+        name: String,
+    },
+    /// A registered property belonging to a model
+    Property {
+        /// Property name (e.g., "title", "email")
+        name: String,
+        /// Reference to the parent Model entity
+        model: EntityId,
+        /// Backend/conflict resolution strategy
+        backend: BackendKind,
+        /// Value encoding type (primarily for LWW)
+        value_type: ValueType,
+        /// Whether the property can be None/missing
+        optional: bool,
+        /// For Ref types: the target model this references
+        target_model: Option<EntityId>,
     },
     #[serde(other)]
     Other,

--- a/specs/property-registration/plan.md
+++ b/specs/property-registration/plan.md
@@ -1,0 +1,165 @@
+# Property Registration Implementation Plan
+
+## Entity Structure
+
+### Model Entity
+
+```
+Model {
+    name: String,           // "User", "Album", etc.
+}
+```
+
+Note: Collection mapping is currently 1:1 with model name (lowercased). Future intent is unified collection with materialized views/indexes for queries, but for now we keep the existing derivation.
+
+### Property Entity
+
+```
+Property {
+    name: String,           // "title", "email", etc.
+    model: Ref<Model>,      // Reference to parent Model entity
+    backend: BackendKind,   // Conflict resolution strategy
+    value_type: ValueType,  // Encoding format (for lww)
+    optional: bool,         // Whether None/missing is valid
+    // Future: additional flags TBD
+}
+```
+
+### BackendKind (language-agnostic)
+
+```
+enum BackendKind {
+    lww,        // Last-write-wins scalar
+    yrs_text,   // Collaborative text (Yrs Text)
+    yrs_map,    // Collaborative map (future)
+    yrs_array,  // Collaborative array (future)
+}
+```
+
+### ValueType (language-agnostic primitives)
+
+For `lww` backend, determines serialization format:
+
+```
+enum ValueType {
+    string,
+    int32,
+    int64,
+    float32,
+    float64,
+    bool,
+    bytes,
+    json,       // Arbitrary structured data
+    ref,        // Entity reference (special case)
+}
+```
+
+For `yrs_*` backends, the value_type may be implied or have different semantics.
+
+### Rust Type Mappings
+
+| Rust Type | backend | value_type | optional |
+|-----------|---------|------------|----------|
+| `String` (via YrsString) | `yrs_text` | `string` | false |
+| `Option<String>` (via YrsString) | `yrs_text` | `string` | true |
+| `LWW<String>` | `lww` | `string` | false |
+| `LWW<i32>` | `lww` | `int32` | false |
+| `LWW<i64>` | `lww` | `int64` | false |
+| `LWW<f32>` | `lww` | `float32` | false |
+| `LWW<f64>` | `lww` | `float64` | false |
+| `LWW<bool>` | `lww` | `bool` | false |
+| `LWW<Json>` | `lww` | `json` | false |
+| `Ref<T>` | `lww` | `ref` | false |
+| `Option<Ref<T>>` | `lww` | `ref` | true |
+
+## Backend Changes
+
+### Property ID Keying
+
+Backends will store/retrieve using property entity IDs instead of string names:
+
+```rust
+// Current
+backend.insert("title", value)
+backend.get_string("title")
+
+// New  
+backend.insert(property_id, value)  // property_id: EntityId
+backend.get_string(property_id)
+```
+
+### Internal ID Mapping
+
+Backends may use an internal map table to compact entity IDs to smaller integers for storage efficiency (similar to sled's approach). This is an internal optimization detail.
+
+## LWW Native Type Registration
+
+LWW value types correspond to native type registration done with the backend. The backend maintains a registry of supported value types and their serialization logic.
+
+## Ref<T> Special Case
+
+When a property has `value_type: ref`, the Property entity needs an additional field:
+
+```
+target_model: Ref<Model>  // Which model this ref points to
+```
+
+**Resolution**: Use two-phase registration. Register all Model entities first, then all Property entities can safely reference them.
+
+## System Entity Structure
+
+Model and Property are **system entities** stored as `sys::Item` variants in `_ankurah_system`. They do not use the derive macro - their data contract is implicit and inferred from internal data.
+
+Entity IDs are looked up at runtime by name (not hardcoded). Future: model structs may be annotated with explicit entity IDs for cases requiring determinism across nodes.
+
+## Registration Flow
+
+1. **Triggered on first `trx.create::<Model>()`** - Registration runs when first entity of a model is created
+2. **Two-phase registration**:
+   - Phase 1: Ensure Model entity exists (upsert by name)
+   - Phase 2: Ensure all Property entities exist (upsert by model + name)
+3. **Runtime lookup** - Property entity IDs looked up by (model_name, property_name)
+4. **Cache entity IDs** - Store property entity IDs for runtime efficiency
+
+## Read Path (with empty string fix)
+
+1. Look up Property entity for `(model, property_name)`
+2. If property not registered → `PropertyError::UnknownProperty`
+3. Get value from backend using property entity ID
+4. If backend returns `None`:
+   - If `optional: true` → return `None`
+   - If `optional: false` → return type's default (empty string, 0, etc.)
+5. If backend returns `Some(value)` → return value
+
+## sys::Item Expansion
+
+```rust
+pub enum Item {
+    SysRoot,
+    Collection { name: String },
+    Model { name: String },
+    Property {
+        name: String,
+        model: EntityId,        // Ref to Model entity
+        backend: String,        // "lww", "yrs_text", etc.
+        value_type: String,     // "string", "int32", etc.
+        optional: bool,
+        target_model: Option<EntityId>,  // For ref types
+    },
+    #[serde(other)]
+    Other,
+}
+```
+
+## Resolved Questions
+
+1. **Ref bootstrapping** - Two-phase registration: all Models first, then Properties
+2. **Registration trigger** - On first `trx.create::<Model>()` for a given model
+3. **Entity ID stability** - Runtime lookup by name for now; future annotation for determinism
+4. **System entity structure** - Implicit data contract via sys::Item variants (no derive macro needed)
+
+## Open Questions
+
+1. **Migration path** - How to upgrade existing data without property registration?
+2. **Validation timing** - When to validate property access against registration?
+3. **Cache invalidation** - How to handle schema changes at runtime?

--- a/specs/property-registration/plan.md
+++ b/specs/property-registration/plan.md
@@ -56,21 +56,23 @@ enum ValueType {
 
 For `yrs_*` backends, the value_type may be implied or have different semantics.
 
+Note: `proto::sys::ValueType` mirrors `core::value::ValueType` exactly and has bidirectional From conversions.
+
 ### Rust Type Mappings
 
 | Rust Type | backend | value_type | optional |
 |-----------|---------|------------|----------|
-| `String` (via YrsString) | `yrs_text` | `string` | false |
-| `Option<String>` (via YrsString) | `yrs_text` | `string` | true |
-| `LWW<String>` | `lww` | `string` | false |
-| `LWW<i32>` | `lww` | `int32` | false |
-| `LWW<i64>` | `lww` | `int64` | false |
-| `LWW<f32>` | `lww` | `float32` | false |
-| `LWW<f64>` | `lww` | `float64` | false |
-| `LWW<bool>` | `lww` | `bool` | false |
-| `LWW<Json>` | `lww` | `json` | false |
-| `Ref<T>` | `lww` | `ref` | false |
-| `Option<Ref<T>>` | `lww` | `ref` | true |
+| `String` (via YrsString) | `YrsText` | `String` | false |
+| `Option<String>` (via YrsString) | `YrsText` | `String` | true |
+| `LWW<String>` | `Lww` | `String` | false |
+| `LWW<i16>` | `Lww` | `I16` | false |
+| `LWW<i32>` | `Lww` | `I32` | false |
+| `LWW<i64>` | `Lww` | `I64` | false |
+| `LWW<f64>` | `Lww` | `F64` | false |
+| `LWW<bool>` | `Lww` | `Bool` | false |
+| `LWW<Json>` | `Lww` | `Json` | false |
+| `Ref<T>` | `Lww` | `EntityId` | false |
+| `Option<Ref<T>>` | `Lww` | `EntityId` | true |
 
 ## Backend Changes
 

--- a/specs/property-registration/spec.md
+++ b/specs/property-registration/spec.md
@@ -1,0 +1,36 @@
+# Property Registration Specification
+
+## Problem Statement
+
+Empty strings in Yrs are encoded as missing properties. After serialization/deserialization round-trip, `txn.get_text("field")` returns `None` for a field that was set to `""`. This makes it impossible to distinguish between:
+1. A property that was never set
+2. A property that was explicitly set to empty string
+
+See: https://github.com/ankurah/ankurah/issues/175
+
+## Root Cause
+
+Yrs CRDTs track operations, not state. Inserting an empty string (`text.insert(0, "")`) creates no CRDT operations, so after serialization there's no record the field ever existed.
+
+## Solution: Property Registration
+
+Implement a property registration system where Models and Properties are represented as Entities in the system collection. This provides:
+
+1. **Schema awareness** - Know which properties *should* exist for a model
+2. **Empty string fix** - If a registered required property is missing from backend, return empty/default instead of error
+3. **Type casting foundation** - Enable proper type information for queries and migrations
+4. **Language agnostic** - Support future TypeScript and other language bindings
+5. **Property renames** - Change property name without losing data (entity ID is stable)
+
+## Design Principles
+
+1. **Models are Entities** - Registered in `_ankurah_system` collection
+2. **Properties are Entities** - Linked to their Model via `Ref<Model>`
+3. **Backend keying by Entity ID** - Backends store/retrieve using property entity IDs, not string names
+4. **Language agnostic type descriptors** - No Rust-specific type info in property metadata
+5. **Model ≠ Collection** - Model defines schema, Collection is storage (divergence intended)
+
+## Related Issues
+
+- https://github.com/ankurah/ankurah/issues/85 (Property registration)
+- https://github.com/ankurah/ankurah/issues/175 (Empty string missing property)

--- a/specs/property-registration/tasks.md
+++ b/specs/property-registration/tasks.md
@@ -1,0 +1,47 @@
+# Property Registration Tasks
+
+## Phase 1: Foundation
+
+- [ ] **Expand sys::Item enum** - Add Model and Property variants to `proto/src/sys.rs`
+- [ ] **Define BackendKind enum** - Language-agnostic backend identifiers
+- [ ] **Define ValueType enum** - Language-agnostic primitive types for LWW
+- [ ] **Update SystemManager** - Add methods for Model/Property entity CRUD
+
+## Phase 2: Backend Refactoring
+
+- [ ] **Refactor YrsBackend** - Accept property entity IDs instead of string names
+- [ ] **Refactor LWWBackend** - Accept property entity IDs instead of string names
+- [ ] **Internal ID mapping** - Implement map table for compacting entity IDs (optional optimization)
+- [ ] **LWW native type registry** - Register value types with serialization logic
+
+## Phase 3: Registration Flow
+
+- [ ] **Model registration** - Ensure Model entity exists on first access
+- [ ] **Property registration** - Ensure Property entities exist for all fields
+- [ ] **Entity ID caching** - Cache property entity IDs for runtime efficiency
+- [ ] **Derive macro updates** - Generate registration code from field metadata
+
+## Phase 4: Read/Write Path Updates
+
+- [ ] **Property lookup** - Look up Property entity on property access
+- [ ] **Empty string fix** - Return default for missing required properties
+- [ ] **Optional handling** - Return None for missing optional properties
+- [ ] **Unknown property error** - New PropertyError variant for unregistered properties
+
+## Phase 5: Ref<T> Support
+
+- [ ] **target_model field** - Add to Property entity for ref types
+- [ ] **Bootstrapping solution** - Handle circular Model references
+- [ ] **Ref registration** - Register target model relationship
+
+## Future / TBD
+
+- [ ] **Migration tooling** - Upgrade existing data to new schema
+- [ ] **Schema validation** - Runtime checks against registered schema
+- [ ] **TypeScript bindings** - Generate TS types from property metadata
+- [ ] **yrs_map backend** - Collaborative map support
+- [ ] **yrs_array backend** - Collaborative array support
+
+## Notes
+
+Tasks will be added/refined as implementation progresses. Each task may spawn subtasks.


### PR DESCRIPTION
## Summary

Fixes #175 - Empty strings are treated as missing properties because Yrs CRDTs don't persist empty text operations.

This PR implements property registration (#85) as the solution:
- Models and Properties become entities in the system collection
- Backends key by property entity ID instead of string names
- Read path returns defaults for missing required properties

## Approach

- **Two-phase registration**: Models first, then Properties (handles Ref<T> references)
- **Language-agnostic types**: Backend kind + value type descriptors
- **Registration trigger**: On first `trx.create::<Model>()`

## Status

- [x] Spec and plan documented
- [ ] Expand sys::Item enum
- [ ] Backend refactoring for property ID keying
- [ ] Registration flow implementation
- [ ] Read path updates with empty string fix

## Test plan

- [ ] Unit tests for property registration
- [ ] Integration test: create entity with empty string, reload, verify no error
- [ ] Test optional vs required property behavior