### PR TITLE
Remove dead state_name/event_name storage helpers

### DIFF
--- a/core/src/storage.rs
+++ b/core/src/storage.rs
@@ -6,10 +6,6 @@ use tracing::warn;
 use crate::error::{MutationError, RetrievalError};
 use ankurah_proto::{Attested, CollectionId, EntityId, EntityState, Event, EventId};
 
-pub fn state_name(name: &str) -> String { format!("{}_state", name) }
-
-pub fn event_name(name: &str) -> String { format!("{}_event", name) }
-
 #[async_trait]
 pub trait StorageEngine: Send + Sync {
     type Value;

--- a/docs/internals/storage-engines.md
+++ b/docs/internals/storage-engines.md
@@ -85,12 +85,9 @@ is engine-specific -- there is no single scheme enforced across the layer:
   *per-collection* `collection_{id}` tree (sled) or index object stores
   (IndexedDB) holding the materialized, indexable projection used for queries.
 
-`core/src/storage.rs` defines helper functions `state_name()` and
-`event_name()` that produce `{collection}_state` / `{collection}_event`, but
-note that the current engines do not route through them (Postgres/SQLite build
-their own names, and the KV engines use fixed shared-store names); treat those
-helpers as a naming convention rather than the authoritative source of table
-names.
+There is no shared naming helper in the storage layer: each engine builds these
+names inline, so the schemes above describe current engine behavior rather than
+a single convention enforced by common code.
 
 **Write ordering.** The state snapshot and its events are written by different
 calls, and the order matters. The invariant enforced one layer up is: commit


### PR DESCRIPTION
Closes #293.

`state_name()` and `event_name()` in `core/src/storage.rs` produced `{collection}_state` / `{collection}_event` names that no engine actually uses. The real per-engine naming is: Postgres/SQLite name the state table for the bare collection (plus a `{collection}_event` table), while sled/indexeddb use shared `entities`/`events` stores. These dead helpers misled the internals docs twice during the 0.9 docs work.

## Changes
- Delete both functions from `core/src/storage.rs`.
- Rewrite the hedged naming paragraph in `docs/internals/storage-engines.md` to describe per-engine naming without referencing the removed helpers. (The book copy in ankurah.org `src/internals/` is synced separately via `scripts/sync-internals.sh`.)

## Zero-callers verification
Workspace-wide grep (all crates, tests included):
- `state_name`: only the definition. No callers.
- `event_name`: only the definition plus DOM event-listener locals in `storage/indexeddb-wasm/src/util/{cb_stream,cb_future}.rs` (`add/remove_event_listener_with_callback`), which are unrelated strings.
- No re-exports (`pub use`) of either.

## Build
- `cargo check -p ankurah-core`: clean.
- `cargo check` (default-members, the scope CI's `cargo test` uses): clean.

Note: `cargo check --workspace` fails on a pre-existing, unrelated error in `ankurah-jwt-auth` (the `Model` derive hits `recursion limit reached` / `self argument only allowed in impl blocks` when wasm features unify onto the host target). This reproduces on origin/main with this change stashed, so it is not introduced here; CI validates via `cargo test` on default-members, which excludes the wasm crates.