### PR TITLE
Phase 2 C2: nightly oracle scale-out

### DIFF
--- a/.github/workflows/nightly-oracle.yml
+++ b/.github/workflows/nightly-oracle.yml
@@ -1,0 +1,105 @@
+name: Nightly Oracle Scale-Out
+
+# C2 (concurrency phase 2, workstream C item 2): the comparison property
+# oracle (core/src/event_dag/tests.rs, randomized_dags_match_reachability_oracle)
+# runs a few hundred seeds on every normal `cargo test`. This workflow runs it
+# at 100k+ seeds so schedules nobody hand-wrote get a chance to surface a
+# divergence between the state machine and the brute-force reachability
+# oracle. On failure the run's output (containing the self-contained
+# ORACLEFAIL line: dag_seed, verdicts, and the exact single-seed command to
+# reproduce) is uploaded as an artifact.
+#
+# IMPORTANT: GitHub only fires `schedule` triggers from the default branch of
+# a repository. This PR targets `concurrent-updates-event-dag` (not `main`),
+# so the cron below is dormant until this workflow file lands on `main`.
+# `workflow_dispatch` works on any branch in the meantime, so the run can be
+# exercised manually before that merge.
+
+on:
+  schedule:
+    # 03:17 UTC daily. Off-the-hour to avoid the top-of-hour thundering herd
+    # on shared runners. Dormant until this file is on the default branch;
+    # see the note above.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      oracle_seeds:
+        description: "Number of dag_seed values to run (ORACLE_SEEDS)"
+        required: false
+        default: "100000"
+      oracle_seed_base:
+        description: "First dag_seed value to run (ORACLE_SEED_BASE)"
+        required: false
+        default: "1"
+
+jobs:
+  oracle-scale-out:
+    name: Comparison oracle (high-seed)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run the comparison property oracle at high seed count
+        id: oracle
+        run: |
+          set -o pipefail
+          ORACLE_SEEDS="${{ github.event.inputs.oracle_seeds || '100000' }}" \
+          ORACLE_SEED_BASE="${{ github.event.inputs.oracle_seed_base || '1' }}" \
+            cargo test -p ankurah-core --lib \
+              event_dag::tests::comparison_property::randomized_dags_match_reachability_oracle \
+              -- --nocapture 2>&1 | tee oracle-output.log
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: Upload failure output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle-failure-output
+          path: oracle-output.log
+          if-no-files-found: warn
+          retention-days: 30
+
+  # Placeholder for the C1 simulation swarm nightly (SIM_SEEDS-driven large
+  # tier: tests/tests/sim_swarm.rs, `--ignored` swarm_* tests). Disabled until
+  # PR #278 (C1: deterministic multi-node simulation harness) lands, since
+  # that harness does not exist on this branch yet and this PR must not
+  # depend on C1's branch content. Once #278 lands, uncomment this job (it is
+  # deliberately left as a `run:` block below rather than removed, so the
+  # follow-up is "uncomment and verify" rather than "reconstruct from
+  # memory").
+  #
+  # sim-swarm-nightly:
+  #   name: Simulation swarm (high-seed)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - name: Set up Rust
+  #       uses: dtolnay/rust-toolchain@stable
+  #
+  #     - name: Cache dependencies
+  #       uses: Swatinem/rust-cache@v2
+  #
+  #     - name: Run the simulation swarm at high seed count
+  #       run: |
+  #         set -o pipefail
+  #         SIM_SEEDS="${{ github.event.inputs.oracle_seeds || '100000' }}" \
+  #           cargo test -p ankurah-tests --test sim_swarm -- --ignored --nocapture 2>&1 | tee sim-swarm-output.log
+  #       env:
+  #         RUST_BACKTRACE: 1
+  #
+  #     - name: Upload failure output
+  #       if: failure()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: sim-swarm-failure-output
+  #         path: sim-swarm-output.log
+  #         if-no-files-found: warn
+  #         retention-days: 30

--- a/.github/workflows/nightly-oracle.yml
+++ b/.github/workflows/nightly-oracle.yml
@@ -1,5 +1,9 @@
-name: Nightly Oracle Scale-Out
+name: "Nightly sweep: comparison engine vs reachability oracle"
 
+# The question this workflow answers nightly: does the causal-comparison
+# engine ever disagree with brute-force ground truth on a randomly generated
+# DAG?
+#
 # C2 (concurrency phase 2, workstream C item 2). Terminology: an "oracle" is
 # the testing term of art for an independent source of expected answers, not
 # a runner. Here the oracle is a brute-force reachability computation over a
@@ -68,40 +72,36 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-  # Placeholder for the C1 simulation swarm nightly (SIM_SEEDS-driven large
-  # tier: tests/tests/sim_swarm.rs, `--ignored` swarm_* tests). Disabled until
-  # PR #278 (C1: deterministic multi-node simulation harness) lands, since
-  # that harness does not exist on this branch yet and this PR must not
-  # depend on C1's branch content. Once #278 lands, uncomment this job (it is
-  # deliberately left as a `run:` block below rather than removed, so the
-  # follow-up is "uncomment and verify" rather than "reconstruct from
-  # memory").
-  #
-  # sim-swarm-nightly:
-  #   name: Simulation swarm (high-seed)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #
-  #     - name: Set up Rust
-  #       uses: dtolnay/rust-toolchain@stable
-  #
-  #     - name: Cache dependencies
-  #       uses: Swatinem/rust-cache@v2
-  #
-  #     - name: Run the simulation swarm at high seed count
-  #       run: |
-  #         set -o pipefail
-  #         SIM_SEEDS="${{ github.event.inputs.oracle_seeds || '100000' }}" \
-  #           cargo test -p ankurah-tests --test sim_swarm -- --ignored --nocapture 2>&1 | tee sim-swarm-output.log
-  #       env:
-  #         RUST_BACKTRACE: 1
-  #
-  #     - name: Upload failure output
-  #       if: failure()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: sim-swarm-failure-output
-  #         path: sim-swarm-output.log
-  #         if-no-files-found: warn
-  #         retention-days: 30
+  # The C1 simulation swarm at nightly scale: the same swarm_* scenarios the
+  # normal test job runs at their default 500 seeds, driven to 100k seeds of
+  # fault schedules (reorder/delay/dup/drop/partition subsets per seed).
+  # Activated 2026-07-06 after PR #278 (C1 harness) merged; SIMFAIL lines in
+  # the log are self-contained repro commands.
+  sim-swarm-nightly:
+    name: Simulation swarm (high-seed)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run the simulation swarm at high seed count
+        run: |
+          set -o pipefail
+          SIM_SEEDS="${{ github.event.inputs.oracle_seeds || '100000' }}" \
+            cargo test -p ankurah-tests --test sim_swarm -- --ignored --nocapture 2>&1 | tee sim-swarm-output.log
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: Upload failure output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-swarm-failure-output
+          path: sim-swarm-output.log
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/nightly-oracle.yml
+++ b/.github/workflows/nightly-oracle.yml
@@ -1,19 +1,21 @@
 name: Nightly Oracle Scale-Out
 
-# C2 (concurrency phase 2, workstream C item 2): the comparison property
-# oracle (core/src/event_dag/tests.rs, randomized_dags_match_reachability_oracle)
-# runs a few hundred seeds on every normal `cargo test`. This workflow runs it
-# at 100k+ seeds so schedules nobody hand-wrote get a chance to surface a
-# divergence between the state machine and the brute-force reachability
-# oracle. On failure the run's output (containing the self-contained
-# ORACLEFAIL line: dag_seed, verdicts, and the exact single-seed command to
-# reproduce) is uploaded as an artifact.
+# C2 (concurrency phase 2, workstream C item 2). Terminology: an "oracle" is
+# the testing term of art for an independent source of expected answers, not
+# a runner. Here the oracle is a brute-force reachability computation over a
+# generated DAG's true parent map; the property test
+# (core/src/event_dag/tests.rs, randomized_dags_match_reachability_oracle)
+# generates random DAGs and random clocks and checks the comparison engine's
+# verdict against that ground truth. The test runs a few hundred seeds on
+# every normal `cargo test`; this workflow runs the same test at 100k+ seeds
+# so schedules nobody hand-wrote get a chance to surface a divergence between
+# the engine and the oracle. On failure the run's output (containing the
+# self-contained ORACLEFAIL line: dag_seed, verdicts, and the exact
+# single-seed command to reproduce) is uploaded as an artifact.
 #
-# IMPORTANT: GitHub only fires `schedule` triggers from the default branch of
-# a repository. This PR targets `concurrent-updates-event-dag` (not `main`),
-# so the cron below is dormant until this workflow file lands on `main`.
-# `workflow_dispatch` works on any branch in the meantime, so the run can be
-# exercised manually before that merge.
+# GitHub only fires `schedule` triggers from the default branch, so the cron
+# below activates when this file lands on `main`. `workflow_dispatch` works
+# on any branch for manual runs in the meantime.
 
 on:
   schedule:

--- a/core/src/event_dag/tests.rs
+++ b/core/src/event_dag/tests.rs
@@ -2814,12 +2814,50 @@ mod comparison_property {
         }
     }
 
+    /// Base of the `dag_seed` range, overridable so a nightly or manual run can
+    /// shift the window without overlapping a prior run's coverage. Default
+    /// matches the historical hardcoded start (`1`) so ordinary test runs are
+    /// unchanged.
+    fn oracle_seed_base() -> u32 { std::env::var("ORACLE_SEED_BASE").ok().and_then(|s| s.parse().ok()).unwrap_or(1) }
+
+    /// Count of `dag_seed` values to run, overridable for the nightly high-seed
+    /// scale-out (100k+). Default matches the historical hardcoded count
+    /// (`300`) so ordinary test runs are unchanged.
+    fn oracle_seed_count() -> u32 { std::env::var("ORACLE_SEEDS").ok().and_then(|s| s.parse().ok()).unwrap_or(300) }
+
+    /// The self-contained, one-line seeded-failure artifact. Everything needed
+    /// to reproduce the exact failing case from the log line alone: the
+    /// dag_seed (which deterministically regenerates the DAG and all four
+    /// subject/comparison pairs via the xorshift `Rng`), the mismatching
+    /// verdict, and the precise command to re-run just that seed. Format
+    /// mirrors C1's `SIMFAIL` line (space-separated `key=value` tokens, one
+    /// line, no wrapping).
+    fn artifact_line(
+        dag_seed: u32,
+        subject_ids: &[EventId],
+        comparison_ids: &[EventId],
+        expected: &Expected,
+        actual: &AbstractCausalRelation<EventId>,
+    ) -> String {
+        format!(
+            "ORACLEFAIL dag_seed={dag_seed} subject={subject_ids:?} comparison={comparison_ids:?} expected={expected:?} actual={actual:?} reproduce=\"ORACLE_SEED_BASE={dag_seed} ORACLE_SEEDS=1 cargo test -p ankurah-core --lib event_dag::tests::comparison_property::randomized_dags_match_reachability_oracle -- --exact --nocapture\""
+        )
+    }
+
     /// Randomized small DAGs (including extra genesis roots), random antichain
     /// clocks, machine verdict checked against the oracle. Clocks are built
     /// sorted since Clock does not yet normalize input order (C1).
+    ///
+    /// The `dag_seed` range is `ORACLE_SEED_BASE..(ORACLE_SEED_BASE +
+    /// ORACLE_SEEDS)`, defaulting to `1..=300` (unchanged from before these
+    /// env vars existed). The nightly scale-out (C2) sets `ORACLE_SEEDS` to
+    /// 100k+; a hit prints an `ORACLEFAIL` line (see `artifact_line`) before
+    /// panicking, so any divergence is reproducible from the log alone.
     #[tokio::test]
     async fn randomized_dags_match_reachability_oracle() {
-        for dag_seed in 1u32..=300 {
+        let seed_base = oracle_seed_base();
+        let seed_count = oracle_seed_count();
+        for dag_seed in seed_base..seed_base.saturating_add(seed_count) {
             let mut rng = Rng(dag_seed.wrapping_mul(0x9E37_79B9) | 1);
             let n_events = 5 + rng.below(6); // 5..=10
 
@@ -2866,13 +2904,32 @@ mod comparison_property {
                 let result = compare(retriever.clone(), &subject, &comparison, 4 * n_events).await.unwrap();
                 let expected = oracle(&parents_map, &subject_ids, &comparison_ids);
 
-                assert!(
-                    verdict_matches(&expected, &result.relation),
-                    "verdict mismatch\n  dag_seed={dag_seed}\n  subject={subject_ids:?}\n  comparison={comparison_ids:?}\n  expected={expected:?}\n  actual={:?}\n  dag={parents_map:#?}",
-                    result.relation
-                );
+                if !verdict_matches(&expected, &result.relation) {
+                    panic!("{}", artifact_line(dag_seed, &subject_ids, &comparison_ids, &expected, &result.relation));
+                }
             }
         }
+    }
+
+    #[test]
+    fn artifact_line_format_is_self_contained() {
+        let subject_ids = vec![];
+        let comparison_ids = vec![];
+        let expected = Expected::Disjoint;
+        let actual = AbstractCausalRelation::Equal;
+        let line = artifact_line(42, &subject_ids, &comparison_ids, &expected, &actual);
+
+        assert!(line.starts_with("ORACLEFAIL "), "artifact line must start with the ORACLEFAIL marker: {line}");
+        assert!(line.contains("dag_seed=42"), "artifact line must carry the exact dag_seed: {line}");
+        assert!(line.contains("expected=Disjoint"), "artifact line must carry the expected verdict: {line}");
+        assert!(line.contains("actual=Equal"), "artifact line must carry the actual verdict: {line}");
+        assert!(
+            line.contains(
+                "reproduce=\"ORACLE_SEED_BASE=42 ORACLE_SEEDS=1 cargo test -p ankurah-core --lib event_dag::tests::comparison_property::randomized_dags_match_reachability_oracle -- --exact --nocapture\""
+            ),
+            "artifact line must carry a copy-pasteable single-seed repro command: {line}"
+        );
+        assert!(!line.contains('\n'), "artifact line must be a single line: {line}");
     }
 }
 

--- a/specs/concurrency/phase-2.md
+++ b/specs/concurrency/phase-2.md
@@ -263,7 +263,7 @@ workstream ends by updating this document's checklist.
 - [ ] A: issue triage table appended, issue comments posted
 - [x] B: bibliography plus design-deltas memo committed
 - [x] C1: simulation harness with reorder/drop/dup/partition and convergence invariants
-- [x] C2: nightly oracle scale-out
+- [x] C2: nightly comparison-vs-oracle property sweep and simulation swarm
 - [ ] C3: backend conformance kit; pn_counter decision
 - [x] C4: threat model document plus wire-level adversarial suite
 - [ ] C5: reactor/LiveQuery coherence under merge schedules

--- a/specs/concurrency/phase-2.md
+++ b/specs/concurrency/phase-2.md
@@ -263,7 +263,7 @@ workstream ends by updating this document's checklist.
 - [ ] A: issue triage table appended, issue comments posted
 - [x] B: bibliography plus design-deltas memo committed
 - [x] C1: simulation harness with reorder/drop/dup/partition and convergence invariants
-- [ ] C2: nightly oracle scale-out
+- [x] C2: nightly oracle scale-out
 - [ ] C3: backend conformance kit; pn_counter decision
 - [x] C4: threat model document plus wire-level adversarial suite
 - [ ] C5: reactor/LiveQuery coherence under merge schedules


### PR DESCRIPTION
Workstream C2 of concurrency phase 2. Tracking: #269. Scope: specs/concurrency/phase-2.md, workstream C item 2.

Draft opened at kickoff per the phase 2 convention. This PR targets the concurrent-updates-event-dag branch while #201 is open; it will be retargeted to main after #201 merges.

Scope:
- Environment parameterization of the comparison property oracle (seed count and base) with defaults unchanged
- A self-contained failure artifact line so any oracle hit reproduces from the log
- Nightly workflow (schedule plus manual dispatch) running the oracle at 100k+ seeds with failure output uploaded; the scheduled trigger activates once this lands on the default branch
- Disabled placeholder for the C1 simulation swarm nightly, activated after PR #278 lands

Note: GitHub scheduled workflows execute from the default branch, so the cron stays dormant until merge; workflow_dispatch covers interim runs.

## What landed

- `ORACLE_SEED_BASE` / `ORACLE_SEEDS` env vars parameterize the dag_seed range in `randomized_dags_match_reachability_oracle`. Defaults are `1` / `300`, identical to the prior hardcoded `1u32..=300`, so ordinary test runs are unaffected.
- A divergence now panics with a single `ORACLEFAIL` line carrying `dag_seed`, both verdicts, and a copy-pasteable single-seed reproduce command, since `dag_seed` alone determines the entire generated DAG and all four subject/comparison pairs via the seeded xorshift Rng. A unit test (`artifact_line_format_is_self_contained`) pins the format.
- `.github/workflows/nightly-oracle.yml`: nightly cron (`17 3 * * *`) plus `workflow_dispatch` with `oracle_seeds`/`oracle_seed_base` inputs, running the oracle at `ORACLE_SEEDS=100000` by default, uploading the captured output as an artifact on failure. Includes a commented-out placeholder job for the C1 simulation swarm nightly (SIM_SEEDS), left disabled until PR #278 lands since that harness does not exist on this branch.
- Also carries the standalone CI-trigger commit (`format-check.yml`, `test.yml`, `wasm-browser-tests.yml` now also trigger on PRs targeting `concurrent-updates-event-dag`; `publish.yml` untouched).

## Local proof

Release build, oracle test only, wall time via `time`:

- 50,000 seeds: 1.93s reported / 2.04s wall, 0 divergences.
- 100,000 seeds (the nightly's default): 3.88s reported / 3.98s wall, 0 divergences.

Artifact line demonstrated locally by temporarily forcing a panic on one seed (not committed), for example:

```
ORACLEFAIL dag_seed=42424 subject=[EventId(Qml8NX_pZva-2cxC62-ALzU2xzUkyMlUIIKBWrtnaSE)] comparison=[EventId(Qml8NX_pZva-2cxC62-ALzU2xzUkyMlUIIKBWrtnaSE), EventId(Ti5aV6XnhaZcpS7SQkOKDcYBJhOmldCCLOaWtABElo8), EventId(-Jaq5-gPDUlO8DZKEFHDrvDYxxngKRnT83bu3aCAb18)] expected=StrictAscends actual=StrictAscends reproduce="ORACLE_SEED_BASE=42424 ORACLE_SEEDS=1 cargo test -p ankurah-core --lib event_dag::tests::comparison_property::randomized_dags_match_reachability_oracle -- --exact --nocapture"
```

Re-running the printed `reproduce` command alone reproduced the identical line byte-for-byte, confirming the artifact is self-contained.

## Validation gate

All green on the final commit: `cargo test -p ankurah-core` (187 passed), `cargo test -p ankurah-tests` (all green), `cargo test -p ankurah-jwt-auth` (all green), `cargo check -p ankurah-core --features wasm` (clean), `cargo fmt --all -- --check`, `taplo fmt --check`.

Checklist line `C2: nightly oracle scale-out` in `specs/concurrency/phase-2.md` ticked in the final commit.
