### PR TITLE
jwt-auth: export policy-sync starters so JwtAgent is wrappable

### DIFF
--- a/extensions/jwt-auth/src/agent_state.rs
+++ b/extensions/jwt-auth/src/agent_state.rs
@@ -26,8 +26,15 @@ impl<'a> std::ops::Deref for AgentStateReadGuard<'a> {
 
 /// Start durable policy watcher: spawns a background task that watches the policy file
 /// and syncs it to the node.
+///
+/// Exported so an application can **wrap** [`JwtAgent`](crate::JwtAgent) — a
+/// newtype delegating [`PolicyAgent`](ankurah_core::policy::PolicyAgent) while
+/// adding its own checks — and reuse the policy-sync machinery instead of
+/// duplicating it. Pass the inner agent's state handle
+/// ([`JwtAgent::state_handle`](crate::JwtAgent::state_handle)). Generic over
+/// any `PolicyAgent<ContextData = JwtContext>`, so it accepts the wrapper type.
 #[cfg(feature = "watcher")]
-pub(crate) fn start_durable_policy_watcher<SE, PA>(
+pub fn start_durable_policy_watcher<SE, PA>(
     node: ankurah_core::node::WeakNode<SE, PA>,
     policy_path: std::path::PathBuf,
     state_handle: Arc<RwLock<AgentState>>,
@@ -55,7 +62,13 @@ pub(crate) fn start_durable_policy_watcher<SE, PA>(
 /// Start ephemeral policy sync: creates a weak-node LiveQuery on "jwtpolicy" (so the
 /// agent does not keep its own node alive) and spawns a background task that applies
 /// policy updates from the durable node.
-pub(crate) fn start_ephemeral_policy_sync<SE, PA>(
+///
+/// Exported for the same wrapping use case as
+/// [`start_durable_policy_watcher`]: a wrapper passes the inner agent's state
+/// handle ([`JwtAgent::state_handle`](crate::JwtAgent::state_handle)) plus its
+/// own `Arc<Mutex<Option<EntityLiveQuery>>>` cell (which owns the livequery's
+/// lifetime), and gets the standard ephemeral sync without reimplementing it.
+pub fn start_ephemeral_policy_sync<SE, PA>(
     node: &Node<SE, PA>,
     state_handle: Arc<RwLock<AgentState>>,
     policy_livequery: &Arc<Mutex<Option<EntityLiveQuery>>>,

--- a/extensions/jwt-auth/src/lib.rs
+++ b/extensions/jwt-auth/src/lib.rs
@@ -16,6 +16,9 @@ mod watcher;
 uniffi::setup_scaffolding!();
 
 pub use agent::{AgentState, JwtAgent};
+#[cfg(feature = "watcher")]
+pub use agent_state::start_durable_policy_watcher;
+pub use agent_state::start_ephemeral_policy_sync;
 pub use claims::{parse_claims_unverified, JwtClaims};
 pub use config::{PolicyConfig, ScopeRule, ScopeRuleOp};
 pub use context::JwtContext;


### PR DESCRIPTION
Last of the jwt-auth hardening series from idp.to's red team. **Visibility change only, no behavior change.** For your review.

`start_ephemeral_policy_sync` and `start_durable_policy_watcher` were `pub(crate)` but already generic over `PolicyAgent<ContextData = JwtContext>`. Exporting them lets an application **wrap** `JwtAgent` — a newtype delegating `PolicyAgent` while adding its own checks — and reuse the policy-sync machinery instead of duplicating it. The wrapper passes the inner agent's `state_handle()` and, for the ephemeral case, its own `Arc<Mutex<Option<EntityLiveQuery>>>` cell.

This is the enabling change behind 'do it in a wrapper' being a real answer for the app-specific-check features the red team deferred (in the docs PR #339).

Builds clean with and without the `watcher` feature (the durable starter is re-exported under that feature, matching `PolicyWatcher`).

**Candor for review:** there is no in-tree consumer of these exports yet — idp.to would use them when/if it wraps JwtAgent for the RFC-28 custody work, which is still in design. If you'd rather not widen the API surface before a concrete caller exists, holding this one is reasonable; #338 (deny_unknown_fields) and #339 (docs) stand on their own.

Series complete: #338 + #339 + this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed policy synchronization utilities for integration with JWT authentication workflows.
  * Added support for durable policy watching when the watcher feature is enabled.

* **Documentation**
  * Added guidance describing required state and live-query handles for using these utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->