### PR TITLE
Phase 2 A: open issue triage

### DIFF
--- a/specs/concurrency/phase-2.md
+++ b/specs/concurrency/phase-2.md
@@ -260,7 +260,7 @@ workstream ends by updating this document's checklist.
 
 ## Checklist
 
-- [ ] A: issue triage table appended, issue comments posted
+- [x] A: issue triage table appended, issue comments posted
 - [x] B: bibliography plus design-deltas memo committed
 - [x] C1: simulation harness with reorder/drop/dup/partition and convergence invariants
 - [x] C2: nightly comparison-vs-oracle property sweep and simulation swarm


### PR DESCRIPTION
Workstream A of concurrency phase 2. Tracking: #269. Scope: specs/concurrency/phase-2.md, workstream A.

Draft opened at kickoff per the phase 2 convention. This PR targets the concurrent-updates-event-dag branch while #201 is open so the diff shows only phase 2 work; it will be retargeted to main after #201 merges.

Contents:
- Triage table for all open issues appended to the scope document, classified as absorbed, blocked, independent, or stale; completeness verified against the live issue list
- Kickoff RFC numbers (#271, #272, #273, #274) recorded in the workstream D ladder and checklist
- Coordination comments posted on the issues whose fate the plan changes, each linking back to #269
