### PR TITLE
Text & vector indexing: spec and design

### DIFF
--- a/specs/text-vector-indexing/plan.md
+++ b/specs/text-vector-indexing/plan.md
@@ -1,0 +1,106 @@
+# Text & Vector Indexing — Implementation Plan
+
+## Overview
+
+Add text search (CONTAINS) and vector search (kNN distance) operators to ankQL, backed by new index types that work across all storage backends. PostgreSQL is the tier-1 backend — its capabilities define the semantics that other backends must match.
+
+## Phase Summary
+
+| Phase | Focus | Deliverable |
+|-------|-------|-------------|
+| 1 | Index Type Abstraction Refactor | `IndexType` trait, `IndexSpec` enum wrapping existing composite indexes — non-breaking |
+| 2 | CONTAINS Operator + Text Index | Grammar, AST, parser, evaluation, SQL pushdown, inverted index on KV backends |
+| 3 | Vector Storage + Distance Expressions | Vector column type, `distance()` expression, kNN ORDER BY, brute-force scan |
+| 4 | Vector Indexes | HNSW/IVF acceleration on Postgres (pgvector), KV backends |
+| 5 | Advanced Text Search | Word-level MATCHES operator, tsvector/tsquery on Postgres, stemming |
+
+## Phase 1: Index Type Abstraction Refactor (Non-Breaking)
+
+### Objective
+Introduce the `IndexType` trait and `IndexSpec` enum so the existing composite key indexes use the new abstraction. No behavior changes — just infrastructure for phases 2-4.
+
+### Files
+- `core/src/indexing/index_type.rs` — `IndexType` trait, `IndexSpec` enum, `IndexBounds` enum
+- `core/src/indexing/composite_index.rs` — `CompositeIndexType` implementing the trait
+- `core/src/indexing/key_spec.rs` — unchanged, wrapped by `CompositeIndexType`
+- `storage/common/src/planner.rs` — refactor to call `index_type.infer_bounds_from_predicate()`
+- `storage/common/src/types.rs` — keep `Plan::Index` as-is
+- `storage/sled/src/index.rs` — `update_indexes_for_entity()` uses `extract_entries()` with set diff
+- Serde migration: `IndexRecord.spec` becomes `IndexSpecSerde` enum, auto-upgrades old `KeySpec`-only records
+
+### Acceptance Criteria
+- All existing tests pass unchanged
+- `IndexManager` stores `IndexSpec::Composite(...)` internally
+- Index maintenance uses `extract_entries()` → set diff pattern
+
+## Phase 2: CONTAINS Operator + Text Index
+
+### Objective
+Add `CONTAINS` / `ICONTAINS` operators for substring text search, backed by inverted indexes on KV backends and native SQL on Postgres/SQLite.
+
+### Grammar + AST
+- `ankql/src/ankql.pest` — add `Contains` / `IContains` rules to `CmpInfixOp`
+- `ankql/src/ast.rs` — add to `ComparisonOperator` enum
+- `ankql/src/parser.rs` — map in `create_comparison()`
+
+### Evaluation
+- `core/src/selection/filter.rs` — string matching branches for CONTAINS/ICONTAINS
+
+### SQL Backends
+- Postgres: `position(lower($1) in lower("col")) > 0` (ICONTAINS), pushdown via `sql_builder.rs`
+- SQLite: `instr(lower("col"), lower(?)) > 0`, pushdown via `sql_builder.rs`
+
+### KV Backends (Text Index)
+- `core/src/indexing/text_index.rs` — `TextIndexType` implementing `IndexType`
+- Tokenizer: whitespace split + lowercase (simple, WASM-compatible)
+- Index key format: `[token_bytes][0x00][entity_id]`
+- `storage/common/src/types.rs` — add `Plan::TextIndex { field, tokens, remaining_predicate, ... }`
+- `storage/common/src/planner.rs` — recognize CONTAINS predicates, generate TextIndex plans
+- Sled: token prefix scan using existing scanner + prefix guard
+- IndexedDB: same pattern via IdbKeyRange
+
+### Model Annotations
+- `#[index(text, field = "description")]`
+
+## Phase 3: Vector Storage + Distance Expressions
+
+### Objective
+Add vector column type and `distance()` expression to ankQL. Support kNN queries via ORDER BY distance LIMIT K. Brute-force evaluation initially (no vector indexes yet).
+
+### Grammar + AST
+- Add `distance(field, vector_literal, metric)` as a function expression in ankQL grammar
+- `distance()` returns a float — becomes boolean via comparison (`< 0.5`), becomes ordering via ORDER BY
+- Vector literal syntax: `[0.1, 0.2, 0.3, ...]`
+
+### Storage
+- Postgres: `vector(N)` column type via pgvector extension, `<=>` / `<->` operators
+- SQLite: BLOB storage, application-level distance computation
+- Sled/IndexedDB: binary storage, application-level distance computation
+
+### Evaluation
+- `core/src/selection/filter.rs` — distance computation for WHERE threshold predicates
+- Distance metrics: L2 (Euclidean), Cosine, Dot Product — pure Rust f32/f64 ops (WASM-safe)
+
+## Phase 4: Vector Indexes
+
+### Objective
+Add index acceleration for vector kNN queries.
+
+### Postgres
+- `CREATE INDEX ... USING HNSW (embedding vector_cosine_ops)` via pgvector
+- Translates `ORDER BY distance(...)` to `ORDER BY embedding <=> $1`
+
+### KV Backends
+- IVF (Inverted File Index) for medium scale: cluster centroids + per-cluster scan
+- HNSW graph structure in separate trees for large scale
+- `Plan::VectorSearch` variant in planner
+
+## Phase 5: Advanced Text Search (Future)
+
+### Objective
+Add word-level full-text search with linguistic features.
+
+- `MATCHES` operator — word/token-level matching with AND/OR semantics
+- Postgres: `to_tsvector('simple', col) @@ to_tsquery('simple', ?)` + GIN index
+- Stemming via `rust-stemmers` crate (WASM-compatible)
+- Relevance ranking via `relevance()` expression in ORDER BY

--- a/specs/text-vector-indexing/questions.md
+++ b/specs/text-vector-indexing/questions.md
@@ -1,0 +1,55 @@
+# Open Questions
+
+## Operator Design
+
+1. ~~**How do distance/scoring expressions compose with boolean predicates?**~~
+   **RESOLVED**: WHERE is boolean, ORDER BY is scoring. Function expressions (`distance()`, `relevance()`) work in both — WHERE adds threshold comparison (`< 0.5`), ORDER BY uses raw float value. Grammar needs `FunctionCall` and `VectorLiteral` rules. See `research-scoring-composition.md`.
+
+2. ~~**How does text relevance ranking work?**~~
+   **RESOLVED**: CONTAINS is purely boolean. For text relevance ranking, use `relevance(field, query)` function in ORDER BY. Explicit over implicit — matches Postgres `ts_rank()` pattern.
+
+3. **Can we combine multiple index types in one query?**
+   - E.g., `WHERE category = 'news' AND description CONTAINS 'urgent' ORDER BY distance(embedding, query) LIMIT 10`
+   - Current planner picks ONE index. Rest goes to `remaining_predicate`.
+   - Should we support bitmap index intersection (like Postgres)?
+   - Or is "pick best index + post-filter" sufficient for now?
+
+## Tokenization
+
+4. **Fixed or pluggable tokenizer?**
+   - MVP: whitespace + lowercase (simple, deterministic)
+   - Future: language-specific stemming, stop words, custom tokenizers
+   - Pluggable adds complexity to serialization (need to persist tokenizer config)
+
+5. **Token normalization across query and index?**
+   - Search string must be tokenized the same way as indexed text
+   - If index uses lowercase, query must lowercase too
+   - Normalization must be deterministic and identical on all backends
+
+## Vector
+
+6. **Which distance metrics to support initially?**
+   - Postgres pgvector supports: L2, Cosine, Inner Product, L1
+   - MVP: Cosine only? Or L2 + Cosine?
+   - More metrics = more code paths but same architecture
+
+7. **Vector dimensions — fixed or flexible per entity?**
+   - Fixed per collection (schema metadata) is simpler and safer
+   - Variable dimensions would require runtime checks and prevent indexing
+
+## Architecture
+
+8. **Plan ranking — pick first viable or estimate selectivity?**
+   - Current: pick first viable plan
+   - Better: estimate selectivity (text index likely more selective than table scan)
+   - Full cost-based optimization is complex — defer?
+
+9. **Index backfill — sync or async?**
+   - Current: lazy backfill on first query (blocking)
+   - Text indexes may be large — async with progress tracking?
+   - Vector indexes with HNSW graph need bulk build
+
+10. **Backward compatibility for IndexRecord serialization?**
+    - Existing sled databases have `KeySpec`-only IndexRecords
+    - Auto-upgrade to `IndexSpec::Composite` on load?
+    - Version tag in serde format for future evolution?

--- a/specs/text-vector-indexing/research-ankql-grammar.md
+++ b/specs/text-vector-indexing/research-ankql-grammar.md
@@ -1,0 +1,58 @@
+# Research: ankQL Grammar, AST, and Operator Pipeline
+
+## Parser Technology
+
+ankQL uses a **PEG parser** via the `pest` crate.
+
+- **Grammar file:** `ankql/src/ankql.pest` (63 lines)
+- **Parser struct:** `ankql/src/grammar.rs` (derive wrapper)
+
+## AST Core Types
+
+**`ankql/src/ast.rs`:**
+
+| Type | Lines | Purpose |
+|------|-------|---------|
+| `Expr` | 24-32 | Literal, Path, Predicate, InfixExpr, ExprList, Placeholder |
+| `Literal` | 34-50 | I16, I32, I64, F64, Bool, String, EntityId, Object, Binary, Json |
+| `PathExpr` | 52-70 | Dot-separated field paths (e.g., `licensing.territory`) |
+| `Predicate` | 133-143 | Comparison, IsNull, And, Or, Not, True, False, Placeholder |
+| `ComparisonOperator` | 412-422 | Equal, NotEqual, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, In, Between |
+| `Selection` | 76-81 | Top-level: predicate + order_by + limit |
+
+## Existing Operators
+
+Currently supported: `=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `IN`
+Defined but not implemented: `BETWEEN`
+Not present: Any text or pattern matching operators
+
+## Operator Pipeline (end-to-end)
+
+1. **Grammar parsing** (`ankql.pest:16-23`) — tokenizes into operator rules
+2. **AST parsing** (`parser.rs:107-143`) — `create_comparison()` maps rules to `ComparisonOperator` enum
+3. **SQL generation** (`selection/sql.rs:169-180`) — `comparison_op_to_sql()` converts to SQL strings
+4. **Runtime evaluation** (`core/src/selection/filter.rs:144-199`) — `evaluate_predicate()` dispatches per operator
+
+## Predicate Evaluation Architecture
+
+Dual-layer system:
+- **SQL pushdown**: Each backend (postgres, sqlite) translates predicates to native SQL WHERE clauses
+- **Post-filtering**: `evaluate_predicate()` handles whatever can't be pushed down (used by all backends, primary for sled/indexeddb)
+
+## Key Extension Points for New Operators
+
+| Step | File | Function | What to add |
+|------|------|----------|-------------|
+| Grammar | `ankql/src/ankql.pest:16` | `CmpInfixOp` rule | New operator keywords |
+| AST | `ankql/src/ast.rs:412` | `ComparisonOperator` | New enum variants |
+| Parser | `ankql/src/parser.rs:128` | `create_comparison()` | New rule → operator mapping |
+| SQL | `ankql/src/selection/sql.rs:169` | `comparison_op_to_sql()` | SQL translation per backend |
+| Evaluation | `core/src/selection/filter.rs:150` | `evaluate_predicate()` | Runtime matching logic |
+
+## String Handling Notes
+
+- Single-quoted strings only: `'value'`
+- Escaping: `'O''Brien'` → `O'Brien` (SQL-style doubled quotes)
+- Placeholder support: `?` tokens populated via `Predicate::populate(values)`
+- Type casting: implicit numeric family casting in comparisons (i32 ↔ i64 ↔ f64)
+- JSON paths: multi-step paths (`licensing.territory`) trigger JSON traversal via `Value::extract_at_path()`

--- a/specs/text-vector-indexing/research-kv-index-infrastructure.md
+++ b/specs/text-vector-indexing/research-kv-index-infrastructure.md
@@ -1,0 +1,129 @@
+# Research: Generalized KV Index Infrastructure
+
+## Architecture Overview
+
+Ankurah has a generalized KV index infrastructure shared by sled and IndexedDB-WASM. The architecture is a pipeline of composable layers:
+
+1. **Planner** (`storage/common/src/planner.rs`) — Query → Plan enum
+2. **Key Encoding** (`core/src/indexing/encoding.rs`) — Values → sorted bytes
+3. **Bounds Normalization** — KeyBounds → engine-native ranges (per-backend)
+4. **Scanners** — Plan → EntityId/record stream (per-backend)
+5. **Index Maintenance** — write-time update hooks (per-backend)
+
+Only stages 3-5 differ between sled and IndexedDB. Stages 1-2 are fully shared.
+
+## The Planner
+
+**Location:** `storage/common/src/planner.rs`
+
+Produces `Plan` enum variants (`storage/common/src/types.rs:49-66`):
+- `Plan::Index { index_spec, bounds, scan_direction, remaining_predicate, order_by_spill }`
+- `Plan::TableScan { bounds, scan_direction, remaining_predicate, order_by_spill }`
+- `Plan::EmptyScan`
+
+Generates multiple candidate plans using strategies:
+- **ORDER-FIRST**: Use index sorted by ORDER BY columns, apply equalities as prefix
+- **INEQ-FIRST**: Use primary inequality field, sort later
+- **EQUALITY-ONLY**: Simple equalities on all index columns
+- **FALLBACK**: TableScan when no indexes apply
+
+**Key invariant:** The planner doesn't know about individual index implementations. It works with `KeySpec` and `KeyBounds` abstractions.
+
+`PlannerConfig` adapts behavior per-engine (e.g., `supports_desc_indexes = false` for IndexedDB).
+
+## KeyBounds — Planner IR
+
+**Location:** `storage/common/src/types.rs:76-142`
+
+```
+KeyBounds {
+    keyparts: Vec<KeyBoundComponent>   // one per index column
+}
+
+KeyBoundComponent {
+    column: String,
+    low: Endpoint,     // UnboundedLow | Value { datum, inclusive }
+    high: Endpoint,    // UnboundedHigh | Value { datum, inclusive }
+}
+```
+
+Engine-agnostic intermediate representation. Both sled and IndexedDB consume the same KeyBounds and convert to native formats.
+
+## Key Encoding
+
+**Location:** `core/src/indexing/encoding.rs`
+
+Two levels:
+1. **Per-value:** `encode_component_typed()` — preserves lexicographic sort order
+2. **Composite:** `encode_tuple_values_with_key_spec()` — concatenates encoded values, respects ASC/DESC (DESC inverts all bytes), appends EntityId suffix (16 bytes)
+
+## Per-Engine Normalization
+
+**Sled** (`storage/sled/src/planner_integration.rs`):
+- KeyBounds → `SledRangeBounds { start: Vec<u8>, end: Option<Vec<u8>>, eq_prefix_guard }`
+- Handles DESC columns by inverting bounds in physical space
+- Prefix guard terminates scan when equality prefix changes
+
+**IndexedDB** (`storage/indexeddb-wasm/src/planner_integration.rs`):
+- KeyBounds → `CanonicalRange` → `IdbKeyRange` + prefix guard config
+- Cannot handle DESC natively — planner only includes ASC columns, ORDER BY spills to in-memory sort
+
+## Scanners
+
+Both engines implement the same pattern:
+
+**Sled** (`storage/sled/src/scan_index.rs`):
+- `SledIndexScanner` — iterates sled tree within byte range, prefix guard terminates, decodes EntityId from last 16 bytes of key
+
+**IndexedDB** (`storage/indexeddb-wasm/src/scanner.rs`):
+- `IdbIndexScanner` — opens cursor with IdbKeyRange, prefix guard compares key array elements, yields JS Objects
+
+Both yield streams that feed into the common filter → sort → limit pipeline.
+
+## Index Maintenance
+
+**Location:** `storage/sled/src/index.rs:256-298`
+
+On every write, `update_indexes_for_entity()`:
+1. For each index matching the collection
+2. Build old key from old materialized properties
+3. Build new key from new materialized properties
+4. Remove old key, insert new key (if changed)
+
+Indexes are built from **materialized property values** (property_id → Value tuples), not raw CRDT state.
+
+**Backfill:** First-time index creation scans collection tree and builds all entries (lazy: NotBuilt → Building → Ready).
+
+## Where Text/Vector Indexes Plug In
+
+**Text index** fits naturally because a token lookup is equivalent to a single-column equality prefix scan:
+- Token = equality bound on virtual `__text_{field}` column
+- Existing prefix guard terminates when token changes
+- Multiple tokens → multiple scans → intersect EntityId sets
+- Index maintenance: tokenize → N entries per entity → set diff on write
+
+**Vector index** diverges from the range scan model:
+- kNN requires distance computation, not lexicographic ordering
+- Needs a new `Plan::VectorSearch` variant
+- Scanner must compute distances and maintain a top-K heap
+- Brute force: scan all vectors. IVF/HNSW: structured search.
+
+### Files That Need Changes for New Index Types
+
+| File | Change |
+|------|--------|
+| `storage/common/src/planner.rs` | Handle CONTAINS/distance predicates |
+| `storage/common/src/types.rs` | Add `Plan::TextIndex`, `Plan::VectorSearch` |
+| `core/src/indexing/encoding.rs` | Text key encoding (token + entity_id) |
+| `core/src/indexing/key_spec.rs` | `IndexSpec` enum wrapping `KeySpec` |
+| `storage/sled/src/index.rs` | Polymorphic `extract_entries()` + set diff maintenance |
+| `storage/sled/src/planner_integration.rs` | Text/vector bounds normalization |
+| `storage/indexeddb-wasm/src/planner_integration.rs` | Same |
+
+### Files That Don't Change
+
+| File | Why |
+|------|-----|
+| `storage/common/src/sorting.rs` | Generic stream combinators |
+| `storage/common/src/filtering.rs` | Predicate evaluation unchanged |
+| `storage/sled/src/scan_index.rs` | Text index reuses prefix-guard pattern as-is |

--- a/specs/text-vector-indexing/research-postgres-pgvector.md
+++ b/specs/text-vector-indexing/research-postgres-pgvector.md
@@ -1,0 +1,75 @@
+# Research: PostgreSQL pgvector — Vector Search Capabilities
+
+## Data Types
+
+| Type | Max Dims | Storage | Use Case |
+|------|----------|---------|----------|
+| `vector(N)` | 2,000 | 32-bit floats | Standard embeddings |
+| `halfvec(N)` | 4,000 (indexed) | 16-bit floats | Memory-constrained |
+| `sparsevec` | 1,000 non-zero | Sparse format | High-dim sparse data |
+
+Typical dimensions: OpenAI = 1,536; BERT = 768; newer models = 3,072.
+
+## Distance Operators
+
+| Operator | Metric | SQL Example |
+|----------|--------|-------------|
+| `<->` | L2 (Euclidean) | `ORDER BY embedding <-> '[0.1,0.2,...]' LIMIT 10` |
+| `<=>` | Cosine distance | `ORDER BY embedding <=> '[0.1,0.2,...]' LIMIT 10` |
+| `<#>` | Inner product (neg) | `ORDER BY embedding <#> '[0.1,0.2,...]' LIMIT 10` |
+| `<+>` | L1 (Manhattan) | `ORDER BY embedding <+> '[0.1,0.2,...]' LIMIT 10` |
+
+Distance operators return a float. Used in ORDER BY for kNN, or in WHERE with comparison for radius search.
+
+## Index Types
+
+**HNSW** (recommended):
+- Multi-layer graph structure — greedy traversal
+- Faster queries, higher recall, more memory
+- No training required — works on empty tables
+- v0.8.0+ iterative scanning prevents over-filtering
+
+**IVFFlat:**
+- Cluster centroids + flat scan within clusters
+- Faster build, less memory
+- Needs `REINDEX` as data changes significantly
+
+**Threshold:** <10K vectors — brute force scan is fine, no index needed.
+
+## Query Patterns
+
+**Basic kNN:**
+```sql
+SELECT id, title FROM docs ORDER BY embedding <=> query_vector LIMIT 10;
+```
+
+**Filtered kNN:**
+```sql
+SELECT id FROM docs WHERE category = 'news' ORDER BY embedding <=> query LIMIT 10;
+```
+
+**Radius search (boolean):**
+```sql
+SELECT id FROM docs WHERE (embedding <=> query) < 0.5;
+```
+
+## Co-existence with Other Indexes
+
+Common pattern — multiple indexes on one table:
+```sql
+CREATE INDEX idx_category ON docs USING BTREE (category);
+CREATE INDEX idx_content ON docs USING GIN (to_tsvector('english', title));
+CREATE INDEX idx_embedding ON docs USING HNSW (embedding vector_cosine_ops);
+```
+
+Postgres planner combines them via nested loops or bitmap scans.
+
+## ankQL Integration
+
+**Column type:** Add `PGValue::Vector(Vec<f32>)` variant, `postgres_type() → "vector(N)"`.
+
+**DDL:** `ALTER TABLE "collection" ADD COLUMN "embedding" vector(1536)` — fits existing `add_missing_columns()` pattern.
+
+**Query translation:** `distance(embedding, query, 'cosine')` → `embedding <=> $1` in Postgres SQL.
+
+**Index creation:** `CREATE INDEX ... USING HNSW (embedding vector_cosine_ops)` — triggered by model annotation or explicit API.

--- a/specs/text-vector-indexing/research-postgres-text-search.md
+++ b/specs/text-vector-indexing/research-postgres-text-search.md
@@ -1,0 +1,76 @@
+# Research: PostgreSQL Text Search Capabilities
+
+PostgreSQL is the tier-1 backend — its capabilities define the operator semantics.
+
+## Two Distinct GIN-Based Approaches
+
+PostgreSQL's GIN (Generalized Inverted Index) supports two text search strategies via different operator classes:
+
+### 1. pg_trgm — Trigram Substring Matching
+
+Breaks text into 3-character overlapping sequences. Best for `CONTAINS` (arbitrary substring) semantics.
+
+**Setup:**
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX idx_name_trgm ON table USING GIN (name gin_trgm_ops);
+```
+
+**Query acceleration:**
+```sql
+-- These automatically use the GIN trigram index:
+SELECT * FROM table WHERE name ILIKE '%pattern%';
+SELECT * FROM table WHERE name LIKE '%pattern%';
+```
+
+**Operators:** `%` (similarity), `<%` (word similarity), `<->` (distance)
+
+**Key advantage:** Works for `%middle%` patterns — no left-anchoring required (unlike B-tree).
+
+### 2. tsvector/tsquery — Full-Text Search
+
+Preprocesses documents into normalized lexemes with positions. Best for word-level search with linguistic features.
+
+**Setup:**
+```sql
+CREATE INDEX idx_fts ON docs USING GIN (to_tsvector('english', content));
+```
+
+**Query:**
+```sql
+SELECT * FROM docs WHERE to_tsvector('english', content) @@ to_tsquery('english', 'word & phrase');
+SELECT *, ts_rank(to_tsvector('english', content), query) AS rank FROM docs ORDER BY rank DESC;
+```
+
+**Features:** Stemming, stop words, phrase search (`<->`), Boolean operators (`& | !`), relevance ranking (`ts_rank`, `ts_rank_cd`).
+
+## Mapping to ankQL Operators
+
+| ankQL Operator | Semantics | Postgres Translation | Index |
+|---|---|---|---|
+| `CONTAINS 'text'` | Case-insensitive substring | `col ILIKE '%text%'` | GIN + gin_trgm_ops |
+| `ICONTAINS 'text'` | Same (alias) | Same | Same |
+| `MATCHES 'words'` (future) | Word-level FTS | `to_tsvector('simple', col) @@ to_tsquery('simple', 'words')` | GIN + tsvector_ops |
+
+## SQL Builder Integration Points
+
+**Current predicate pushdown** (`storage/postgres/src/sql_builder.rs`):
+- `split_predicate_for_postgres()` classifies pushable vs post-filter
+- `can_pushdown_expr()` checks expression types
+- JSONB multi-step paths use `->` operator
+
+**For CONTAINS:**
+- Mark as pushdown-capable in `can_pushdown_expr()`
+- Generate: `position(lower($1) in lower("col")) > 0` (ICONTAINS)
+- Or: `"col" ILIKE '%' || $1 || '%'` (with proper escaping of `%` and `_` in the pattern)
+
+## Co-existence
+
+A single table can have multiple index types simultaneously:
+```sql
+CREATE INDEX idx_category ON docs USING BTREE (category);        -- scalar
+CREATE INDEX idx_content ON docs USING GIN (to_tsvector('english', content));  -- FTS
+CREATE INDEX idx_embedding ON docs USING HNSW (embedding vector_cosine_ops);   -- vector
+```
+
+Postgres query planner estimates selectivity per predicate and chooses the best index path.

--- a/specs/text-vector-indexing/research-scoring-composition.md
+++ b/specs/text-vector-indexing/research-scoring-composition.md
@@ -1,0 +1,135 @@
+# Research: Scoring & Predicate Composition Design
+
+## Problem Statement
+
+ankQL needs to combine boolean predicates (WHERE) with continuous scoring/distance expressions (ORDER BY). How do other systems handle this, and what's the most elegant design?
+
+## Patterns Across Major Systems
+
+### Pattern 1: Separate Boolean from Scoring (PostgreSQL, SQLite)
+
+PostgreSQL FTS: `@@` is boolean (WHERE), `ts_rank()` is scoring (ORDER BY):
+```sql
+WHERE to_tsvector('english', content) @@ to_tsquery('english', 'query')
+ORDER BY ts_rank(to_tsvector('english', content), query) DESC
+```
+
+pgvector: distance operators work in both contexts:
+```sql
+WHERE (embedding <=> query_vec) < 0.5    -- boolean threshold
+ORDER BY embedding <=> query_vec          -- distance sort
+```
+
+SQLite FTS5: `MATCH` is boolean, `rank`/`bm25()` is scoring:
+```sql
+WHERE docs MATCH 'query' ORDER BY rank
+```
+
+### Pattern 2: Filter vs Query Context (Elasticsearch)
+
+- **filter** context: boolean, no scoring, cached — like WHERE
+- **must/should** context: boolean AND scored — contributes to `_score`
+- Distinct compilation paths: filters are cheap, queries compute relevance
+
+```json
+{
+  "bool": {
+    "filter": [{"term": {"category": "news"}}],
+    "must": [{"match": {"content": "urgent"}}]
+  }
+}
+```
+
+### Pattern 3: Pre-filter then Score (Vector DBs)
+
+Qdrant, Pinecone, Weaviate all:
+- Apply metadata filters first (narrow candidate set)
+- Score remaining candidates by vector similarity
+- Filters never affect the score
+- Hybrid search: combine multiple independent scores with fusion (RRF, weighted sum)
+
+### Pattern 4: Implicit Score Field (MongoDB)
+
+- `$meta: "vectorSearchScore"` — score is a metadata field you access
+- Scores are computed by the search stage, not the filter stage
+- Ordering is explicit: `{ $sort: { score: { $meta: "vectorSearchScore" } } }`
+
+### Pattern 5: Scored Query vs Filter Query (Lucene/Solr)
+
+- `q=` — scored query, contributes to relevance
+- `fq=` — filter query, boolean only, cached
+- Clear separation: filters narrow, queries score
+
+## Common Principle
+
+Every system separates two concerns:
+1. **Filtering** — boolean, narrows candidates (WHERE)
+2. **Scoring** — continuous, ranks candidates (ORDER BY)
+
+Filters don't contribute to scores. Scores don't affect filtering. They compose via pipeline: filter first, then score the survivors.
+
+## Recommended ankQL Design
+
+### Core Principles
+
+1. **All WHERE predicates are purely boolean** — they produce true/false, nothing more
+2. **Scoring expressions live in ORDER BY** — `distance()`, `relevance()`, `bm25()` return floats
+3. **Functions work in both contexts** — in WHERE, `distance(...) < 0.5` is a boolean threshold; in ORDER BY, `distance(...)` is a sort key
+4. **CONTAINS is NOT a scoring operator** — it's boolean. For text relevance ranking, use `relevance()` in ORDER BY.
+5. **Filters never affect scores** — WHERE narrows, ORDER BY ranks. Independent.
+
+### Query Examples
+
+```
+-- Boolean-only (no scoring)
+WHERE category = 'news' AND description ICONTAINS 'urgent'
+
+-- Boolean filter + distance ordering
+WHERE category = 'news'
+ORDER BY distance(embedding, [0.1, 0.2, ...], 'cosine')
+LIMIT 10
+
+-- Distance threshold (boolean) + distance ordering
+WHERE distance(embedding, [0.1, 0.2, ...], 'cosine') < 0.5
+ORDER BY distance(embedding, [0.1, 0.2, ...], 'cosine')
+LIMIT 10
+
+-- Combined text filter + vector ordering
+WHERE category = 'news' AND description ICONTAINS 'urgent'
+ORDER BY distance(embedding, [0.1, 0.2, ...], 'cosine')
+LIMIT 10
+
+-- Weighted multi-signal scoring (future)
+WHERE category = 'news'
+ORDER BY distance(embedding, query, 'cosine') * 0.7 + relevance(description, 'search') * 0.3
+LIMIT 10
+```
+
+### Execution Model
+
+1. **WHERE phase**: Evaluate boolean predicates, narrow candidate set
+   - Composite index: range scan
+   - Text index: token lookup + intersect
+   - Distance threshold: vector scan + threshold filter
+2. **ORDER BY phase**: Compute scoring expressions on surviving candidates
+   - `distance()`: compute vector distance per candidate
+   - `relevance()`: compute text relevance per candidate
+3. **LIMIT phase**: Take top-K from scored results
+
+This matches how Postgres, Solr, and vector DBs all actually execute queries.
+
+### Grammar Extension
+
+Use **function expression syntax** (Option A from grammar research):
+- Add `FunctionCall` rule: `Identifier "(" (Expr ("," Expr)*)? ")"`
+- Add `VectorLiteral` rule: `"[" Float ("," Float)* "]"`
+- Add `Expr::FunctionCall { name, args }` and `Literal::Vector(Vec<f64>)` to AST
+- Extend `OrderByItem` to accept expressions, not just field paths
+
+### Why This Design
+
+- **Clarity**: No hidden scoring. WHERE = filter, ORDER BY = rank.
+- **Composability**: Functions are first-class expressions. They work everywhere.
+- **Performance**: Pre-filter before scoring matches real DB execution models.
+- **Minimalism**: No special hybrid syntax. Just WHERE + ORDER BY + functions.
+- **Extensibility**: New scoring functions (bm25, tfidf, custom) are just new functions.

--- a/specs/text-vector-indexing/research-storage-backends.md
+++ b/specs/text-vector-indexing/research-storage-backends.md
@@ -1,0 +1,66 @@
+# Research: Per-Backend Text Search Implementation
+
+## Backend Comparison
+
+| Backend | Type | Native Text Search | Native Vector Search | Index Strategy |
+|---------|------|-------------------|---------------------|----------------|
+| **PostgreSQL** | SQL/relational | ILIKE, pg_trgm GIN, tsvector FTS | pgvector HNSW/IVFFlat | Native — CREATE INDEX |
+| **SQLite** | SQL/embedded | instr(), LIKE, FTS5 | None | FTS5 virtual tables |
+| **Sled** | KV/embedded | None | None | Custom inverted index trees |
+| **IndexedDB** | KV/browser | None | None | Custom object stores |
+
+## PostgreSQL
+
+**CONTAINS translation:** `position(lower($1) in lower("col")) > 0` or `"col" ILIKE '%' || $1 || '%'`
+
+**Index:** GIN + gin_trgm_ops for substring search. Native, managed by Postgres.
+
+**Predicate pushdown:** Fully pushable — add to `can_pushdown_expr()` and `comparison_op_to_sql()` in `sql_builder.rs`.
+
+**Key files:** `storage/postgres/src/sql_builder.rs`, `storage/postgres/src/lib.rs`
+
+## SQLite
+
+**CONTAINS translation:** `instr(lower("col"), lower(?)) > 0`
+
+**Index options:** FTS5 virtual tables for word-level search, or no index for simple substring (instr is O(n)).
+
+**Predicate pushdown:** Pushable — extend `split_predicate_for_sqlite()`.
+
+**Schema:** State table stores entities with dynamic columns. DDL lock protects concurrent changes.
+
+**Key files:** `storage/sqlite/src/sql_builder.rs`, `storage/sqlite/src/engine.rs`
+
+## Sled
+
+**CONTAINS evaluation:** Application-level `value.to_string().to_lowercase().contains(&needle.to_lowercase())`
+
+**Index:** Custom inverted index tree — `text_index_{field}` with key = `[token_bytes][0x00][entity_id]`, value = empty.
+
+**Maintenance:** Tokenize on write via `update_indexes_for_entity()`. Set diff for incremental updates.
+
+**Query execution:** Planner generates `Plan::TextIndex`, scanner does token prefix scan using existing prefix-guard pattern.
+
+**Existing index infrastructure:** Sophisticated — composite key indexes with lazy backfill, `IndexManager`, `SledIndexScanner`. Text index plugs into this directly.
+
+**Key files:** `storage/sled/src/index.rs`, `storage/sled/src/scan_index.rs`, `storage/sled/src/collection.rs`
+
+## IndexedDB-WASM
+
+**CONTAINS evaluation:** Same Rust string ops as sled, running in WASM.
+
+**Index:** Separate object store with compound keys `[collection, field, token, entity_id]`.
+
+**Constraints:** Single-threaded JS event loop, no native C libraries, WASM binary size matters (~150KB compressed currently).
+
+**Scanner:** `IdbIndexScanner` with IdbKeyRange + cursor-based traversal. Prefix guard terminates scan.
+
+**Key files:** `storage/indexeddb-wasm/src/collection.rs`, `storage/indexeddb-wasm/src/scanner.rs`
+
+## WASM-Compatible Crates
+
+| Crate | Purpose | WASM Safe | Size Impact |
+|-------|---------|-----------|-------------|
+| `unicode-segmentation` | Tokenization | Yes | ~15KB |
+| `rust-stemmers` | Stemming (future) | Yes | ~20KB/language |
+| Manual f32 ops | Vector distance | Yes | 0 |

--- a/specs/text-vector-indexing/review-findings.md
+++ b/specs/text-vector-indexing/review-findings.md
@@ -1,0 +1,83 @@
+# Spec Review Findings
+
+Three independent reviewers evaluated the spec. Below are the consolidated findings by severity.
+
+## Critical Issues
+
+### 1. extract_entries() doesn't fit vector indexes
+The trait returns `Vec<(Vec<u8>, EntityId)>` — forcing vectors into byte keys. HNSW graph traversal operates on raw f32 vectors, not encoded byte keys. This abstraction leaks.
+
+**Resolution options:**
+- A) Split the trait: composite/text indexes share `extract_entries()`, vector indexes have a separate interface
+- B) Polymorphic return: `IndexEntry` enum with `Composite(Vec<u8>)` / `Text(String, EntityId)` / `Vector(Vec<f32>)`
+- C) Don't force a unified trait — use `IndexSpec` enum with match arms that call index-type-specific methods directly
+
+### 2. Concurrent text index writes are not atomic
+Updating a text field with 100 tokens requires 100+ sled tree operations (removes + inserts). A crash mid-sequence leaves a corrupted index. Individual sled ops are atomic, but the sequence is not.
+
+**Resolution:** Batch all index changes in a single sled transaction. Or accept that index can be stale and rebuild on startup.
+
+### 3. NULL semantics unspecified
+Spec says nothing about:
+- `NULL CONTAINS 'x'` → NULL? false? error?
+- `distance(NULL_embedding, query, 'cosine')` → NULL? error?
+
+**Resolution:** Document: NULL propagates (SQL three-valued logic). In WHERE context, NULL predicates filter out the row.
+
+## Major Issues
+
+### 4. Plan enum needs TextIndex + VectorSearch variants
+Every `match plan` in every backend (sled, indexeddb, postgres, sqlite) will need new arms. This is a cascade of ~5-10 new match arms per backend.
+
+**Resolution:** Accept this — it's unavoidable when adding new plan types. Phase 1 (trait refactor) should add the variants with `unimplemented!()` stubs.
+
+### 5. HashSet diff performance on large text fields
+A document with 10K words → 10K hash insertions + 10K lookups + up to 10K tree operations per write. Write-heavy workloads with large text fields will see p99 latency spikes.
+
+**Resolution:** Sorted Vec diff is O(N) with less allocation overhead. Or: batch sled writes. For MVP, HashSet diff is fine — optimize later if profiling shows it's a bottleneck.
+
+### 6. Lazy backfill blocks first query
+Creating a text index on a 1M-document collection → first query triggers full scan + tokenize + index build. Could block for seconds.
+
+**Resolution:** Add a timeout/budget. Or: make index creation explicit (not lazy). Document that `#[index(text)]` triggers background build on node startup.
+
+### 7. Planner needs 3 separate code paths
+Current planner only handles composite key bounds. Text (token sets) and vector (kNN) are fundamentally different query shapes.
+
+**Resolution:** Refactor planner to iterate candidate indexes and delegate to `index_type.infer_bounds_from_predicate()`. Each index type owns its own plan generation logic.
+
+### 8. SQL backends have divergent index lifecycle
+KV backends use extract_entries() + set diff. SQL backends use native `CREATE INDEX` DDL. No unified abstraction.
+
+**Resolution:** Accept this as inherent — SQL and KV index lifecycles ARE different. Document clearly. The `IndexType` trait is for KV backends only. SQL backends handle index creation/maintenance via their own DDL paths.
+
+## High Priority (Must Document)
+
+### 9. OrderByItem only accepts PathExpr, not Expr
+Current AST: `OrderByItem { path: PathExpr, direction }`. Must change to `{ expr: Expr, direction }` for `ORDER BY distance(...)`.
+
+### 10. Empty string CONTAINS behavior
+`field CONTAINS ''` is always true (empty string is substring of everything). Document or disallow.
+
+### 11. Unicode normalization for ICONTAINS
+`'café' ICONTAINS 'cafe'` — depends on Unicode normalization form (NFC vs NFD). Document: "ICONTAINS uses simple lowercase, no Unicode normalization. NFC recommended for storage."
+
+### 12. Double computation of distance() in WHERE + ORDER BY
+`WHERE distance(...) < 0.5 ORDER BY distance(...)` computes distance twice. Acceptable for MVP; add deduplication optimization later.
+
+### 13. OR with text/vector predicates
+`WHERE a CONTAINS 'x' OR b CONTAINS 'y'` — planner can't use indexes for OR across different fields. Falls back to full scan + post-filter. Document this limitation.
+
+### 14. Grammar: FunctionCall vs PathExpr ambiguity
+`distance(` must parse as function call, not path expression. Ensure FunctionCall rule has priority over PathExpr in pest grammar.
+
+## Minor Issues
+
+### 15. extract_entries() allocation overhead
+10K allocations per write for large text fields. Use preallocated buffers if profiling shows this matters.
+
+### 16. Offset + distance ORDER BY is meaningless for kNN
+Document: "OFFSET with kNN ordering computes top-(limit+offset) then discards. Use keyset pagination for efficiency."
+
+### 17. CONTAINS on nested JSON paths
+Spec doesn't address `data.description CONTAINS 'text'`. Document: works if the path resolves to a string value.

--- a/specs/text-vector-indexing/spec.md
+++ b/specs/text-vector-indexing/spec.md
@@ -1,0 +1,254 @@
+# Text & Vector Indexing Specification
+
+## Overview
+
+This specification defines new ankQL operators and index types for text search and vector similarity search. The system encompasses:
+
+1. **CONTAINS / ICONTAINS operators** — Substring text search with inverted index acceleration
+2. **distance() expression** — Vector distance computation for kNN and radius queries
+3. **IndexType trait abstraction** — Polymorphic index infrastructure supporting composite, text, and vector indexes
+4. **Per-backend implementations** — PostgreSQL (native GIN/HNSW), SQLite (instr/FTS5), Sled + IndexedDB (custom inverted/vector indexes)
+
+## Design Goals
+
+- **Postgres-canonical semantics**: PostgreSQL is tier-1. Its operator behavior defines what all backends must match.
+- **Cross-backend parity**: Every operator works on every backend. SQL backends push down to native ops; KV backends evaluate in application code with optional index acceleration.
+- **Pluggable index types**: New index types plug into the existing Planner → Plan → Scanner → Stream pipeline without modifying the execution framework.
+- **WASM-compatible**: All application-level code (tokenization, distance computation) must compile for wasm32 targets.
+- **Incremental adoption**: Operators work without indexes (full scan + filter). Indexes are an optimization, not a requirement.
+- **WHERE is boolean, ORDER BY is scoring**: All WHERE predicates produce true/false. Scoring expressions (`distance()`, `relevance()`) are ORDER BY expressions. Filters never affect scores.
+
+## New ankQL Operators
+
+### CONTAINS / ICONTAINS (Text Search)
+
+**Semantics:** Boolean substring match. Returns true if the field value contains the search string.
+
+```
+name CONTAINS 'Alice'          -- case-sensitive substring
+name ICONTAINS 'alice'         -- case-insensitive substring
+description ICONTAINS 'urgent' AND status = 'open'
+```
+
+**Evaluation:**
+- `CONTAINS`: `field_value.contains(search_string)`
+- `ICONTAINS`: `field_value.to_lowercase().contains(search_string.to_lowercase())`
+
+**Backend translation:**
+
+| Backend | CONTAINS | ICONTAINS |
+|---------|----------|-----------|
+| PostgreSQL | `position($1 in "col") > 0` | `position(lower($1) in lower("col")) > 0` |
+| SQLite | `instr("col", ?) > 0` | `instr(lower("col"), lower(?)) > 0` |
+| Sled/IndexedDB | `value.contains(needle)` | `.to_lowercase().contains(...)` |
+
+### distance() Expression (Vector Search)
+
+**Semantics:** Computes distance between a vector field and a query vector. Returns a float. Becomes boolean via comparison, becomes ordering via ORDER BY.
+
+```
+-- kNN: find 10 nearest neighbors
+ORDER BY distance(embedding, [0.1, 0.2, ...], 'cosine') LIMIT 10
+
+-- Radius search: find all within threshold (boolean predicate)
+WHERE distance(embedding, [0.1, 0.2, ...], 'cosine') < 0.5
+
+-- Combined with other predicates
+WHERE category = 'news'
+ORDER BY distance(embedding, [0.1, 0.2, ...], 'cosine') LIMIT 10
+```
+
+**Metrics:** `'l2'` (Euclidean), `'cosine'`, `'dot'` (inner product)
+
+**Backend translation:**
+
+| Backend | distance() in ORDER BY | distance() in WHERE |
+|---------|----------------------|---------------------|
+| PostgreSQL | `embedding <=> $1` (cosine) | `(embedding <=> $1) < 0.5` |
+| SQLite | Application-level compute | Application-level compute |
+| Sled/IndexedDB | Application-level compute | Application-level compute |
+
+## Scoring & Predicate Composition
+
+### Core Principles
+
+Informed by patterns across PostgreSQL, Elasticsearch, Lucene/Solr, and vector databases:
+
+1. **All WHERE predicates are purely boolean** — `=`, `CONTAINS`, `distance(...) < 0.5` all produce true/false
+2. **Scoring expressions live in ORDER BY** — `distance()`, `relevance()` return floats for ranking
+3. **Functions work in both contexts** — same `distance()` call; WHERE adds a threshold comparison, ORDER BY uses the raw value
+4. **CONTAINS is not a scoring operator** — it's boolean. For text relevance ranking, use `relevance(field, query)` in ORDER BY
+5. **Filters never affect scores** — WHERE narrows the candidate set, ORDER BY ranks it. Independent concerns.
+
+### Execution Model
+
+```
+1. WHERE phase:  Evaluate boolean predicates → candidate set
+                  (indexes accelerate this: composite → range scan, text → token lookup, vector → threshold scan)
+2. ORDER BY phase: Compute scoring expressions on surviving candidates
+                  (distance(), relevance() evaluated per-candidate)
+3. LIMIT phase:  Take top-K from scored results
+```
+
+### Compound Query Example
+
+```
+WHERE category = 'news' AND description ICONTAINS 'urgent'
+ORDER BY distance(embedding, [0.1, 0.2, ...], 'cosine')
+LIMIT 10
+```
+
+Execution: composite index on `category` narrows to news articles → text index on `description` further narrows to those containing "urgent" → compute cosine distance for survivors → return top 10 by distance.
+
+### Grammar Extension: Function Expressions
+
+Add function call syntax to ankQL (currently only has paths, literals, infix operators):
+
+```pest
+VectorLiteral = { "[" ~ Float ~ ("," ~ Float)* ~ "]" }
+FunctionCall  = { Identifier ~ "(" ~ (Expr ~ ("," ~ Expr)*)? ~ ")" }
+AtomicExpr    = _{ ... | FunctionCall | VectorLiteral | ... }
+```
+
+AST additions:
+- `Expr::FunctionCall { name: String, args: Vec<Expr> }`
+- `Literal::Vector(Vec<f64>)`
+- `OrderByItem` accepts expressions (not just field paths)
+
+### Future: Weighted Multi-Signal Scoring
+
+```
+WHERE category = 'news'
+ORDER BY distance(embedding, query, 'cosine') * 0.7 + relevance(description, 'search') * 0.3
+LIMIT 10
+```
+
+Requires arithmetic expressions in ORDER BY — a natural extension of function expression support.
+
+## Index Type Abstraction
+
+### IndexType Trait
+
+```rust
+pub trait IndexType: Send + Sync + Debug {
+    fn extract_entries(
+        &self, eid: &EntityId, properties: &[(u32, Value)], pm: &PropertyManager,
+    ) -> Result<Vec<(Vec<u8>, EntityId)>, IndexError>;
+
+    fn infer_bounds_from_predicate(
+        &self, predicates: &[Predicate],
+    ) -> Result<Option<IndexBounds>, PlannerError>;
+
+    fn make_plan(
+        &self, bounds: IndexBounds, remaining: Predicate, order_by_spill: OrderByComponents,
+    ) -> Plan;
+}
+```
+
+### IndexSpec Enum
+
+```rust
+pub enum IndexSpec {
+    Composite(CompositeIndexType),   // Existing behavior, wrapped
+    Text(TextIndexType),             // Inverted token index
+    Vector(VectorIndexType),         // kNN vector index
+}
+```
+
+### Plan Enum (Extended)
+
+```rust
+pub enum Plan {
+    Index { index_spec, scan_direction, bounds, remaining_predicate, order_by_spill },
+    TextIndex { field, tokens, remaining_predicate, order_by_spill },
+    VectorSearch { field, query_vector, k_limit, radius, remaining_predicate, order_by_spill },
+    TableScan { bounds, scan_direction, remaining_predicate, order_by_spill },
+    EmptyScan,
+}
+```
+
+### IndexBounds Polymorphism
+
+```rust
+pub enum IndexBounds {
+    Composite(CompositeKeyBounds),     // Existing KeyBounds
+    Text(TextBounds { tokens, match_type }),
+    Vector(VectorBounds { query_vector, k, radius }),
+}
+```
+
+## Text Index Design (KV Backends)
+
+### Key Format
+```
+[token_bytes][0x00][entity_id_bytes]
+```
+
+Sorts lexicographically by token, then by entity. Prefix scan finds all entities for a given token.
+
+### Tokenization (MVP)
+- Split on whitespace and punctuation
+- Lowercase all tokens
+- No stemming initially (add via `rust-stemmers` later)
+- WASM-compatible: pure Rust, no native deps
+
+### Index Maintenance
+On every entity write:
+1. Extract text field value from materialized properties
+2. Tokenize old value → old token set
+3. Tokenize new value → new token set
+4. Compute set diff: remove old-only tokens, insert new-only tokens
+
+Uses the polymorphic `extract_entries()` → set diff pattern in `update_indexes_for_entity()`.
+
+### Query Execution
+For `description CONTAINS 'hello world'`:
+1. Tokenize search string → `["hello", "world"]`
+2. For each token: prefix scan index tree, collect EntityId sets
+3. Intersect sets → candidate entities
+4. Post-filter with actual substring match (handles false positives from tokenization)
+
+## Vector Index Design
+
+### Postgres
+Native pgvector: `CREATE INDEX ... USING HNSW (embedding vector_cosine_ops)`
+
+### KV Backends (Phased)
+- **Phase 1:** Brute force — scan all vectors, compute distances, return top-K
+- **Phase 2:** IVF — cluster centroids + per-cluster scan
+- **Phase 3:** HNSW graph structure in separate trees (if scale demands it)
+
+### Distance Computation
+Pure Rust f32/f64 operations — WASM-safe, no external deps:
+- L2: `sqrt(sum((a[i] - b[i])^2))`
+- Cosine: `1.0 - dot(a, b) / (norm(a) * norm(b))`
+- Dot product: `sum(a[i] * b[i])`
+
+## Model Annotations
+
+```rust
+#[derive(Model)]
+#[index(composite, fields = ["user_id", "created_at"])]
+#[index(text, field = "description")]
+#[index(vector, field = "embedding", dimensions = 768)]
+pub struct Task {
+    pub user_id: String,
+    pub created_at: String,
+    pub description: String,
+    pub embedding: Vec<f64>,
+}
+```
+
+## Serialization
+
+IndexRecord evolves to hold `IndexSpecSerde` — a tagged enum:
+```json
+{
+  "spec": {
+    "type": "text",
+    "config": { "field": "description", "tokenizer": "simple" }
+  }
+}
+```
+
+Backward-compatible: existing `KeySpec`-only records auto-upgrade to `IndexSpec::Composite` on load.


### PR DESCRIPTION
## Summary

- Spec and research for adding text search (`CONTAINS`/`ICONTAINS`) and vector similarity search (`distance()`) operators to ankQL
- Unified `IndexType` trait abstraction supporting composite (existing), text/inverted, and vector index types
- Per-backend implementation strategy: Postgres (native GIN/HNSW), SQLite (instr/FTS5), Sled + IndexedDB (custom indexes via shared KV planner/scanner infrastructure)
- Scoring/predicate composition design: WHERE = boolean filtering, ORDER BY = scoring expressions, function call syntax for `distance()` and `relevance()`

## Contents

- `specs/text-vector-indexing/plan.md` — 5-phase implementation roadmap
- `specs/text-vector-indexing/spec.md` — Full specification
- `specs/text-vector-indexing/questions.md` — Open design questions
- `specs/text-vector-indexing/research-*.md` — Research documents (grammar, KV infrastructure, Postgres text/vector, backends, scoring)

## Status

Spec-only — no code changes yet. Ready for review before implementation begins.