### PR TITLE
Make server-side emission paths deterministic under the simulation audit

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ ankql           = { path = "../ankql", version = "=0.9.0" }
 ankurah-proto   = { path = "../proto", version = "=0.9.0" }
 ankurah-signals = { path = "../signals", version = "=0.9.0" }
 
-rand                 = "0.8"
+rand                 = { version = "0.8", features = ["small_rng"] }
 anyhow               = "1.0"
 thiserror            = "2"
 chrono               = { version = "0.4", default-features = false }

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -3,11 +3,12 @@ use ankurah_proto::{self as proto, Attested, CollectionId, EntityState};
 use anyhow::anyhow;
 
 use rand::prelude::*;
+use rand::rngs::SmallRng;
 use std::{
     fmt,
     hash::Hash,
     ops::Deref,
-    sync::{Arc, Weak},
+    sync::{Arc, Mutex, Weak},
 };
 use tokio::sync::oneshot;
 
@@ -132,6 +133,12 @@ where PA: PolicyAgent
     peer_connections: SafeMap<proto::EntityId, Arc<PeerState>>,
     durable_peers: SafeSet<proto::EntityId>,
 
+    /// Per-node source of randomness for peer selection. Seeded from entropy in production;
+    /// an explicit seed can be injected at construction so the simulation harness and tests
+    /// can reproduce an identical selection sequence. Held behind a Mutex because draws mutate
+    /// RNG state and Node is shared across tasks; the lock is only ever held for a single draw.
+    rng: Mutex<SmallRng>,
+
     pub(crate) predicate_context: SafeMap<proto::QueryId, PA::ContextData>,
 
     /// The reactor for handling subscriptions
@@ -150,17 +157,32 @@ where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
-    pub fn new(engine: Arc<SE>, policy_agent: PA) -> Self {
-        let collections = CollectionSet::new(engine.clone());
+    pub fn new(engine: Arc<SE>, policy_agent: PA) -> Self { Self::build(engine, policy_agent, false, SmallRng::from_entropy()) }
+    pub fn new_durable(engine: Arc<SE>, policy_agent: PA) -> Self { Self::build(engine, policy_agent, true, SmallRng::from_entropy()) }
+
+    /// Construct an ephemeral node whose peer-selection RNG is seeded explicitly.
+    /// Intended for the simulation harness and deterministic tests; production paths use [`Node::new`].
+    pub fn new_with_seed(engine: Arc<SE>, policy_agent: PA, rng_seed: u64) -> Self {
+        Self::build(engine, policy_agent, false, SmallRng::seed_from_u64(rng_seed))
+    }
+
+    /// Construct a durable node whose peer-selection RNG is seeded explicitly.
+    /// Intended for the simulation harness and deterministic tests; production paths use [`Node::new_durable`].
+    pub fn new_durable_with_seed(engine: Arc<SE>, policy_agent: PA, rng_seed: u64) -> Self {
+        Self::build(engine, policy_agent, true, SmallRng::seed_from_u64(rng_seed))
+    }
+
+    fn build(engine: Arc<SE>, policy_agent: PA, durable: bool, rng: SmallRng) -> Self {
+        let collections = CollectionSet::new(engine);
         let entityset: WeakEntitySet = Default::default();
         let id = proto::EntityId::new();
         let reactor = Reactor::new();
-        notice_info!("Node {id:#} created as ephemeral");
+        notice_info!("Node {id:#} created as {}", if durable { "durable" } else { "ephemeral" });
 
-        let system_manager = SystemManager::new(collections.clone(), entityset.clone(), reactor.clone(), false);
+        let system_manager = SystemManager::new(collections.clone(), entityset.clone(), reactor.clone(), durable);
 
-        // Create subscription relay for ephemeral nodes
-        let subscription_relay = Some(SubscriptionRelay::new());
+        // Only ephemeral nodes relay subscriptions upstream to a durable peer.
+        let subscription_relay = if durable { None } else { Some(SubscriptionRelay::new()) };
 
         let node = Node(Arc::new(NodeInner {
             id,
@@ -168,8 +190,9 @@ where
             entities: entityset,
             peer_connections: SafeMap::new(),
             durable_peers: SafeSet::new(),
+            rng: Mutex::new(rng),
             reactor,
-            durable: false,
+            durable,
             policy_agent,
             system: system_manager,
             predicate_context: SafeMap::new(),
@@ -184,34 +207,6 @@ where
                 warn!("Failed to set message sender for subscription relay");
             }
         }
-
-        node.policy_agent.on_node_ready(node.weak());
-
-        node
-    }
-    pub fn new_durable(engine: Arc<SE>, policy_agent: PA) -> Self {
-        let collections = CollectionSet::new(engine);
-        let entityset: WeakEntitySet = Default::default();
-        let id = proto::EntityId::new();
-        let reactor = Reactor::new();
-        notice_info!("Node {id:#} created as durable");
-
-        let system_manager = SystemManager::new(collections.clone(), entityset.clone(), reactor.clone(), true);
-
-        let node = Node(Arc::new(NodeInner {
-            id,
-            collections,
-            entities: entityset,
-            peer_connections: SafeMap::new(),
-            durable_peers: SafeSet::new(),
-            reactor,
-            durable: true,
-            policy_agent,
-            system: system_manager,
-            predicate_context: SafeMap::new(),
-            subscription_relay: None,
-            type_resolver: crate::TypeResolver::new(),
-        }));
 
         node.policy_agent.on_node_ready(node.weak());
 
@@ -801,16 +796,25 @@ where
         }
     }
 
-    /// Get a random durable peer node ID
+    /// Get a random durable peer node ID.
+    ///
+    /// Draws from the node's seeded RNG (not `thread_rng`) so the simulation harness can reproduce
+    /// selections. The candidate slice is sorted first: `choose` indexes by position, so a stable
+    /// candidate order is required for a given seed to yield a given peer.
     pub fn get_durable_peer_random(&self) -> Option<proto::EntityId> {
-        let mut rng = rand::thread_rng();
-        // Convert to Vec since DashSet iterator doesn't support random selection
-        let peers: Vec<_> = self.durable_peers.to_vec();
-        peers.choose(&mut rng).copied()
+        let peers = self.get_durable_peers();
+        let mut rng = self.rng.lock().expect("node rng mutex poisoned");
+        peers.choose(&mut *rng).copied()
     }
 
-    /// Get all durable peer node IDs
-    pub fn get_durable_peers(&self) -> Vec<proto::EntityId> { self.durable_peers.to_vec() }
+    /// Get all durable peer node IDs, sorted by id for a stable fan-out order.
+    /// The underlying set is unordered; callers that emit per peer (relay, random selection)
+    /// depend on this stable order for the C1 determinism audit.
+    pub fn get_durable_peers(&self) -> Vec<proto::EntityId> {
+        let mut peers = self.durable_peers.to_vec();
+        peers.sort();
+        peers
+    }
 
     /// TEST ONLY: Create a phantom entity with a specific ID.
     ///
@@ -825,6 +829,15 @@ where
     pub fn conjure_evil_phantom(&self, id: proto::EntityId, collection: proto::CollectionId) -> crate::entity::Entity {
         self.entities.conjure_evil_phantom(id, collection)
     }
+
+    /// TEST ONLY: Register a durable peer id directly, bypassing the connection handshake.
+    ///
+    /// Lets tests populate the durable-peer set to exercise fan-out ordering and seeded random
+    /// selection without standing up real peer connections.
+    ///
+    /// Requires the `test-helpers` feature to be enabled.
+    #[cfg(feature = "test-helpers")]
+    pub fn insert_durable_peer_for_test(&self, peer_id: proto::EntityId) { self.durable_peers.insert(peer_id); }
 }
 
 impl<SE, PA> NodeInner<SE, PA>

--- a/core/src/reactor.rs
+++ b/core/src/reactor.rs
@@ -29,7 +29,7 @@ use crate::{
 use ankurah_proto::{self as proto};
 use futures::future::join_all;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::{Arc, Mutex},
 };
 
@@ -336,8 +336,11 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
 
         tracing::debug!("Reactor.notify_change({} changes)", changes.len());
 
-        // Build per-subscription candidate accumulators (first lock of watcher_set)
-        let mut candidates_by_sub: HashMap<ReactorSubscriptionId, CandidateChanges<C>> = HashMap::new();
+        // Build per-subscription candidate accumulators (first lock of watcher_set).
+        // BTreeMap (not HashMap) so that emission across subscriptions follows a stable,
+        // ReactorSubscriptionId-sorted order. Any order is semantically legal, but the C1
+        // simulation audit requires the same seed to reproduce an identical emission trace.
+        let mut candidates_by_sub: BTreeMap<ReactorSubscriptionId, CandidateChanges<C>> = BTreeMap::new();
         {
             let watcher_set = self.0.watcher_set.lock().unwrap();
             for (offset, change) in changes.iter().enumerate() {
@@ -626,4 +629,81 @@ mod tests {
     // 6. Test index_watchers for field-specific comparisons
     // 7. Test proper cleanup when unsubscribing (all watchers removed)
     // 8. Test multiple subscriptions watching the same entity
+
+    /// A ChangeNotification over the test entity/event types, so notify_change can be driven directly.
+    #[derive(Debug, Clone)]
+    struct TestChange {
+        entity: TestEntity,
+        events: Vec<TestEvent>,
+    }
+    impl std::fmt::Display for TestChange {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "TestChange({})", self.entity.id) }
+    }
+    impl ChangeNotification for TestChange {
+        type Entity = TestEntity;
+        type Event = TestEvent;
+        fn into_parts(self) -> (Self::Entity, Vec<Self::Event>) { (self.entity, self.events) }
+        fn entity(&self) -> &Self::Entity { &self.entity }
+        fn events(&self) -> &[Self::Event] { &self.events }
+    }
+
+    /// notify_change must emit across subscriptions in a stable, id-sorted order.
+    ///
+    /// Any emission order is semantically legal, but the C1 simulation audit requires the same
+    /// inputs to reproduce an identical trace. candidates_by_sub is a BTreeMap keyed on
+    /// ReactorSubscriptionId, so the order is a strict refinement (sorted by subscription id) and
+    /// is identical across runs. Every subscription entity-subscribes to the same entity id, so a
+    /// single change fans out to all of them and their relative emission order is observable.
+    #[tokio::test]
+    async fn test_notify_change_emits_in_stable_subscription_order() {
+        // Shared observer: every subscription pushes its id here as its update is emitted.
+        // Because Broadcast::send runs listeners synchronously and evaluate_changes emits before
+        // returning (no gap fill for entity subscriptions), the push order equals the
+        // candidates_by_sub iteration order.
+        async fn run_once(shared_entity: &TestEntity) -> Vec<ReactorSubscriptionId> {
+            let reactor = Reactor::<TestEntity, TestEvent>::new();
+            let emission_order = Arc::new(Mutex::new(Vec::<ReactorSubscriptionId>::new()));
+
+            // Several subscriptions, all watching the same entity by id. Both the ReactorSubscription
+            // handles and the listen guards must stay alive for the whole run: dropping a
+            // ReactorSubscription unsubscribes it, and dropping a guard detaches its listener.
+            let mut subs = Vec::new();
+            let mut guards = Vec::new();
+            for _ in 0..5 {
+                let rsub = reactor.subscribe();
+                let sub_id = rsub.id();
+                let order = emission_order.clone();
+                let guard = rsub.subscribe(Box::new(move |_update: ReactorUpdate<TestEntity, TestEvent>| {
+                    order.lock().unwrap().push(sub_id);
+                }) as Box<dyn Fn(ReactorUpdate<TestEntity, TestEvent>) + Send + Sync>);
+                reactor.add_entity_subscriptions(sub_id, [shared_entity.id]);
+                guards.push(guard);
+                subs.push(rsub);
+            }
+
+            // A single change on the shared entity fans out to every subscription.
+            let change = TestChange { entity: shared_entity.clone(), events: vec![] };
+            reactor.notify_change(vec![change]).await;
+
+            let observed = emission_order.lock().unwrap().clone();
+            drop(guards);
+            drop(subs);
+            observed
+        }
+
+        let shared_entity = TestEntity::new("Album", "pending");
+        let order1 = run_once(&shared_entity).await;
+        let order2 = run_once(&shared_entity).await;
+
+        assert_eq!(order1.len(), 5, "all subscriptions should be notified");
+
+        // Within a run, the order is the ascending subscription-id sort (BTreeMap refinement),
+        // not a HashMap-arbitrary order.
+        let mut sorted1 = order1.clone();
+        sorted1.sort();
+        assert_eq!(order1, sorted1, "emission order must be sorted by subscription id");
+        let mut sorted2 = order2.clone();
+        sorted2.sort();
+        assert_eq!(order2, sorted2, "emission order must be sorted by subscription id on the second run too");
+    }
 }

--- a/core/src/reactor/watcherset.rs
+++ b/core/src/reactor/watcherset.rs
@@ -3,7 +3,7 @@ use crate::reactor::comparison_index::ComparisonIndex;
 use crate::reactor::property_path::PropertyPath;
 use crate::reactor::{AbstractEntity, ReactorSubscriptionId};
 use ankurah_proto as proto;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 pub struct WatcherSet {
@@ -25,7 +25,7 @@ impl WatcherSet {
         entity: &E,
         offset: usize,
         changes_arc: &Arc<Vec<C>>,
-        candidates_by_sub: &mut HashMap<ReactorSubscriptionId, CandidateChanges<C>>,
+        candidates_by_sub: &mut BTreeMap<ReactorSubscriptionId, CandidateChanges<C>>,
     ) {
         let entity_id = AbstractEntity::id(entity);
 

--- a/tests/tests/durable_peer_determinism.rs
+++ b/tests/tests/durable_peer_determinism.rs
@@ -1,0 +1,97 @@
+//! Determinism of the two node-level durable-peer emission paths (issue #279).
+//!
+//! - `get_durable_peers` must return a stable, id-sorted order so peer fan-out is reproducible.
+//! - `get_durable_peer_random` must draw from the node's seeded RNG, so two nodes seeded
+//!   identically produce an identical selection sequence for identical peer sets.
+//!
+//! These paths are only reachable in multi-durable-peer topologies, which the current smoke
+//! scenarios do not exercise; the C1 simulation audit will arm them for C5.
+
+mod common;
+use ankurah::{proto, Node, PermissiveAgent};
+use ankurah_storage_sled::SledStorageEngine;
+use anyhow::Result;
+use std::sync::Arc;
+
+/// Insert a batch of durable peers into a node via the test-only seam.
+fn seed_peers(node: &Node<SledStorageEngine, PermissiveAgent>, peers: &[proto::EntityId]) {
+    for p in peers {
+        node.insert_durable_peer_for_test(*p);
+    }
+}
+
+/// Path 2: get_durable_peers returns a stable, id-sorted order across repeated calls.
+///
+/// The peers are inserted in a deliberately unsorted sequence; the underlying set is unordered,
+/// so a naive to_vec could surface any order. The returned order must equal the ascending-id sort
+/// and be identical on every call.
+#[tokio::test]
+async fn test_get_durable_peers_is_stable_and_sorted() -> Result<()> {
+    let node = common::durable_sled_setup().await?;
+
+    // Generate several peer ids, then insert them in an order that is not their sorted order.
+    let mut peers: Vec<proto::EntityId> = (0..8).map(|_| proto::EntityId::new()).collect();
+    peers.sort();
+    let mut insertion = peers.clone();
+    insertion.reverse();
+    seed_peers(&node, &insertion);
+
+    let run1 = node.get_durable_peers();
+    let run2 = node.get_durable_peers();
+
+    assert_eq!(run1, run2, "get_durable_peers must be identical across calls");
+    assert_eq!(run1, peers, "get_durable_peers must be sorted ascending by id");
+
+    Ok(())
+}
+
+/// Path 3: get_durable_peer_random draws from the node's seeded RNG.
+///
+/// Two nodes constructed with the same seed and the same peer set must produce an identical
+/// sequence of selections. A run with a different seed must (with overwhelming probability over a
+/// long sequence and a wide peer set) diverge, proving randomness is preserved, not removed.
+#[tokio::test]
+async fn test_get_durable_peer_random_same_seed_same_sequence() -> Result<()> {
+    // Shared peer set; both seeded nodes see the identical set.
+    let peers: Vec<proto::EntityId> = (0..16).map(|_| proto::EntityId::new()).collect();
+
+    let draw_sequence = |seed: u64| -> Vec<proto::EntityId> {
+        let node = Node::new_durable_with_seed(Arc::new(SledStorageEngine::new_test().unwrap()), PermissiveAgent::new(), seed);
+        seed_peers(&node, &peers);
+        (0..64).map(|_| node.get_durable_peer_random().expect("peer set is non-empty")).collect()
+    };
+
+    let seq_a1 = draw_sequence(0xA11CE);
+    let seq_a2 = draw_sequence(0xA11CE);
+    let seq_b = draw_sequence(0xB0B);
+
+    assert_eq!(seq_a1, seq_a2, "same seed and same peer set must yield an identical selection sequence");
+    assert_ne!(seq_a1, seq_b, "a different seed must yield a different sequence (randomness preserved)");
+
+    // Sanity: selection actually varies across the sequence (not pinned to one peer).
+    let distinct: std::collections::HashSet<_> = seq_a1.iter().collect();
+    assert!(distinct.len() > 1, "seeded selection should visit more than one peer over 64 draws");
+
+    Ok(())
+}
+
+/// A node's default (entropy-seeded) construction still selects a valid peer, and selection is
+/// confined to the registered peer set. Guards against the seam accidentally breaking production.
+#[tokio::test]
+async fn test_get_durable_peer_random_default_stays_in_set() -> Result<()> {
+    let node = common::durable_sled_setup().await?;
+    let peers: Vec<proto::EntityId> = (0..4).map(|_| proto::EntityId::new()).collect();
+    seed_peers(&node, &peers);
+
+    let peer_set: std::collections::HashSet<_> = peers.iter().copied().collect();
+    for _ in 0..32 {
+        let picked = node.get_durable_peer_random().expect("peer set is non-empty");
+        assert!(peer_set.contains(&picked), "selected peer must be a registered durable peer");
+    }
+
+    // With no peers, selection yields None rather than panicking.
+    let empty = common::durable_sled_setup().await?;
+    assert!(empty.get_durable_peer_random().is_none(), "no durable peers means no selection");
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #279. Tracking: #269. Prerequisite for phase 2 workstream C5 (reactor and LiveQuery coherence scenarios under the C1 simulation audit, PR #278).

Draft opened per the phase 2 convention. This PR targets the concurrent-updates-event-dag branch while #201 is open; it will be retargeted to main after #201 merges.

Scope:
- Stable iteration for reactor notification candidates and durable-peer fan-out (any order was legal; a stable order is a strict refinement)
- A seedable per-node RNG source behind the existing construction idiom; get_durable_peer_random draws from it (entropy-seeded by default, explicitly seedable for tests and the simulation harness)
- Order-stability and same-seed-same-sequence tests
