### PR TITLE
Phase 2 E1: benchmark harness and baseline

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -1,0 +1,61 @@
+name: Benchmarks
+
+# Runs the event DAG micro-benchmarks in a short "smoke" mode so the harness
+# stays green and its output is archived on every change, without gating the
+# job on runner timing noise. Regression tracking is ADVISORY: the critcmp step
+# below never fails the job. Full-fidelity numbers for the methodology doc are
+# captured locally (see core/benches/README.md), not on shared CI runners.
+
+on:
+  pull_request:
+    branches: [main, concurrent-updates-event-dag]
+    paths:
+      - "core/**"
+      - "proto/**"
+      - ".github/workflows/benches.yml"
+  workflow_dispatch:
+
+jobs:
+  benches:
+    name: Event DAG micro-benchmarks (smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      # Smoke mode: tiny warm-up and measurement windows keep the job fast and
+      # tolerant of shared-runner jitter. This validates that every bench builds
+      # and runs and that criterion produces output; it does not produce
+      # publication-grade medians.
+      - name: Run benches (smoke)
+        run: |
+          cargo bench -p ankurah-core --features bench-internals --bench event_dag -- \
+            --warm-up-time 0.5 --measurement-time 1 --sample-size 10 \
+            --save-baseline ci-smoke
+
+      # Advisory only: compare against a saved baseline if one is present in the
+      # tree. `|| true` guarantees the step (and job) never fails on timing.
+      # critcmp is best-effort; absence of a baseline is not an error.
+      - name: Compare against archived baseline (advisory, never fails)
+        run: |
+          cargo install critcmp --locked || true
+          if [ -f benches/baselines/ci-smoke.json ]; then
+            critcmp benches/baselines/ci-smoke.json ci-smoke || true
+          else
+            echo "No archived baseline (benches/baselines/ci-smoke.json); skipping comparison."
+          fi
+        continue-on-error: true
+
+      - name: Upload criterion output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-event-dag
+          path: target/criterion
+          if-no-files-found: warn
+          retention-days: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ankql"
 version = "0.9.0"
 dependencies = [
@@ -160,12 +166,13 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "chrono",
+ "criterion",
  "futures",
  "futures-signals",
  "futures-timer",
  "futures-util",
  "indexmap 2.12.1",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
  "lru",
  "maplit",
@@ -467,7 +474,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "ctor 0.2.9",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -1106,6 +1113,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1158,31 @@ dependencies = [
  "crypto-common 0.2.0",
  "inout 0.2.2",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coarsetime"
@@ -1230,6 +1289,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1350,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -2039,6 +2152,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2232,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2512,10 +2642,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3223,6 +3373,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,6 +3572,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -4415,6 +4613,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,6 +25,11 @@ default = []
 instrument = []
 # Enables test helper methods for adversarial testing (e.g., creating phantom entities)
 test-helpers = []
+# Exposes narrow wrappers over the crate-internal event DAG engine
+# (`bench_support`) for the criterion benches in `benches/`. Never enabled by
+# the default build; keeps the DAG comparison/layering/ordering primitives
+# crate-local for normal consumers.
+bench-internals = []
 
 [dependencies]
 # Internal dependencies
@@ -65,3 +70,11 @@ uniffi               = { version = "0.29", optional = true }
 [dev-dependencies]
 maplit         = "1.0"
 ankurah-derive = { path = "../derive", version = "=0.9.0" }
+criterion      = { version = "0.5", features = ["async_tokio"] }
+
+# Event DAG engine benchmarks (workstream E). harness = false because criterion
+# provides its own harness; requires the `bench-internals` feature to reach the
+# crate-internal engine via `bench_support`.
+[[bench]]
+name    = "event_dag"
+harness = false

--- a/core/benches/BASELINE.md
+++ b/core/benches/BASELINE.md
@@ -158,3 +158,14 @@ tree has a `Clock` type but the phase 1 work changed it materially (normalizing
 construction and binary-search membership are #201-era invariants), and
 `topo_sort_events` did not exist pre-#201 (it is the V4 ordered-application fix).
 They are recorded here as forward baselines rather than old-vs-new comparisons.
+
+## Re-run confirmation (2026-07-06, post-merge main)
+
+Re-run of the identical command on main at a2bed145 (post 0.9.0 release, PR
+#299 no-op-suppression fix, and PR #278 sim harness; none touch the bench
+path). All 27 cases landed within the noise band of the medians above (worst
+regression +4.7% on compare/wide_antichain/64, well inside criterion
+run-to-run variance on this machine); toposort/shuffled_chain/1024 improved
+about 10% (623-638 us vs 704.3 us), plausibly from the post-#201 layer
+machinery refactor. The baseline above remains the valid E2/D1 reference.
+Raw criterion log: bench-main-a2bed145-2026-07-06.log (kept outside the repo).

--- a/core/benches/BASELINE.md
+++ b/core/benches/BASELINE.md
@@ -1,0 +1,160 @@
+# Event DAG baseline (phase 2 start)
+
+Baseline captured at the start of concurrency phase 2, before any workstream D
+refactor, so later optimization work (workstream E2) has a fixed reference. Two
+engines are measured: the new event_dag engine on this branch (main plus the
+#201 feature commit), and the pre-#201 `lineage` engine on `origin/main`.
+
+Numbers are criterion medians (the middle value of criterion's
+`[lower median upper]` estimate). They are wall-clock micro-benchmark figures on
+one machine and are meant for relative comparison and regression tracking, not
+as absolute throughput guarantees.
+
+## Hardware and toolchain
+
+- Machine: Apple M4 Max, 16 cores, 128 GB RAM
+- OS: macOS 26.5.1 (build 25F80)
+- Toolchain: rustc 1.97.0-nightly (ca9a134e0 2026-04-26), cargo 1.97.0-nightly
+- criterion 0.5, default sampling (100 samples, 3 s measurement) unless noted
+- Quiet machine, on AC power. Absolute values will differ on other hardware and
+  on shared CI runners; capture your own baseline on the target machine before
+  reading regressions into small deltas.
+
+## New engine (this branch)
+
+Commit: the E1 branch head (main plus #201 feature commit 90f9a67d).
+
+Command:
+
+```sh
+cargo bench -p ankurah-core --features bench-internals --bench event_dag
+```
+
+| Group / case                    | Size | Median   |
+| ------------------------------- | ---- | -------- |
+| compare / linear_deep           | 10   | 14.52 us |
+| compare / linear_deep           | 100  | 131.8 us |
+| compare / linear_deep           | 1000 | 2.613 ms |
+| compare / diamond_chain         | 4    | 18.14 us |
+| compare / diamond_chain         | 16   | 71.92 us |
+| compare / diamond_chain         | 64   | 292.0 us |
+| compare / wide_antichain        | 4    | 10.05 us |
+| compare / wide_antichain        | 16   | 30.43 us |
+| compare / wide_antichain        | 64   | 109.2 us |
+| compare / disjoint              | 10   | 26.05 us |
+| compare / disjoint              | 100  | 263.7 us |
+| layers / diamond_chain_drain    | 4    | 20.94 us |
+| layers / diamond_chain_drain    | 16   | 84.29 us |
+| layers / diamond_chain_drain    | 64   | 361.6 us |
+| clock / contains                | 8    | 2.68 ns  |
+| clock / contains                | 64   | 5.01 ns  |
+| clock / contains                | 512  | 9.11 ns  |
+| clock / normalize_from          | 8    | 27.19 ns |
+| clock / normalize_from          | 64   | 510.9 ns |
+| clock / normalize_from          | 512  | 4.99 us  |
+| clock / with_event              | 8    | 54.95 ns |
+| clock / with_event              | 64   | 105.3 ns |
+| clock / with_event              | 512  | 502.4 ns |
+| toposort / shuffled_chain       | 16   | 7.20 us  |
+| toposort / shuffled_chain       | 128  | 66.04 us |
+| toposort / shuffled_chain       | 1024 | 704.3 us |
+
+## Old engine (origin/main, pre-#201)
+
+Commit: `81082afd` (detached HEAD in a separate `baseline-main` checkout).
+
+The pre-#201 comparison machinery is `core/src/lineage.rs`. Its entry point is
+`lineage::compare<G, C>(getter, subject, other, budget) -> Ordering<Id>`, which
+walks the generic `TClock` / `TEvent` / `GetEvents` traits with integer ids (no
+content addressing). Its verdict enum differs from the new engine:
+
+| Old `Ordering`     | New `AbstractCausalRelation` | Scenario                    |
+| ------------------ | ---------------------------- | --------------------------- |
+| `Descends`         | `StrictDescends`             | linear_deep, wide_antichain |
+| `NotDescends{meet}`| `DivergedSince`              | diamond_chain               |
+| `Incomparable`     | `Disjoint`                   | disjoint                    |
+| `PartiallyDescends`| (folded into DivergedSince)  | not exercised here          |
+
+The old-engine bench (`core/benches/lineage_baseline.rs` in `baseline-main`,
+preserved as `baseline-main-benches.patch`) ports the same DAG shapes to this
+API and asserts the mapped verdict on every case.
+
+Command (from the `baseline-main` checkout):
+
+```sh
+cargo bench -p ankurah-core --bench lineage_baseline
+```
+
+| Group / case             | Size | Median   |
+| ------------------------ | ---- | -------- |
+| compare / linear_deep    | 10   | 2.33 us  |
+| compare / linear_deep    | 100  | 17.16 us |
+| compare / linear_deep    | 1000 | 182.3 us |
+| compare / diamond_chain  | 4    | 699 ns   |
+| compare / diamond_chain  | 16   | 706 ns   |
+| compare / diamond_chain  | 64   | 709 ns   |
+| compare / wide_antichain | 4    | 1.01 us  |
+| compare / wide_antichain | 16   | 2.44 us  |
+| compare / wide_antichain | 64   | 7.94 us  |
+| compare / disjoint       | 10   | 2.85 us  |
+| compare / disjoint       | 100  | 26.89 us |
+
+Budget note: the old engine charges budget per BFS step (the mock returns cost 1
+per `retrieve_event` batch) and does NOT self-escalate, whereas the new engine
+escalates internally from `DEFAULT_BUDGET = 1000` up to 4x. The old-engine bench
+uses a high fixed budget (1_000_000) so every shape reaches its terminal verdict
+and the two engines measure comparable logical work. With the new engine's
+default budget the old engine would hit `BudgetExceeded` on `linear_deep/1000`.
+
+## Old vs new, comparable cases
+
+Same DAG, same clocks, same logical verdict. Ratio is new / old.
+
+| Scenario              | Size | Old      | New      | New / Old |
+| --------------------- | ---- | -------- | -------- | --------- |
+| compare / linear_deep | 10   | 2.33 us  | 14.52 us | ~6.2x     |
+| compare / linear_deep | 100  | 17.16 us | 131.8 us | ~7.7x     |
+| compare / linear_deep | 1000 | 182.3 us | 2.613 ms | ~14x      |
+| compare / wide_antichain | 4 | 1.01 us  | 10.05 us | ~10x      |
+| compare / wide_antichain | 16| 2.44 us  | 30.43 us | ~12x      |
+| compare / wide_antichain | 64| 7.94 us  | 109.2 us | ~14x      |
+| compare / disjoint    | 10   | 2.85 us  | 26.05 us | ~9x       |
+| compare / disjoint    | 100  | 26.89 us | 263.7 us | ~10x      |
+
+The new engine is consistently slower per comparison. That is the expected cost
+of the #201 correctness work: the new engine accumulates the full DAG structure
+during traversal, computes grounding ancestry (the V3 root-containment guard),
+and builds forward chains for layer application, none of which the old engine
+did. The old engine is faster but is the one the phase 1 verification found to
+be wrong on the concurrency shapes #201 fixed. The baseline exists precisely so
+E2 can recover some of this gap (the accumulator-memory and streaming-
+application targets in workstream E3) with the correctness gates held.
+
+### diamond_chain is measured but NOT directly comparable
+
+The old engine's `diamond_chain` medians are flat (~700 ns regardless of chain
+length) because it terminates as soon as the relationship is clear: comparing
+the two pre-join tips of the final diamond, it reaches their immediate meet (the
+previous join, one step down) and stops. The new engine does NOT early-terminate
+on `DivergedSince`: `check_result` emits the verdict only once both frontiers
+have fully drained, so it walks the entire chain to the root even though the
+meet is one step down. Measured `get_event` calls scale as 3 * n (n=4 -> 12,
+n=16 -> 48, n=64 -> 192), which is the linear scaling seen in the new-engine
+table.
+
+Both benches drive the same DAG, clocks, and verdict (meet = previous join), so
+they are logically equivalent comparisons, but the wall-clock numbers reflect
+different termination strategies and should not be divided against each other.
+The new engine's full-walk-on-divergence is a candidate E2 optimization
+(bounded-by-divergence-window rather than by history depth); it is filed as a
+follow-up. The `layers/diamond_chain_drain` group has no old-engine equivalent
+(the old engine had no `EventLayers` iterator; layering was introduced by #201),
+so it is a new-engine-only baseline.
+
+### clock and toposort
+
+`Clock` operations and `topo_sort_events` are new-engine-only baselines. The old
+tree has a `Clock` type but the phase 1 work changed it materially (normalizing
+construction and binary-search membership are #201-era invariants), and
+`topo_sort_events` did not exist pre-#201 (it is the V4 ordered-application fix).
+They are recorded here as forward baselines rather than old-vs-new comparisons.

--- a/core/benches/README.md
+++ b/core/benches/README.md
@@ -1,0 +1,80 @@
+# Event DAG benchmarks
+
+Criterion micro-benchmarks for the event DAG engine, landed at the start of
+concurrency phase 2 (workstream E1) so a baseline predates the workstream D
+refactors. The companion baseline numbers and methodology live in
+[`BASELINE.md`](./BASELINE.md).
+
+## What is measured
+
+One bench target, `event_dag` (`core/benches/event_dag.rs`), with four groups:
+
+- **`compare`**: the causal comparison `compare()` across DAG shapes:
+  - `linear_deep` (depths 10, 100, 1000): head vs root, a `StrictDescends`
+    that walks the whole chain.
+  - `diamond_chain` (4, 16, 64 diamonds): two concurrent tips, `DivergedSince`.
+  - `wide_antichain` (widths 4, 16, 64): a join event vs the root, stressing
+    multi-parent frontier expansion.
+  - `disjoint` (depths 10, 100): two independent roots, `Disjoint`.
+- **`layers`**: draining a `DivergedSince` comparison into topological
+  `EventLayer`s (`diamond_chain_drain`).
+- **`clock`**: `Clock` operations at sizes 8, 64, 512:
+  `contains` (membership), `normalize_from` (sort + dedup construction),
+  `with_event` (clone + insert).
+- **`toposort`**: `topo_sort_events` on a shuffled linear batch (16, 128, 1024).
+
+DAG generation is deterministic. Event ids are content addressed, so a given
+shape at a given size always produces the same DAG, and no RNG state is carried
+between cases. Events are served from an in-memory `GetEvents` map
+(`MemRetriever`), so no storage engine is in the hot path.
+
+## Running
+
+The engine lives in a `pub(crate)` module; the benches reach it through the
+feature-gated `ankurah_core::bench_support` wrappers, so the feature must be on:
+
+```sh
+# Full run (publication-grade medians; several minutes)
+cargo bench -p ankurah-core --features bench-internals --bench event_dag
+
+# Quick smoke run (what CI does)
+cargo bench -p ankurah-core --features bench-internals --bench event_dag -- \
+  --warm-up-time 0.5 --measurement-time 1 --sample-size 10
+
+# A single group or case
+cargo bench -p ankurah-core --features bench-internals --bench event_dag -- compare/diamond_chain
+```
+
+criterion writes HTML reports and raw estimates under `target/criterion/`.
+
+### The `bench-internals` feature
+
+`event_dag` (and the specific compare / relation / accumulator / ordering items
+the benches touch) is `pub(crate)` in the default build. Rather than restructure
+the engine or scatter `pub` across it, the `bench-internals` feature raises the
+module to `pub` and exposes a narrow `bench_support` module of wrappers over
+exactly the primitives the benches exercise. The default build and the public
+API are unchanged: the feature is never enabled except to run these benches.
+`criterion` is a dev-dependency and the `[[bench]]` target sets
+`harness = false`, so bench machinery stays out of the default build and test
+paths.
+
+## CI
+
+`.github/workflows/benches.yml` runs the suite in **smoke** mode (tiny warm-up
+and measurement windows) on pull requests that touch `core/` or `proto/`, and on
+manual dispatch. It uploads `target/criterion` as an artifact.
+
+Regression tracking is **advisory**: shared CI runners are too noisy to gate a
+build on timing. The workflow includes a best-effort `critcmp` comparison step
+that is wrapped so it can never fail the job, and it archives criterion output
+so trends can be inspected by hand. Publication-grade numbers are captured
+locally on a quiet machine, not on CI runners; see `BASELINE.md`.
+
+## Old-engine baseline
+
+The pre-#201 engine (`core/src/lineage.rs` on `origin/main`) is benchmarked from
+a separate checkout with an equivalent, uncommitted bench. That bench is
+preserved here as [`baseline-main-benches.patch`](./baseline-main-benches.patch)
+so the old-engine numbers are reproducible without committing to the pinned
+baseline tree. `BASELINE.md` documents the porting and the old-vs-new results.

--- a/core/benches/baseline-main-benches.patch
+++ b/core/benches/baseline-main-benches.patch
@@ -1,0 +1,271 @@
+# Old-engine (pre-#201) benchmark, for reproducing the origin/main baseline.
+# Apply from a clean checkout of origin/main 81082afd:
+#   git checkout 81082afd
+#   git apply core/benches/baseline-main-benches.patch   # path relative to repo root
+#   cargo bench -p ankurah-core --bench lineage_baseline
+# This bench uses only the old engine's public lineage::compare API; no core
+# source changes are needed. NEVER commit it to the baseline tree.
+#
+diff --git a/core/Cargo.toml b/core/Cargo.toml
+index 20f3d352..a5de85f0 100644
+--- a/core/Cargo.toml
++++ b/core/Cargo.toml
+@@ -64,3 +64,8 @@ uniffi               = { version = "0.29", optional = true }
+ [dev-dependencies]
+ maplit         = "1.0"
+ ankurah-derive = { path = "../derive", version = "=0.8.1" }
++criterion      = { version = "0.5", features = ["async_tokio"] }
++
++[[bench]]
++name    = "lineage_baseline"
++harness = false
+diff --git a/core/benches/lineage_baseline.rs b/core/benches/lineage_baseline.rs
+new file mode 100644
+index 00000000..e9343e28
+--- /dev/null
++++ b/core/benches/lineage_baseline.rs
+@@ -0,0 +1,244 @@
++//! Old-engine (pre-#201) baseline benchmarks for workstream E1.
++//!
++//! This file is DELIBERATELY UNCOMMITTED in the baseline-main checkout (detached
++//! HEAD at origin/main 81082afd). It is preserved as a patch on the E1 branch
++//! (`benches/baseline-main-benches.patch`) so the old-engine numbers are
++//! reproducible without committing to the pinned baseline tree.
++//!
++//! It ports the same DAG shapes as the new-engine `event_dag` bench to the old
++//! `lineage::compare` API, which operates over the generic `TClock`/`TEvent`/
++//! `GetEvents` traits with integer ids (no content addressing). Verdict names
++//! differ from the new engine:
++//!   Descends        <- linear_deep, wide_antichain  (== new StrictDescends)
++//!   NotDescends     <- diamond_chain                (== new DivergedSince)
++//!   Incomparable    <- disjoint                     (== new Disjoint)
++//!
++//! Build and run (from the baseline-main worktree):
++//!   cargo bench -p ankurah-core --bench lineage_baseline
++
++use std::collections::HashMap;
++
++use ankurah_core::lineage::{compare, GetEvents, Ordering};
++use ankurah_core::error::RetrievalError;
++use ankurah_core::retrieval::{TClock, TEvent};
++use ankurah_proto::{AttestationSet, Attested};
++use async_trait::async_trait;
++use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
++
++type TestId = u32;
++
++#[derive(Clone)]
++struct TestClock {
++    members: Vec<TestId>,
++}
++
++#[derive(Clone)]
++struct TestEvent {
++    id: TestId,
++    parent_clock: TestClock,
++}
++
++impl TClock for TestClock {
++    type Id = TestId;
++    fn members(&self) -> &[Self::Id] { &self.members }
++}
++
++impl TEvent for TestEvent {
++    type Id = TestId;
++    type Parent = TestClock;
++    fn id(&self) -> TestId { self.id }
++    fn parent(&self) -> &TestClock { &self.parent_clock }
++}
++
++impl std::fmt::Display for TestEvent {
++    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "Event({})", self.id) }
++}
++
++/// In-memory event store mirroring the old lineage tests' MockEventStore, plus
++/// convenience constructors for the benchmark DAG shapes.
++struct MockEventStore {
++    events: HashMap<TestId, Attested<TestEvent>>,
++}
++
++impl MockEventStore {
++    fn new() -> Self { Self { events: HashMap::new() } }
++
++    fn add(&mut self, id: TestId, parent_ids: &[TestId]) {
++        let event = TestEvent { id, parent_clock: TestClock { members: parent_ids.to_vec() } };
++        self.events.insert(id, Attested { payload: event, attestations: AttestationSet::default() });
++    }
++}
++
++#[async_trait]
++impl GetEvents for MockEventStore {
++    type Id = TestId;
++    type Event = TestEvent;
++
++    async fn retrieve_event(&self, event_ids: Vec<Self::Id>) -> Result<(usize, Vec<Attested<Self::Event>>), RetrievalError> {
++        let mut result = Vec::new();
++        for id in event_ids {
++            if let Some(event) = self.events.get(&id) {
++                result.push(event.clone());
++            }
++        }
++        Ok((1, result))
++    }
++
++    fn stage_events(&self, _events: impl IntoIterator<Item = Attested<Self::Event>>) {}
++    fn mark_event_used(&self, _event_id: &Self::Id) {}
++}
++
++struct Scenario {
++    store: MockEventStore,
++    subject: TestClock,
++    comparison: TestClock,
++    events: u64,
++}
++
++/// Linear chain 0 -> ... -> depth-1; head vs root => Descends.
++fn linear_deep(depth: usize) -> Scenario {
++    let mut s = MockEventStore::new();
++    for i in 0..depth {
++        if i == 0 {
++            s.add(0, &[]);
++        } else {
++            s.add(i as u32, &[(i - 1) as u32]);
++        }
++    }
++    Scenario { store: s, subject: TestClock { members: vec![(depth - 1) as u32] }, comparison: TestClock { members: vec![0] }, events: depth as u64 }
++}
++
++/// A chain of `n` diamonds; the two pre-join tips of the final diamond are
++/// concurrent => NotDescends. Ids: root 0, then per diamond (a, b, join).
++fn diamond_chain(n: usize) -> Scenario {
++    let mut s = MockEventStore::new();
++    let mut id = 0u32;
++    let mut next = || {
++        let v = id;
++        id += 1;
++        v
++    };
++    let mut base = next();
++    s.add(base, &[]);
++    let mut last_a = base;
++    let mut last_b = base;
++    for _ in 0..n {
++        let a = next();
++        s.add(a, &[base]);
++        let b = next();
++        s.add(b, &[base]);
++        last_a = a;
++        last_b = b;
++        let join = next();
++        s.add(join, &[a, b]);
++        base = join;
++    }
++    Scenario { store: s, subject: TestClock { members: vec![last_a] }, comparison: TestClock { members: vec![last_b] }, events: (1 + n * 3) as u64 }
++}
++
++/// Root with `width` concurrent children joined by one event; join vs root =>
++/// Descends over a width-wide parent antichain.
++fn wide_antichain(width: usize) -> Scenario {
++    let mut s = MockEventStore::new();
++    s.add(0, &[]);
++    let children: Vec<TestId> = (1..=width as u32).collect();
++    for &c in &children {
++        s.add(c, &[0]);
++    }
++    let join = width as u32 + 1;
++    s.add(join, &children);
++    Scenario { store: s, subject: TestClock { members: vec![join] }, comparison: TestClock { members: vec![0] }, events: (width + 2) as u64 }
++}
++
++/// Two independent chains sharing no root; heads compare Incomparable.
++fn disjoint(depth: usize) -> Scenario {
++    let mut s = MockEventStore::new();
++    // Chain A: 0..depth
++    for i in 0..depth {
++        if i == 0 {
++            s.add(0, &[]);
++        } else {
++            s.add(i as u32, &[(i - 1) as u32]);
++        }
++    }
++    // Chain B: base 1_000_000
++    let b0 = 1_000_000u32;
++    for i in 0..depth {
++        if i == 0 {
++            s.add(b0, &[]);
++        } else {
++            s.add(b0 + i as u32, &[b0 + (i - 1) as u32]);
++        }
++    }
++    Scenario {
++        store: s,
++        subject: TestClock { members: vec![(depth - 1) as u32] },
++        comparison: TestClock { members: vec![b0 + (depth - 1) as u32] },
++        events: (2 * depth) as u64,
++    }
++}
++
++// The old engine charges budget per BFS step (the mock returns cost 1 per
++// retrieve_event batch) and, unlike the new engine, does NOT self-escalate the
++// budget. A high fixed budget lets every shape reach its terminal verdict so
++// the comparison measures the same work as the new engine (which escalates
++// internally from DEFAULT_BUDGET = 1000 up to 4x). See the methodology doc.
++const BUDGET: usize = 1_000_000;
++
++fn bench_compare(c: &mut Criterion) {
++    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
++    let mut group = c.benchmark_group("compare");
++
++    for depth in [10usize, 100, 1000] {
++        let s = linear_deep(depth);
++        group.throughput(Throughput::Elements(s.events));
++        group.bench_with_input(BenchmarkId::new("linear_deep", depth), &s, |b, s| {
++            b.to_async(&rt).iter(|| async {
++                let o = compare(&s.store, &s.subject, &s.comparison, BUDGET).await.unwrap();
++                assert!(matches!(o, Ordering::Descends));
++                std::hint::black_box(o);
++            });
++        });
++    }
++
++    for n in [4usize, 16, 64] {
++        let s = diamond_chain(n);
++        group.throughput(Throughput::Elements(s.events));
++        group.bench_with_input(BenchmarkId::new("diamond_chain", n), &s, |b, s| {
++            b.to_async(&rt).iter(|| async {
++                let o = compare(&s.store, &s.subject, &s.comparison, BUDGET).await.unwrap();
++                assert!(matches!(o, Ordering::NotDescends { .. }));
++                std::hint::black_box(o);
++            });
++        });
++    }
++
++    for width in [4usize, 16, 64] {
++        let s = wide_antichain(width);
++        group.throughput(Throughput::Elements(s.events));
++        group.bench_with_input(BenchmarkId::new("wide_antichain", width), &s, |b, s| {
++            b.to_async(&rt).iter(|| async {
++                let o = compare(&s.store, &s.subject, &s.comparison, BUDGET).await.unwrap();
++                assert!(matches!(o, Ordering::Descends));
++                std::hint::black_box(o);
++            });
++        });
++    }
++
++    for depth in [10usize, 100] {
++        let s = disjoint(depth);
++        group.throughput(Throughput::Elements(s.events));
++        group.bench_with_input(BenchmarkId::new("disjoint", depth), &s, |b, s| {
++            b.to_async(&rt).iter(|| async {
++                let o = compare(&s.store, &s.subject, &s.comparison, BUDGET).await.unwrap();
++                assert!(matches!(o, Ordering::Incomparable));
++                std::hint::black_box(o);
++            });
++        });
++    }
++
++    group.finish();
++}
++
++criterion_group!(benches, bench_compare);
++criterion_main!(benches);

--- a/core/benches/event_dag.rs
+++ b/core/benches/event_dag.rs
@@ -11,17 +11,28 @@
 //! DAG generation is deterministic (fixed content-addressed seeds, no RNG
 //! state carried between cases) and events are served from an in-memory
 //! `GetEvents` map, so there are no storage engines in the hot path and
-//! results are reproducible across runs and machines.
+//! results are reproducible across runs and machines. Ids are content
+//! addressed, so a given shape at a given size always produces the same DAG.
+//!
+//! Groups:
+//! - `compare`: the causal comparison across DAG shapes (linear deep, uneven
+//!   diamond chains, wide antichains, disjoint graphs).
+//! - `layers`: draining a `DivergedSince` comparison into topological layers.
+//! - `clock`: membership, normalizing construction, and insert on `Clock`.
+//! - `toposort`: parents-first ordering of a shuffled event batch.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
-use ankurah_core::bench_support::compare;
+use ankurah_core::bench_support::{compare, topo_sort_events, AbstractCausalRelation, DEFAULT_BUDGET};
 use ankurah_core::error::RetrievalError;
 use ankurah_core::retrieval::GetEvents;
-use ankurah_proto::{Clock, EntityId, Event, EventId, OperationSet};
+use ankurah_proto::{Attested, Clock, EntityId, Event, EventId, OperationSet};
 use async_trait::async_trait;
-use criterion::{criterion_group, criterion_main, Criterion};
-use std::collections::BTreeMap;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+// ============================================================================
+// In-memory event source and deterministic DAG generators
+// ============================================================================
 
 /// In-memory event source: the whole DAG lives in a `HashMap`, so `compare`
 /// exercises only the traversal/accumulation logic, never storage IO.
@@ -32,7 +43,11 @@ struct MemRetriever {
 
 impl MemRetriever {
     fn new() -> Self { Self { events: HashMap::new() } }
-    fn add(&mut self, event: Event) { self.events.insert(event.id(), event); }
+    fn add(&mut self, event: Event) -> EventId {
+        let id = event.id();
+        self.events.insert(id.clone(), event);
+        id
+    }
 }
 
 #[async_trait]
@@ -45,10 +60,11 @@ impl GetEvents for MemRetriever {
 
 /// Deterministic event with a content-addressed id derived from `seed` and the
 /// parent clock. The seed only differentiates otherwise-identical events; ids
-/// remain stable across runs.
-fn event(seed: u16, parents: &[EventId]) -> Event {
+/// remain stable across runs. A `u32` seed space keeps wide/deep shapes free
+/// of collisions.
+fn event(seed: u32, parents: &[EventId]) -> Event {
     let mut entity_id_bytes = [0u8; 16];
-    entity_id_bytes[0..2].copy_from_slice(&seed.to_be_bytes());
+    entity_id_bytes[0..4].copy_from_slice(&seed.to_be_bytes());
     Event {
         entity_id: EntityId::from_bytes(entity_id_bytes),
         collection: "bench".into(),
@@ -57,35 +73,277 @@ fn event(seed: u16, parents: &[EventId]) -> Event {
     }
 }
 
-/// Build a linear chain of `depth` events; return the retriever and the head id.
-fn linear_chain(depth: usize) -> (MemRetriever, EventId) {
+/// A generated scenario: the populated retriever plus the two clocks to
+/// compare and the total event count (for throughput reporting).
+struct Scenario {
+    retriever: MemRetriever,
+    subject: Clock,
+    comparison: Clock,
+    events: u64,
+}
+
+/// Linear chain root -> ... -> head of `depth` events. Compares head against
+/// root: a `StrictDescends` that walks the whole chain (the general BFS path,
+/// not the one-step fast path, because comparison is the root not head-1).
+fn linear_deep(depth: usize) -> Scenario {
     let mut r = MemRetriever::new();
     let mut prev: Vec<EventId> = vec![];
+    let mut root = None;
     let mut head = None;
     for i in 0..depth {
-        let ev = event(i as u16, &prev);
-        let id = ev.id();
-        r.add(ev);
+        let id = r.add(event(i as u32, &prev));
+        if i == 0 {
+            root = Some(id.clone());
+        }
         prev = vec![id.clone()];
         head = Some(id);
     }
-    (r, head.expect("depth >= 1"))
+    Scenario {
+        retriever: r,
+        subject: Clock::from(vec![head.expect("depth >= 1")]),
+        comparison: Clock::from(vec![root.expect("depth >= 1")]),
+        events: depth as u64,
+    }
 }
 
-fn bench_compare_linear(c: &mut Criterion) {
+/// A chain of `n` diamonds: each diamond forks a base into two concurrent
+/// events A and B, then joins them. The two clocks are the pre-join tips of
+/// the final diamond, forcing a real two-frontier BFS all the way down to a
+/// `DivergedSince` at the last shared join. Uneven because the A and B legs
+/// carry different seeds (distinct ids), so neither leg dominates.
+fn diamond_chain(n: usize) -> Scenario {
+    let mut r = MemRetriever::new();
+    let mut seed = 0u32;
+    let mut next = || {
+        let s = seed;
+        seed += 1;
+        s
+    };
+
+    let mut base = r.add(event(next(), &[]));
+    let mut last_a = base.clone();
+    let mut last_b = base.clone();
+
+    for _ in 0..n {
+        let a = r.add(event(next(), &[base.clone()]));
+        let b = r.add(event(next(), &[base.clone()]));
+        last_a = a.clone();
+        last_b = b.clone();
+        let join = r.add(event(next(), &[a, b]));
+        base = join;
+    }
+
+    // Compare the two pre-join tips of the final diamond: concurrent, meeting
+    // at the previous join (or the root for n == 1).
+    Scenario { retriever: r, subject: Clock::from(vec![last_a]), comparison: Clock::from(vec![last_b]), events: (1 + n * 3) as u64 }
+}
+
+/// A single root with `width` concurrent children (a wide antichain), joined
+/// by one event that names all of them as parents. Compares the join against
+/// the root: `StrictDescends`, but the join's parent clock is a width-wide
+/// antichain, stressing the multi-parent frontier expansion.
+fn wide_antichain(width: usize) -> Scenario {
+    let mut r = MemRetriever::new();
+    let root = r.add(event(0, &[]));
+    let mut children = Vec::with_capacity(width);
+    for i in 0..width {
+        children.push(r.add(event(i as u32 + 1, &[root.clone()])));
+    }
+    let join = r.add(event(width as u32 + 1, &children));
+    Scenario { retriever: r, subject: Clock::from(vec![join]), comparison: Clock::from(vec![root]), events: (width + 2) as u64 }
+}
+
+/// Two independent linear chains of `depth` each, sharing no root. Comparing
+/// their heads yields `Disjoint`: both frontiers walk to their own genesis
+/// before the exhaustion verdict fires.
+fn disjoint(depth: usize) -> Scenario {
+    let mut r = MemRetriever::new();
+    let mut mk_chain = |base_seed: u32| -> EventId {
+        let mut prev: Vec<EventId> = vec![];
+        let mut head = None;
+        for i in 0..depth {
+            let id = r.add(event(base_seed + i as u32, &prev));
+            prev = vec![id.clone()];
+            head = Some(id);
+        }
+        head.expect("depth >= 1")
+    };
+    let head_a = mk_chain(0);
+    let head_b = mk_chain(1_000_000);
+    Scenario { retriever: r, subject: Clock::from(vec![head_a]), comparison: Clock::from(vec![head_b]), events: (2 * depth) as u64 }
+}
+
+// ============================================================================
+// compare() across DAG shapes
+// ============================================================================
+
+fn bench_compare(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    let (retriever, head) = linear_chain(100);
-    let root = retriever.events.values().find(|e| e.parent.is_empty()).map(|e| e.id()).expect("chain has a root");
-    let subject = Clock::from(vec![head]);
-    let comparison = Clock::from(vec![root]);
+    let mut group = c.benchmark_group("compare");
 
-    c.bench_function("compare/linear_deep/100", |b| {
-        b.to_async(&rt).iter(|| async {
-            let result = compare(retriever.clone(), &subject, &comparison, 1000).await.unwrap();
-            std::hint::black_box(result.relation());
+    // Linear deep: head vs root, StrictDescends over the whole chain.
+    for depth in [10usize, 100, 1000] {
+        let s = linear_deep(depth);
+        group.throughput(Throughput::Elements(s.events));
+        group.bench_with_input(BenchmarkId::new("linear_deep", depth), &s, |b, s| {
+            b.to_async(&rt).iter(|| async {
+                let r = compare(s.retriever.clone(), &s.subject, &s.comparison, DEFAULT_BUDGET).await.unwrap();
+                debug_assert!(matches!(r.relation(), AbstractCausalRelation::StrictDescends { .. }));
+                std::hint::black_box(r.relation());
+            });
         });
-    });
+    }
+
+    // Uneven diamond chains: two concurrent tips, DivergedSince at the last join.
+    for n in [4usize, 16, 64] {
+        let s = diamond_chain(n);
+        group.throughput(Throughput::Elements(s.events));
+        group.bench_with_input(BenchmarkId::new("diamond_chain", n), &s, |b, s| {
+            b.to_async(&rt).iter(|| async {
+                let r = compare(s.retriever.clone(), &s.subject, &s.comparison, DEFAULT_BUDGET).await.unwrap();
+                debug_assert!(matches!(r.relation(), AbstractCausalRelation::DivergedSince { .. }));
+                std::hint::black_box(r.relation());
+            });
+        });
+    }
+
+    // Wide antichains: join vs root, StrictDescends over a width-wide parent set.
+    for width in [4usize, 16, 64] {
+        let s = wide_antichain(width);
+        group.throughput(Throughput::Elements(s.events));
+        group.bench_with_input(BenchmarkId::new("wide_antichain", width), &s, |b, s| {
+            b.to_async(&rt).iter(|| async {
+                let r = compare(s.retriever.clone(), &s.subject, &s.comparison, DEFAULT_BUDGET).await.unwrap();
+                debug_assert!(matches!(r.relation(), AbstractCausalRelation::StrictDescends { .. }));
+                std::hint::black_box(r.relation());
+            });
+        });
+    }
+
+    // Disjoint graphs: two roots, exhaustion to a Disjoint verdict.
+    for depth in [10usize, 100] {
+        let s = disjoint(depth);
+        group.throughput(Throughput::Elements(s.events));
+        group.bench_with_input(BenchmarkId::new("disjoint", depth), &s, |b, s| {
+            b.to_async(&rt).iter(|| async {
+                let r = compare(s.retriever.clone(), &s.subject, &s.comparison, DEFAULT_BUDGET).await.unwrap();
+                debug_assert!(matches!(r.relation(), AbstractCausalRelation::Disjoint { .. }));
+                std::hint::black_box(r.relation());
+            });
+        });
+    }
+
+    group.finish();
 }
 
-criterion_group!(benches, bench_compare_linear);
+// ============================================================================
+// Layer iteration: DivergedSince -> EventLayers -> drain
+// ============================================================================
+
+fn bench_layers(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+    let mut group = c.benchmark_group("layers");
+
+    // A diamond chain diverges into two long concurrent tips; draining walks
+    // every layer from the meet to both tips. current_head is the comparison
+    // tip so the partition into to_apply / already_applied is non-trivial.
+    for n in [4usize, 16, 64] {
+        let s = diamond_chain(n);
+        let current_head: Vec<EventId> = s.comparison.to_vec();
+        group.throughput(Throughput::Elements(s.events));
+        group.bench_with_input(BenchmarkId::new("diamond_chain_drain", n), &s, |b, s| {
+            b.to_async(&rt).iter(|| async {
+                let r = compare(s.retriever.clone(), &s.subject, &s.comparison, DEFAULT_BUDGET).await.unwrap();
+                let mut layers = r.into_layers(current_head.clone()).expect("DivergedSince yields layers");
+                let mut count = 0usize;
+                while let Some(layer) = layers.next().await.unwrap() {
+                    count += layer.to_apply + layer.already_applied;
+                }
+                std::hint::black_box(count);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ============================================================================
+// Clock operations: membership, normalization, insert
+// ============================================================================
+
+/// A vector of `n` distinct event ids in reverse (worst case for a sort that
+/// normalizes), plus a mid-vector member to probe for.
+fn clock_ids(n: usize) -> Vec<EventId> { (0..n as u32).rev().map(|i| event(i, &[]).id()).collect() }
+
+fn bench_clock(c: &mut Criterion) {
+    let mut group = c.benchmark_group("clock");
+
+    for n in [8usize, 64, 512] {
+        let ids = clock_ids(n);
+        let sorted = Clock::from(ids.clone());
+        // A member guaranteed present: the id at the middle of the set.
+        let needle = ids[n / 2].clone();
+
+        // Membership: binary search over the normalized inner vec.
+        group.bench_with_input(BenchmarkId::new("contains", n), &(&sorted, &needle), |b, (clock, needle)| {
+            b.iter(|| std::hint::black_box(clock.contains(needle)));
+        });
+
+        // Normalizing construction: sort + dedup from unsorted input.
+        group.bench_with_input(BenchmarkId::new("normalize_from", n), &ids, |b, ids| {
+            b.iter_batched(|| ids.clone(), |ids| std::hint::black_box(Clock::from(ids)), criterion::BatchSize::SmallInput);
+        });
+
+        // Insert: clone-and-insert a new id into a normalized clock.
+        let extra = event(n as u32 + 1, &[]).id();
+        group.bench_with_input(BenchmarkId::new("with_event", n), &(&sorted, &extra), |b, (clock, extra)| {
+            b.iter(|| std::hint::black_box(clock.with_event((*extra).clone())));
+        });
+    }
+
+    group.finish();
+}
+
+// ============================================================================
+// Topological sort of event batches (ordering.rs)
+// ============================================================================
+
+/// A linear chain of `n` events as an `Attested<Event>` batch, then rotated so
+/// no event precedes its parent in input order: worst case for Kahn's
+/// algorithm, which must reorder the whole batch parents-first.
+fn shuffled_chain_batch(n: usize) -> Vec<Attested<Event>> {
+    let mut prev: Vec<EventId> = vec![];
+    let mut events = Vec::with_capacity(n);
+    for i in 0..n {
+        let ev = event(i as u32, &prev);
+        prev = vec![ev.id()];
+        events.push(ev);
+    }
+    // Rotate by half so children appear before parents in the input.
+    events.rotate_left(n / 2);
+    events.into_iter().map(|e| Attested::opt(e, None)).collect()
+}
+
+fn bench_toposort(c: &mut Criterion) {
+    let mut group = c.benchmark_group("toposort");
+
+    for n in [16usize, 128, 1024] {
+        let batch = shuffled_chain_batch(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::new("shuffled_chain", n), &batch, |b, batch| {
+            b.iter_batched(
+                || batch.clone(),
+                |batch| {
+                    let sorted = topo_sort_events(batch).unwrap();
+                    std::hint::black_box(sorted.len());
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_compare, bench_layers, bench_clock, bench_toposort);
 criterion_main!(benches);

--- a/core/benches/event_dag.rs
+++ b/core/benches/event_dag.rs
@@ -1,0 +1,91 @@
+//! Criterion micro-benchmarks for the event DAG engine (workstream E1).
+//!
+//! Reaches the crate-internal comparison, layering, and ordering primitives
+//! through the feature-gated `ankurah_core::bench_support` surface. Build and
+//! run with:
+//!
+//! ```text
+//! cargo bench -p ankurah-core --features bench-internals --bench event_dag
+//! ```
+//!
+//! DAG generation is deterministic (fixed content-addressed seeds, no RNG
+//! state carried between cases) and events are served from an in-memory
+//! `GetEvents` map, so there are no storage engines in the hot path and
+//! results are reproducible across runs and machines.
+
+use std::collections::HashMap;
+
+use ankurah_core::bench_support::compare;
+use ankurah_core::error::RetrievalError;
+use ankurah_core::retrieval::GetEvents;
+use ankurah_proto::{Clock, EntityId, Event, EventId, OperationSet};
+use async_trait::async_trait;
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::collections::BTreeMap;
+
+/// In-memory event source: the whole DAG lives in a `HashMap`, so `compare`
+/// exercises only the traversal/accumulation logic, never storage IO.
+#[derive(Clone)]
+struct MemRetriever {
+    events: HashMap<EventId, Event>,
+}
+
+impl MemRetriever {
+    fn new() -> Self { Self { events: HashMap::new() } }
+    fn add(&mut self, event: Event) { self.events.insert(event.id(), event); }
+}
+
+#[async_trait]
+impl GetEvents for MemRetriever {
+    async fn get_event(&self, event_id: &EventId) -> Result<Event, RetrievalError> {
+        self.events.get(event_id).cloned().ok_or_else(|| RetrievalError::EventNotFound(event_id.clone()))
+    }
+    async fn event_stored(&self, _event_id: &EventId) -> Result<bool, RetrievalError> { Ok(false) }
+}
+
+/// Deterministic event with a content-addressed id derived from `seed` and the
+/// parent clock. The seed only differentiates otherwise-identical events; ids
+/// remain stable across runs.
+fn event(seed: u16, parents: &[EventId]) -> Event {
+    let mut entity_id_bytes = [0u8; 16];
+    entity_id_bytes[0..2].copy_from_slice(&seed.to_be_bytes());
+    Event {
+        entity_id: EntityId::from_bytes(entity_id_bytes),
+        collection: "bench".into(),
+        parent: Clock::from(parents.to_vec()),
+        operations: OperationSet(BTreeMap::new()),
+    }
+}
+
+/// Build a linear chain of `depth` events; return the retriever and the head id.
+fn linear_chain(depth: usize) -> (MemRetriever, EventId) {
+    let mut r = MemRetriever::new();
+    let mut prev: Vec<EventId> = vec![];
+    let mut head = None;
+    for i in 0..depth {
+        let ev = event(i as u16, &prev);
+        let id = ev.id();
+        r.add(ev);
+        prev = vec![id.clone()];
+        head = Some(id);
+    }
+    (r, head.expect("depth >= 1"))
+}
+
+fn bench_compare_linear(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+    let (retriever, head) = linear_chain(100);
+    let root = retriever.events.values().find(|e| e.parent.is_empty()).map(|e| e.id()).expect("chain has a root");
+    let subject = Clock::from(vec![head]);
+    let comparison = Clock::from(vec![root]);
+
+    c.bench_function("compare/linear_deep/100", |b| {
+        b.to_async(&rt).iter(|| async {
+            let result = compare(retriever.clone(), &subject, &comparison, 1000).await.unwrap();
+            std::hint::black_box(result.relation());
+        });
+    });
+}
+
+criterion_group!(benches, bench_compare_linear);
+criterion_main!(benches);

--- a/core/src/bench_support.rs
+++ b/core/src/bench_support.rs
@@ -10,8 +10,9 @@
 //! relation and accumulator, layer draining, and batch topological sort.
 
 use crate::error::{MutationError, RetrievalError};
-use crate::event_dag::accumulator::{ComparisonResult, EventLayers};
+use crate::event_dag::accumulator::ComparisonResult;
 use crate::event_dag::compare as compare_internal;
+use crate::event_dag::layers::EventLayers;
 use crate::event_dag::ordering::topo_sort_events as topo_sort_internal;
 use crate::retrieval::GetEvents;
 use ankurah_proto::{Attested, Clock, Event, EventId};

--- a/core/src/bench_support.rs
+++ b/core/src/bench_support.rs
@@ -1,0 +1,63 @@
+//! Stable entry points into the crate-internal event DAG engine for the
+//! benchmark harness (workstream E). Gated behind the `bench-internals`
+//! feature so it never widens the default public surface: the DAG comparison,
+//! layering, and ordering primitives stay `pub(crate)` for everyone else.
+//!
+//! The benches live in a separate compilation unit (`core/benches/`) and thus
+//! cannot reach `pub(crate)` items directly. Rather than restructure the
+//! engine or scatter `pub` across it, this module offers narrow wrappers over
+//! exactly the primitives the benches exercise: `compare`, the resulting
+//! relation and accumulator, layer draining, and batch topological sort.
+
+use crate::error::{MutationError, RetrievalError};
+use crate::event_dag::accumulator::{ComparisonResult, EventLayer, EventLayers};
+use crate::event_dag::compare as compare_internal;
+use crate::event_dag::ordering::topo_sort_events as topo_sort_internal;
+use crate::retrieval::GetEvents;
+use ankurah_proto::{Attested, Clock, Event, EventId};
+
+pub use crate::event_dag::relation::AbstractCausalRelation;
+pub use crate::event_dag::DEFAULT_BUDGET;
+
+/// Re-exported so bench code can name the layer-drain iterator's output.
+pub use crate::event_dag::accumulator::EventLayer as BenchEventLayer;
+
+/// Compare two clocks over the given event source, returning the causal
+/// relation and the accumulated DAG. Mirror of the internal `compare`.
+pub async fn compare<E: GetEvents>(
+    event_getter: E,
+    subject: &Clock,
+    comparison: &Clock,
+    budget: usize,
+) -> Result<BenchComparisonResult<E>, RetrievalError> {
+    let result = compare_internal(event_getter, subject, comparison, budget).await?;
+    Ok(BenchComparisonResult(result))
+}
+
+/// Opaque wrapper over the crate-internal `ComparisonResult`. Exposes only the
+/// relation and the layer-draining path the benches need.
+pub struct BenchComparisonResult<E: GetEvents>(ComparisonResult<E>);
+
+impl<E: GetEvents> BenchComparisonResult<E> {
+    /// The causal relation verdict.
+    pub fn relation(&self) -> &AbstractCausalRelation<EventId> { &self.0.relation }
+
+    /// For a `DivergedSince` verdict, consume self to get a layer iterator
+    /// seeded at the meet and partitioned against `current_head`. Returns
+    /// `None` for non-divergent verdicts, matching the internal contract.
+    pub fn into_layers(self, current_head: Vec<EventId>) -> Option<BenchEventLayers<E>> {
+        self.0.into_layers(current_head).map(BenchEventLayers)
+    }
+}
+
+/// Opaque wrapper over the crate-internal `EventLayers` async iterator.
+pub struct BenchEventLayers<E: GetEvents>(EventLayers<E>);
+
+impl<E: GetEvents> BenchEventLayers<E> {
+    /// Yield the next topological layer, or `None` when drained.
+    pub async fn next(&mut self) -> Result<Option<EventLayer>, RetrievalError> { self.0.next().await }
+}
+
+/// Topologically sort a batch of events parents-first. Mirror of the internal
+/// `topo_sort_events` used by the ingress applier.
+pub fn topo_sort_events(events: Vec<Attested<Event>>) -> Result<Vec<Attested<Event>>, MutationError> { topo_sort_internal(events) }

--- a/core/src/bench_support.rs
+++ b/core/src/bench_support.rs
@@ -10,7 +10,7 @@
 //! relation and accumulator, layer draining, and batch topological sort.
 
 use crate::error::{MutationError, RetrievalError};
-use crate::event_dag::accumulator::{ComparisonResult, EventLayer, EventLayers};
+use crate::event_dag::accumulator::{ComparisonResult, EventLayers};
 use crate::event_dag::compare as compare_internal;
 use crate::event_dag::ordering::topo_sort_events as topo_sort_internal;
 use crate::retrieval::GetEvents;
@@ -19,8 +19,17 @@ use ankurah_proto::{Attested, Clock, Event, EventId};
 pub use crate::event_dag::relation::AbstractCausalRelation;
 pub use crate::event_dag::DEFAULT_BUDGET;
 
-/// Re-exported so bench code can name the layer-drain iterator's output.
-pub use crate::event_dag::accumulator::EventLayer as BenchEventLayer;
+/// Sizes of a drained layer. The internal `EventLayer` keeps its event vecs
+/// `pub(crate)`; the benches only need the counts (to drive draining and to
+/// keep the work from being optimized away), so we surface those rather than
+/// widen `EventLayer`'s public API.
+#[derive(Debug, Clone, Copy)]
+pub struct BenchLayer {
+    /// Events this layer would apply (not yet in the current head ancestry).
+    pub to_apply: usize,
+    /// Events already present in the current head ancestry.
+    pub already_applied: usize,
+}
 
 /// Compare two clocks over the given event source, returning the causal
 /// relation and the accumulated DAG. Mirror of the internal `compare`.
@@ -54,8 +63,10 @@ impl<E: GetEvents> BenchComparisonResult<E> {
 pub struct BenchEventLayers<E: GetEvents>(EventLayers<E>);
 
 impl<E: GetEvents> BenchEventLayers<E> {
-    /// Yield the next topological layer, or `None` when drained.
-    pub async fn next(&mut self) -> Result<Option<EventLayer>, RetrievalError> { self.0.next().await }
+    /// Yield the next topological layer's sizes, or `None` when drained.
+    pub async fn next(&mut self) -> Result<Option<BenchLayer>, RetrievalError> {
+        Ok(self.0.next().await?.map(|layer| BenchLayer { to_apply: layer.to_apply.len(), already_applied: layer.already_applied.len() }))
+    }
 }
 
 /// Topologically sort a batch of events parents-first. Mirror of the internal

--- a/core/src/event_dag/accumulator.rs
+++ b/core/src/event_dag/accumulator.rs
@@ -71,7 +71,7 @@ impl<E: GetEvents> EventAccumulator<E> {
 }
 
 /// Result of a causal comparison, carrying the accumulated DAG.
-pub(crate) struct ComparisonResult<E: GetEvents> {
+pub struct ComparisonResult<E: GetEvents> {
     /// The causal relation between the compared clocks.
     pub(crate) relation: AbstractCausalRelation<EventId>,
     /// The event accumulator with DAG structure (private -- access via into_layers).

--- a/core/src/event_dag/comparison.rs
+++ b/core/src/event_dag/comparison.rs
@@ -52,7 +52,7 @@ use std::collections::{BTreeSet, HashMap};
 ///
 /// Budget escalation: if the initial budget is exhausted, retries internally
 /// with up to 4x the initial budget before returning `BudgetExceeded`.
-pub(crate) async fn compare<E: GetEvents>(
+pub async fn compare<E: GetEvents>(
     event_getter: E,
     subject: &Clock,
     comparison: &Clock,

--- a/core/src/event_dag/mod.rs
+++ b/core/src/event_dag/mod.rs
@@ -4,12 +4,17 @@
 //! Attestations are handled at a higher layer - this code works only with
 //! causal assertions and event relationships.
 
-pub(crate) mod accumulator;
-pub(crate) mod comparison;
+// Submodules are `pub` so the feature-gated `bench_support` module can reach
+// them, but the `event_dag` module itself is `pub(crate)` in normal builds
+// (see lib.rs), which caps everything here at `pub(crate)`. Only under the
+// `bench-internals` feature does `event_dag` become `pub` and this surface
+// become reachable from the separate benches compilation unit.
+pub mod accumulator;
+pub mod comparison;
 pub(crate) mod frontier;
 pub(crate) mod layers;
-pub(crate) mod ordering;
-pub(crate) mod relation;
+pub mod ordering;
+pub mod relation;
 #[cfg(test)]
 mod tests;
 
@@ -17,7 +22,7 @@ pub(crate) use comparison::compare;
 pub(crate) use layers::{CausalRelation, EventLayer};
 pub(crate) use relation::AbstractCausalRelation;
 
-/// Default budget for DAG traversal — large enough for typical histories
-/// but bounded to prevent runaway traversal on malicious/corrupted data.
-/// Budget escalation is handled internally by `compare` (up to 4x).
-pub(crate) const DEFAULT_BUDGET: usize = 1000;
+/// Default budget for DAG traversal: large enough for typical histories but
+/// bounded to prevent runaway traversal on malicious/corrupted data. Budget
+/// escalation is handled internally by `compare` (up to 4x).
+pub const DEFAULT_BUDGET: usize = 1000;

--- a/core/src/event_dag/ordering.rs
+++ b/core/src/event_dag/ordering.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 /// Duplicate events (by id) are collapsed to their first occurrence. Ids are
 /// content-addressed, so cycles are impossible in honest input; a cycle means
 /// a malformed or malicious batch and returns an error.
-pub(crate) fn topo_sort_events(events: Vec<Attested<Event>>) -> Result<Vec<Attested<Event>>, MutationError> {
+pub fn topo_sort_events(events: Vec<Attested<Event>>) -> Result<Vec<Attested<Event>>, MutationError> {
     let mut by_id: BTreeMap<EventId, Attested<Event>> = BTreeMap::new();
     for event in events {
         by_id.entry(event.payload.id()).or_insert(event);

--- a/core/src/event_dag/relation.rs
+++ b/core/src/event_dag/relation.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 /// Causal relationship between two clocks in the event DAG.
 /// Aligned with proto::CausalRelation for wire compatibility.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum AbstractCausalRelation<Id> {
+pub enum AbstractCausalRelation<Id> {
     /// Identical lattice points.
     Equal,
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,7 +4,18 @@ pub mod connector;
 pub mod context;
 pub mod entity;
 pub mod error;
+#[cfg(not(feature = "bench-internals"))]
 pub(crate) mod event_dag;
+// The benchmark harness (workstream E) compiles in a separate unit and needs
+// to reach the DAG engine. Under `bench-internals` the module is raised to
+// `pub` so `bench_support` can wrap it; the default build keeps it crate-local.
+#[cfg(feature = "bench-internals")]
+pub mod event_dag;
+
+/// Narrow, feature-gated entry points into the event DAG engine for the
+/// benchmark harness. Never part of the default public surface.
+#[cfg(feature = "bench-internals")]
+pub mod bench_support;
 pub mod indexing;
 pub mod livequery;
 pub mod model;

--- a/specs/concurrency/phase-2.md
+++ b/specs/concurrency/phase-2.md
@@ -273,5 +273,5 @@ workstream ends by updating this document's checklist.
 - [ ] D6: validated ingress
 - [ ] D7: observability counters and alerts
 - [ ] D8: #265 and #267 remainders
-- [ ] E1: benchmark harness and baseline (lands at phase 2 start)
+- [x] E1: benchmark harness and baseline (lands at phase 2 start)
 - [ ] E2: optimization PR with before/after numbers


### PR DESCRIPTION
Workstream E1 of concurrency phase 2. Tracking: #269. Scope: specs/concurrency/phase-2.md, workstream E.

Draft opened at kickoff per the phase 2 convention so CI and progress are visible from day one. This PR targets the concurrent-updates-event-dag branch while #201 is open so the diff shows only phase 2 work; it will be retargeted to main after #201 merges.

Scope:
- Criterion micro-benchmarks for compare() across DAG shapes (linear deep, uneven diamond chains, wide antichains, disjoint), layer iteration, clock operations, and topological sort
- CI wiring that runs the benches and archives results; regression tracking starts advisory to avoid gating on runner noise
- Baseline numbers for the new engine in this tree, plus old engine numbers (origin/main 81082afd) captured from a separate checkout with the porting methodology documented

Macro benchmarks (multi-node churn) depend on the C1 simulation harness and follow separately once it lands.
