### PR TITLE
jwt-auth: fail closed on unknown policy keys and future config versions

### DIFF
--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -36,8 +36,8 @@ impl JwtAgent {
         let path = policy_path.as_ref();
         let json_str =
             std::fs::read_to_string(path).map_err(|e| anyhow::anyhow!("Failed to read policy file {}: {}", path.display(), e))?;
-        let config: PolicyConfig =
-            serde_json::from_str(&json_str).map_err(|e| anyhow::anyhow!("Failed to parse policy config from {}: {}", path.display(), e))?;
+        let config = PolicyConfig::from_json(&json_str)
+            .map_err(|e| anyhow::anyhow!("Failed to load policy config from {}: {}", path.display(), e))?;
         Ok(Self {
             state: Arc::new(RwLock::new(AgentState { config, keys: Some(JwtKeys::Signing(keys)) })),
             policy_path: Some(path.to_path_buf()),

--- a/extensions/jwt-auth/src/agent_state.rs
+++ b/extensions/jwt-auth/src/agent_state.rs
@@ -111,10 +111,13 @@ fn apply_policy_from_resultset(resultset: &EntityResultSet, state: &Arc<RwLock<A
 /// Process a single JwtPolicy view, updating config and keys atomically.
 fn apply_policy_view(view: &crate::JwtPolicyView, state: &Arc<RwLock<AgentState>>) {
     let new_config = match view.config_json() {
-        Ok(json) => match serde_json::from_str::<PolicyConfig>(&json) {
+        // Fail-closed on unknown fields / future version: keep the prior
+        // (deny-all until first sync) config rather than applying a policy
+        // this build may not fully understand.
+        Ok(json) => match PolicyConfig::from_json(&json) {
             Ok(c) => Some(c),
             Err(e) => {
-                tracing::warn!("Ephemeral: failed to parse policy config: {e}");
+                tracing::warn!("Ephemeral: failed to load policy config: {e}");
                 None
             }
         },

--- a/extensions/jwt-auth/src/config.rs
+++ b/extensions/jwt-auth/src/config.rs
@@ -2,12 +2,52 @@ use ankurah_proto::CollectionId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// The policy-schema version this build of the crate understands.
+///
+/// Bump this when the config shape gains a field or semantic that the agent
+/// must actively consume to enforce policy correctly. A config declaring a
+/// higher version is refused at load (see [`PolicyConfig::from_json`]): a
+/// newer policy may rely on a restriction an older agent cannot apply, so
+/// loading it anyway would be a silent fail-open under version skew — exactly
+/// the class of problem this crate must not have as a data-path admission
+/// engine.
+pub const CURRENT_POLICY_VERSION: u32 = 1;
+
+/// Error loading a [`PolicyConfig`] from JSON. Both variants are fail-closed:
+/// an unrecognized key or a future version stops the config from loading
+/// rather than loading a partially-understood policy.
+#[derive(Debug, thiserror::Error)]
+pub enum PolicyConfigError {
+    /// JSON did not parse, or carried an unknown field (`deny_unknown_fields`).
+    #[error("policy config did not parse: {0}")]
+    Parse(#[from] serde_json::Error),
+    /// The config declares a schema version newer than this build supports.
+    #[error(
+        "policy config declares version {found}, but this build supports at most {max}; \
+         refusing to load a policy this agent may not fully enforce"
+    )]
+    UnsupportedVersion { found: u32, max: u32 },
+}
+
 /// Top-level policy configuration.
 ///
 /// Maps roles to their granted privileges, and defines entity access rules
 /// that map privileges to collection operations.
+///
+/// `deny_unknown_fields`: an unrecognized key fails the load rather than being
+/// silently dropped. A policy authored against a newer schema must not appear
+/// to load "successfully" on an older agent with the unknown restriction
+/// quietly missing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PolicyConfig {
+    /// Config schema version. Absent means "legacy / unversioned", treated as
+    /// [`CURRENT_POLICY_VERSION`] for back-compat with configs written before
+    /// this field existed. A value greater than `CURRENT_POLICY_VERSION` is
+    /// refused at load; see [`PolicyConfig::from_json`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u32>,
+
     /// Role name → list of privilege names
     pub roles: HashMap<String, Vec<String>>,
 
@@ -20,6 +60,7 @@ pub struct PolicyConfig {
 /// If `unless_privilege` is set, the filter is skipped when the user holds that privilege.
 /// Multiple scope rules are AND-ed together (fail-closed).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ScopeRule {
     /// AnkQL predicate string with $jwt.* variables (e.g., "assignee = $jwt.sub")
     pub filter: String,
@@ -57,6 +98,7 @@ impl ScopeRuleOp {
 
 /// Access rules for a single collection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CollectionRules {
     /// Privilege required to read entities in this collection (None = no access)
     pub read: Option<String>,
@@ -70,6 +112,30 @@ pub struct CollectionRules {
 }
 
 impl PolicyConfig {
+    /// Parse and validate a policy config from JSON. This is the load path
+    /// every caller should use: it rejects unknown fields
+    /// (`deny_unknown_fields`) and refuses a config whose declared version is
+    /// newer than this build supports. Both failures are fail-closed — the
+    /// config does not load — which is the correct posture for an admission
+    /// engine facing version skew (e.g. a wasm client pinned to a different
+    /// crate version than its server).
+    pub fn from_json(json: &str) -> Result<Self, PolicyConfigError> {
+        let config: PolicyConfig = serde_json::from_str(json)?;
+        config.check_version()?;
+        Ok(config)
+    }
+
+    /// Refuse a config that declares a schema version newer than this build
+    /// supports. An absent version is treated as current (legacy configs).
+    pub fn check_version(&self) -> Result<(), PolicyConfigError> {
+        match self.version {
+            Some(found) if found > CURRENT_POLICY_VERSION => {
+                Err(PolicyConfigError::UnsupportedVersion { found, max: CURRENT_POLICY_VERSION })
+            }
+            _ => Ok(()),
+        }
+    }
+
     /// Check if any of the given roles can access a collection (read or write).
     pub fn can_access_collection(&self, roles: &[String], collection: &CollectionId) -> bool {
         for role in roles {
@@ -151,5 +217,79 @@ impl PolicyConfig {
 
 impl Default for PolicyConfig {
     /// Default config: deny-all (no roles or collections defined).
-    fn default() -> Self { Self { roles: HashMap::new(), collections: HashMap::new() } }
+    fn default() -> Self { Self { version: None, roles: HashMap::new(), collections: HashMap::new() } }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL: &str = r#"{ "roles": {}, "collections": {} }"#;
+
+    #[test]
+    fn loads_a_versionless_config() {
+        // Configs written before the `version` field must still load.
+        let config = PolicyConfig::from_json(MINIMAL).expect("versionless config loads");
+        assert_eq!(config.version, None);
+    }
+
+    #[test]
+    fn loads_a_current_version_config() {
+        let json = format!(r#"{{ "version": {CURRENT_POLICY_VERSION}, "roles": {{}}, "collections": {{}} }}"#);
+        assert!(PolicyConfig::from_json(&json).is_ok());
+    }
+
+    #[test]
+    fn refuses_a_future_version() {
+        let json = format!(r#"{{ "version": {}, "roles": {{}}, "collections": {{}} }}"#, CURRENT_POLICY_VERSION + 1);
+        match PolicyConfig::from_json(&json) {
+            Err(PolicyConfigError::UnsupportedVersion { found, max }) => {
+                assert_eq!(found, CURRENT_POLICY_VERSION + 1);
+                assert_eq!(max, CURRENT_POLICY_VERSION);
+            }
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_an_unknown_top_level_key() {
+        // A newer schema's key must not vanish silently on an older agent.
+        let json = r#"{ "roles": {}, "collections": {}, "future_restriction": ["x"] }"#;
+        assert!(matches!(PolicyConfig::from_json(json), Err(PolicyConfigError::Parse(_))));
+    }
+
+    #[test]
+    fn rejects_an_unknown_nested_key() {
+        // Unknown keys inside a scope rule are equally fail-closed.
+        let json = r#"{
+            "roles": {},
+            "collections": {
+                "task": {
+                    "read": "view",
+                    "write": "edit",
+                    "scope": [{ "filter": "assignee = $jwt.sub", "deny_when": "old.locked" }]
+                }
+            }
+        }"#;
+        assert!(matches!(PolicyConfig::from_json(json), Err(PolicyConfigError::Parse(_))));
+    }
+
+    #[test]
+    fn round_trips_a_realistic_config_including_applies_to() {
+        // Serialize→parse of a config using every current field must succeed —
+        // guards against deny_unknown_fields rejecting our own output.
+        let json = r#"{
+            "roles": { "admin": ["*"], "member": ["view", "edit"] },
+            "collections": {
+                "task": {
+                    "read": "view",
+                    "write": "edit",
+                    "scope": [{ "filter": "assignee = $jwt.sub", "unless_privilege": "task:unscoped", "applies_to": "write" }]
+                }
+            }
+        }"#;
+        let config = PolicyConfig::from_json(json).expect("realistic config loads");
+        let reserialized = serde_json::to_string(&config).expect("serializes");
+        PolicyConfig::from_json(&reserialized).expect("own output round-trips");
+    }
 }


### PR DESCRIPTION
First of the jwt-auth hardening series that came out of idp.to's red team (findings recorded in ankurah#336's sibling review). **For your review — do not merge without a look at the consumer-impact note.**

## Problem

There are zero `deny_unknown_fields` in the tree. An unknown key in a policy JSON deserializes to nothing, so a policy written against a newer schema loads cleanly on an older agent with the new restriction silently missing — fail-open under version skew. idp.to is exposed to exactly this because it pins jwt-auth separately across its wasm client and native server.

## Change

- `#[serde(deny_unknown_fields)]` on `PolicyConfig`, `ScopeRule`, `CollectionRules`.
- An optional `version` field + `CURRENT_POLICY_VERSION`; a config declaring a newer version is refused at load. Absent version = legacy = treated as current (back-compat with every existing config).
- `PolicyConfig::from_json` centralizes parse + version check; both load paths — the durable file read (`new_durable`) and the ephemeral livequery sync (`apply_policy_view`) — now route through it and fail closed (durable errors hard at startup; ephemeral logs and keeps the prior deny-all).
- New `PolicyConfigError` (parse | unsupported-version).

## Tests

6 new config tests: versionless loads, current-version loads, future-version refused, unknown top-level key rejected, unknown nested (scope-rule) key rejected, and a full round-trip of a realistic config using every field (guards against rejecting our own serialized output). Full `ankurah-jwt-auth` suite green (20 unit + integration).

## Consumer-impact callout (the thing to weigh before merge)

After this lands and a consumer bumps the crate, **a policy JSON carrying any extra top-level or nested key will fail to load** where it previously loaded with the key ignored. That's the intended fix, but it's a behavior change at the version boundary. I checked idp.to's own config (`roles`/`collections`; `read`/`write`/`scope`; `filter`/`unless_privilege`/`applies_to`) — no extra keys, so idp is clean. Worth a grep of any other consumer's config before release.

Next in the series (separate PRs): export the `agent_state` sync starters for wrappability; document the both-sides write-scope freeze pattern + the considered-and-rejected transition-guard/livequery-dataset design notes.