### PR TITLE
fix(node_applier): suppress no-op subscription deltas that emit empty-events Updates

### DIFF
--- a/core/src/node_applier.rs
+++ b/core/src/node_applier.rs
@@ -316,7 +316,7 @@ impl NodeApplier {
                 let attested_state = (delta.entity_id, delta.collection.clone(), state).into();
                 node.policy_agent.validate_received_state(node, from_peer_id, &attested_state)?;
 
-                let (_, entity) = node
+                let (changed, entity) = node
                     .entities
                     .with_state(state_getter, event_getter, delta.entity_id, delta.collection, attested_state.payload.state)
                     .await?;
@@ -324,7 +324,21 @@ impl NodeApplier {
                 // Save state to storage
                 Self::save_state(node, &entity, &collection).await?;
 
-                // Phase 1: Return EntityChange with empty events
+                // Only notify if the snapshot actually advanced the entity. with_state
+                // returns Some(false) when the state did not apply (the entity is
+                // already resident at this head, or the snapshot is older). Emitting a
+                // change here would be spurious: notify_change is global across every
+                // subscription on the node, so a no-op snapshot for one subscribing
+                // query surfaces on ANOTHER already-established query - which holds the
+                // same entity - as an empty-events ItemChange::Update. That is the
+                // subscription-notification race behind the intermittent
+                // server_edits_subscription failure. None (freshly created) and
+                // Some(true) (advanced) are real changes and still notify.
+                if matches!(changed, Some(false)) {
+                    return Ok(None);
+                }
+
+                // Snapshots carry no events, so the change reports an empty events list.
                 Ok(Some(EntityChange::new(entity, Vec::new())?))
             }
 
@@ -343,15 +357,29 @@ impl NodeApplier {
                 // (V4). The producer also sorts, but receivers must not rely
                 // on sender ordering.
                 let attested_events = crate::event_dag::ordering::topo_sort_events(attested_events)?;
+                let mut applied_any = false;
                 for event in attested_events.into_iter() {
-                    entity.apply_event(event_getter, &event.payload).await?;
+                    if entity.apply_event(event_getter, &event.payload).await? {
+                        applied_any = true;
+                    }
                     event_getter.commit_event(&event).await?;
                 }
 
                 // Save updated state
                 Self::save_state(node, &entity, &collection).await?;
 
-                // Phase 1: Return EntityChange with empty events
+                // Only notify if the bridge actually advanced the entity. If every
+                // event was already applied (apply_event returned false for all), the
+                // entity did not change and emitting an EntityChange would surface a
+                // spurious empty-events Update on other subscriptions holding this
+                // entity (see the StateSnapshot arm above). This mirrors the streaming
+                // StateAndEvent fallback, which also only notifies when events applied.
+                if !applied_any {
+                    return Ok(None);
+                }
+
+                // Bridges carry no events on the change itself; the events were applied
+                // above, so the change reports an empty events list.
                 Ok(Some(EntityChange::new(entity, Vec::new())?))
             }
 

--- a/tests/tests/common.rs
+++ b/tests/tests/common.rs
@@ -48,6 +48,131 @@ pub struct Record {
     pub artist: String,
 }
 
+// ---------------------------------------------------------------------------
+// GatedConnection: a LocalProcessConnection variant that lets a test hold
+// selected inbound messages to one node and release them on demand. Used to
+// make subscription-ordering races deterministic (see
+// inter_node::subscription_empty_events_from_noop_delta). Lives in the test
+// crate so the shipped connector keeps its minimal API.
+// ---------------------------------------------------------------------------
+
+use ankurah::core::connector::{PeerSender, SendError};
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+struct GatedSender {
+    sender: mpsc::Sender<proto::NodeMessage>,
+    node_id: proto::EntityId,
+}
+
+#[async_trait::async_trait]
+impl PeerSender for GatedSender {
+    fn send_message(&self, message: proto::NodeMessage) -> Result<(), SendError> {
+        self.sender.try_send(message).map_err(|_| SendError::ConnectionClosed)?;
+        Ok(())
+    }
+    fn recipient_node_id(&self) -> proto::EntityId { self.node_id }
+    fn cloned(&self) -> Box<dyn PeerSender> { Box::new(self.clone()) }
+}
+
+/// Handle for holding/releasing messages the gated side would otherwise deliver.
+#[derive(Clone)]
+pub struct MessageGate {
+    filter: Arc<dyn Fn(&proto::NodeMessage) -> bool + Send + Sync>,
+    held: Arc<Mutex<Vec<proto::NodeMessage>>>,
+}
+
+impl MessageGate {
+    /// Release all currently-held messages back into the gated node, in arrival order.
+    pub async fn release_held<SE, PA>(&self, node: &Node<SE, PA>)
+    where
+        SE: ankurah::core::storage::StorageEngine + Send + Sync + 'static,
+        PA: ankurah::policy::PolicyAgent + Send + Sync + 'static,
+    {
+        let drained: Vec<_> = { self.held.lock().unwrap().drain(..).collect() };
+        for message in drained {
+            let _ = node.handle_message(message).await;
+        }
+    }
+}
+
+/// One-directional gated connection: messages destined for `gated` that match
+/// the filter are parked in the gate instead of being handled, until released.
+/// All other messages (both directions) are handled immediately.
+pub struct GatedConnection {
+    task_a: tokio::task::JoinHandle<()>,
+    task_b: tokio::task::JoinHandle<()>,
+}
+
+impl GatedConnection {
+    /// `other` <-> `gated`. Only messages arriving at `gated` are subject to the gate.
+    pub fn new<SE1, PA1, SE2, PA2>(
+        other: &Node<SE1, PA1>,
+        gated: &Node<SE2, PA2>,
+        filter: impl Fn(&proto::NodeMessage) -> bool + Send + Sync + 'static,
+    ) -> (Self, MessageGate)
+    where
+        SE1: ankurah::core::storage::StorageEngine + Send + Sync + 'static,
+        PA1: ankurah::policy::PolicyAgent + Send + Sync + 'static,
+        SE2: ankurah::core::storage::StorageEngine + Send + Sync + 'static,
+        PA2: ankurah::policy::PolicyAgent + Send + Sync + 'static,
+    {
+        let (other_tx, mut other_rx) = mpsc::channel(1024);
+        let (gated_tx, mut gated_rx) = mpsc::channel(1024);
+
+        other.register_peer(
+            proto::Presence { node_id: gated.id, durable: gated.durable, system_root: gated.system.root() },
+            Box::new(GatedSender { sender: gated_tx, node_id: gated.id }),
+        );
+        gated.register_peer(
+            proto::Presence { node_id: other.id, durable: other.durable, system_root: other.system.root() },
+            Box::new(GatedSender { sender: other_tx, node_id: other.id }),
+        );
+
+        let gate = MessageGate { filter: Arc::new(filter), held: Arc::new(Mutex::new(Vec::new())) };
+
+        // Messages flowing INTO `other` are always handled immediately.
+        let task_a = {
+            let node = other.clone();
+            tokio::spawn(async move {
+                while let Some(message) = other_rx.recv().await {
+                    let node = node.clone();
+                    tokio::spawn(async move {
+                        let _ = node.handle_message(message).await;
+                    });
+                }
+            })
+        };
+
+        // Messages flowing INTO `gated` are parked if they match the filter.
+        let task_b = {
+            let node = gated.clone();
+            let gate = gate.clone();
+            tokio::spawn(async move {
+                while let Some(message) = gated_rx.recv().await {
+                    if (gate.filter)(&message) {
+                        gate.held.lock().unwrap().push(message);
+                        continue;
+                    }
+                    let node = node.clone();
+                    tokio::spawn(async move {
+                        let _ = node.handle_message(message).await;
+                    });
+                }
+            })
+        };
+
+        (Self { task_a, task_b }, gate)
+    }
+}
+
+impl Drop for GatedConnection {
+    fn drop(&mut self) {
+        self.task_a.abort();
+        self.task_b.abort();
+    }
+}
+
 // Initialize tracing for tests
 #[ctor::ctor]
 fn init_tracing() {

--- a/tests/tests/inter_node.rs
+++ b/tests/tests/inter_node.rs
@@ -160,6 +160,103 @@ async fn server_edits_subscription() -> Result<()> {
     Ok(())
 }
 
+// Deterministic red repro for the subscription-notification race behind the
+// intermittent `server_edits_subscription` failure (flaky-test tracker #202).
+//
+// Mechanism: when a query initializes, its QuerySubscribed deltas are applied by
+// NodeApplier::apply_delta_inner. For a StateSnapshot delta it calls
+// entity.with_state(...), which returns Some(false) when the state does NOT
+// advance the entity (already resident at that head). apply_delta_inner discards
+// that flag and unconditionally emits an EntityChange with EMPTY events. Because
+// reactor.notify_change is global across every subscription on the node, that
+// no-op change is delivered to ANOTHER, already-established query that holds the
+// same entity as an ItemChange::Update with an empty events list. On slow
+// runners this spurious empty-events Update wins the race against the real
+// edit-driven Update, producing exactly:
+//     left:  [(id, Update, [])]        right: [(id, Update, [EventId(..)])]
+//
+// The race in production is timing (message ordering across two concurrently
+// initializing subscriptions). Here we make the window explicit and
+// deterministic with a MessageGate that holds query B's QuerySubscribed
+// response until query A is fully established and watching the same entity at
+// the same head. Releasing B's (now no-op) delta must NOT notify query A.
+#[tokio::test]
+async fn subscription_empty_events_from_noop_delta() -> Result<()> {
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test().unwrap()), PermissiveAgent::new());
+    server.system.create().await?;
+    let client = Node::new(Arc::new(SledStorageEngine::new_test().unwrap()), PermissiveAgent::new());
+
+    // Query B's id is not known until we build it, but the gate closure needs to
+    // recognize B's QuerySubscribed response. Share it via an Arc set below.
+    let gate_query_id: Arc<std::sync::Mutex<Option<proto::QueryId>>> = Arc::new(std::sync::Mutex::new(None));
+
+    // Hold QuerySubscribed responses whose query_id matches B, so B's initial
+    // delta is not applied on the client until we explicitly release it.
+    let (_conn, gate) = {
+        let gate_query_id = gate_query_id.clone();
+        GatedConnection::new(&server, &client, move |msg: &proto::NodeMessage| match msg {
+            proto::NodeMessage::Response(resp) => match &resp.body {
+                proto::NodeResponseBody::QuerySubscribed { query_id, .. } => Some(*query_id) == *gate_query_id.lock().unwrap(),
+                _ => false,
+            },
+            _ => false,
+        })
+    };
+    client.system.wait_system_ready().await;
+
+    let server_ctx = server.context(c)?;
+    let client_ctx = client.context(c)?;
+
+    // Create Rex on the server.
+    let rex = {
+        let trx = server_ctx.begin();
+        let rex = trx.create(&Pet { name: "Rex".to_string(), age: "1".to_string() }).await?;
+        let read = rex.read();
+        trx.commit().await?;
+        read
+    };
+
+    let pred = "name = 'Rex'";
+
+    // Query B: start (do NOT wait). Its known_matches are empty (Rex not local
+    // yet) so the server returns a StateSnapshot for Rex - which the gate parks.
+    let query_b = client_ctx.query::<PetView>(nocache(pred)?)?;
+    *gate_query_id.lock().unwrap() = Some(query_b.query_id());
+
+    // Query A: fully establish. Rex is still not local (B's delta is held), so A
+    // gets and applies its own StateSnapshot, making Rex resident at head0 and
+    // registering A's watchers.
+    let query_a = client_ctx.query_wait::<PetView>(nocache(pred)?).await?;
+    assert_eq!(query_a.ids(), vec![rex.id()]);
+
+    let watcher_a = TestWatcher::changeset_with_event_ids();
+    let _handle_a = query_a.subscribe(&watcher_a);
+    assert_eq!(watcher_a.count(), 0); // no notification on subscribe
+
+    // Release B's held delta: a StateSnapshot for Rex at the SAME head A already
+    // holds - a no-op apply (with_state -> Some(false)). This must NOT surface a
+    // spurious empty-events Update on query A's watcher.
+    gate.release_held(&client).await;
+    assert_eq!(
+        watcher_a.quiesce().await,
+        0,
+        "a no-op initial-subscription delta for an already-resident entity must not notify another subscription"
+    );
+
+    // Sanity: the real signal path still works. A genuine edit yields exactly one
+    // Update carrying the writing event id.
+    {
+        let trx = server_ctx.begin();
+        rex.edit(&trx)?.age().overwrite(0, 1, "7")?;
+        trx.commit().await?;
+    }
+    assert_eq!(watcher_a.take_one().await, vec![(rex.id(), ChangeKind::Update, rex.entity().head().to_vec())]);
+    assert_eq!(watcher_a.quiesce().await, 0);
+
+    let _ = query_b; // keep B alive through the assertions
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_client_server_propagation() -> Result<()> {
     // Create server (durable) and two client nodes


### PR DESCRIPTION
## Summary

Fixes the intermittent `server_edits_subscription` failure where the streaming `Update` for an edited entity reaches a subscriber with an EMPTY events list instead of the writing event id:

```
left:  [(id, Update, [])]
right: [(id, Update, [EventId(..)])]
```

## Mechanism

When a query initializes, `NodeApplier::apply_delta_inner` applies its `QuerySubscribed` deltas. For a `StateSnapshot`, it calls `entity.with_state(...)`, which returns `Some(false)` when the state does NOT advance the entity (already resident at that head, or older). `apply_delta_inner` discarded that flag (`let (_, entity) = ...`) and unconditionally emitted an `EntityChange` with empty events (`core/src/node_applier.rs:319,328` on main).

Because `reactor.notify_change` is global across every subscription on a node (`core/src/reactor.rs:330`), that no-op change is delivered to ANOTHER, already-established query that holds the same entity. In the reactor, an already-resident entity with no membership change is emitted as a bare item (`core/src/reactor/subscription_state.rs:423`), which the LiveQuery converts to `ItemChange::Update { events: item.events }` (`core/src/livequery.rs:497`), here with an empty events list.

The two subscriptions in the failing test (`cached_query` and `client_query`, same client node, same reactor) both match `Rex`. When `cached_query`'s no-op snapshot for `Rex` is applied after `client_query` is established and watching, `client_query`'s watcher receives a spurious empty-events `Update`. On slow CI runners this spurious `Update` wins the race against the real edit-driven `Update`, and is what `take_one()` observes.

The same defect exists in the `EventBridge` arm, which also emitted a change even when no event actually applied.

## Where the emptiness originates

At the source, not on the wire or in client assembly. The empty-events change is created by `apply_delta_inner` on the receiving node; the reactor and LiveQuery relay it faithfully. Temporary instrumentation confirmed the sequence: the second (held) `StateSnapshot` for `Rex` applies against an already-resident entity (`change_events=0`, `did_match=true`, `mc=None`) and produces the empty-events `Update` on the other subscription.

## Fix

Honor the change signal at the source (`core/src/node_applier.rs`, 32 insertions / 4 deletions, no public API or wire change):

- `StateSnapshot`: return `Ok(None)` when `with_state` reports `Some(false)` (no advance). `None` (freshly created) and `Some(true)` (advanced) remain real changes.
- `EventBridge`: track whether any event actually applied; return `Ok(None)` when none did. Events are still persisted; only the redundant notification is dropped. This mirrors the streaming `StateAndEvent` fallback, which already only notifies when events applied.

## Repro

`tests/tests/inter_node.rs::subscription_empty_events_from_noop_delta` is a deterministic red test. The production race is message-ordering timing between two concurrently initializing subscriptions; the test makes the window explicit with a test-only gated connection (`MessageGate` in `tests/tests/common.rs`) that holds query B's `QuerySubscribed` response until query A is fully established and watching the same entity at the same head. Releasing B's now no-op delta must not notify query A. The test fails without the fix (`left: 1, right: 0`) and passes with it. It is committed before the fix (red then green).

## CI evidence

Four hits recently with an identical signature across three PRs: #275 (a markdown-only diff), #280, and #285 twice in a row. The markdown-only and two-in-a-row hits confirm the race lives on merged `main` itself, not in any single PR.

`main` and `phase-2` carry byte-identical `node_applier.rs`, `reactor`, `livequery`, and `changes` for this path, so the fix belongs on `main`.

### On #285

Not causal, an incidence-shifter. The bug's source is a discarded `changed` flag in `apply_delta_inner`, which is order-independent; #285's `phase-2-279-determinism` branch carries the identical discard. #285's changes (candidate iteration `HashMap` to `BTreeMap`, durable-peer fan-out ordering, seeded per-node RNG) only change which of the two competing `Rex` `Update`s (the no-op empty one vs. the real edit one) lands first in the subscriber buffer. Deterministic ordering lands the empty one first more often on slow runners, which is why #285 hit 2-for-2 on CI while the race is otherwise occasional.

## Validation

- `cargo test -p ankurah-core`: 192 passed, 0 failed
- `cargo test -p ankurah-tests`: all suites pass (`inter_node` 9/9); `server_edits_subscription` and the new repro: 0 failures in 40 runs
- `cargo test -p ankurah-jwt-auth`: all pass
- `cargo check -p ankurah-core --features wasm`: clean
- `cargo fmt --all -- --check`: clean

References #202 (flaky-test tracker). This removes one specific race in that class; leaving the issue open for the remaining reports.
