### PR TITLE
ankql: NOT keyword requires an identifier boundary

### DIFF
--- a/ankql/src/ankql.pest
+++ b/ankql/src/ankql.pest
@@ -63,4 +63,8 @@ NotFlag = @{ ^"not" ~ !IDENT_CONT }
 EOF = { EOI | ";" }
 WS = _{ WHITESPACE }
 WHITESPACE = _{ " " | "\t" | "\n" | "\r\n" }
-IDENT_CONT  = _{ ASCII_ALPHANUMERIC | "_" }
+// The continuation set must equal Identifier's own: IdentifierNonDigit
+// admits hyphen and Cyrillic letters, so a guard narrower than the
+// identifier grammar would let a keyword prefix mangle identifiers like
+// not-field.
+IDENT_CONT  = _{ IdentifierNonDigit | ASCII_DIGIT }

--- a/ankql/src/ankql.pest
+++ b/ankql/src/ankql.pest
@@ -55,7 +55,10 @@ OrderByItem = ${ Identifier ~ (WS+ ~ OrderDirection)? }
 OrderDirection = { ^"asc" | ^"desc" }
 LimitClause = ${ ^"limit" ~ WS+ ~ Unsigned }
 
-NotFlag = { ^"not" }
+// Keyword boundary guard like And/Or/True/False/Null above: without it, any
+// identifier STARTING with "not" (note, notes, notify...) lexes as a unary
+// NOT plus a mangled remainder.
+NotFlag = @{ ^"not" ~ !IDENT_CONT }
 
 EOF = { EOI | ";" }
 WS = _{ WHITESPACE }

--- a/ankql/src/parser.rs
+++ b/ankql/src/parser.rs
@@ -437,6 +437,22 @@ mod tests {
         );
     }
 
+    /// Identifiers STARTING with the keyword "not" must parse as identifiers,
+    /// not as a unary NOT plus a mangled remainder (NotFlag carries the same
+    /// !IDENT_CONT boundary guard as the other keywords).
+    #[test]
+    fn test_parse_identifier_starting_with_not() {
+        let selection = parse_selection(r#"note IS NULL"#).unwrap();
+        assert_eq!(selection.predicate, ast::Predicate::IsNull(Box::new(ast::Expr::Path(ast::PathExpr::simple("note".to_string())))));
+
+        let selection = parse_selection(r#"notes = 1"#).unwrap();
+        assert!(matches!(selection.predicate, ast::Predicate::Comparison { .. }));
+
+        // The bare keyword keeps working as unary NOT.
+        let selection = parse_selection(r#"NOT (status = 'x')"#).unwrap();
+        assert!(matches!(selection.predicate, ast::Predicate::Not(_)));
+    }
+
     #[test]
     fn unary_not_parenthesized() {
         let input = r#"NOT (status = 'active')"#;

--- a/ankql/src/parser.rs
+++ b/ankql/src/parser.rs
@@ -445,8 +445,31 @@ mod tests {
         let selection = parse_selection(r#"note IS NULL"#).unwrap();
         assert_eq!(selection.predicate, ast::Predicate::IsNull(Box::new(ast::Expr::Path(ast::PathExpr::simple("note".to_string())))));
 
+        // Assert the complete identifier survived: a loose Comparison match
+        // would also pass on a mangled remainder.
         let selection = parse_selection(r#"notes = 1"#).unwrap();
-        assert!(matches!(selection.predicate, ast::Predicate::Comparison { .. }));
+        assert_eq!(
+            selection.predicate,
+            ast::Predicate::Comparison {
+                left: Box::new(ast::Expr::Path(ast::PathExpr::simple("notes".to_string()))),
+                operator: ast::ComparisonOperator::Equal,
+                right: Box::new(ast::Expr::Literal(ast::Literal::I32(1)))
+            }
+        );
+
+        // The identifier grammar admits hyphens and Cyrillic letters, so the
+        // boundary guard must treat them as identifier continuation too.
+        let selection = parse_selection(r#"not-field = 1"#).unwrap();
+        assert_eq!(
+            selection.predicate,
+            ast::Predicate::Comparison {
+                left: Box::new(ast::Expr::Path(ast::PathExpr::simple("not-field".to_string()))),
+                operator: ast::ComparisonOperator::Equal,
+                right: Box::new(ast::Expr::Literal(ast::Literal::I32(1)))
+            }
+        );
+        let selection = parse_selection("notа IS NULL").unwrap();
+        assert_eq!(selection.predicate, ast::Predicate::IsNull(Box::new(ast::Expr::Path(ast::PathExpr::simple("notа".to_string())))));
 
         // The bare keyword keeps working as unary NOT.
         let selection = parse_selection(r#"NOT (status = 'x')"#).unwrap();


### PR DESCRIPTION
Any identifier starting with "not" (note, notes, notify) lexed as a unary NOT plus a mangled remainder, because NotFlag lacked the !IDENT_CONT boundary guard the other keywords carry. This guards it and pins identifiers-starting-with-not alongside the still-working bare keyword.

Carved out of #307 to shrink that review: this is an independent parser fix with no dependency on the property-metadata work. Once merged, #307 rebases over it and the commit drops out as already applied.

Verification: cherry-picks cleanly onto main; cargo check -p ankql is clean; cargo test -p ankql passes (60 tests, including the new boundary pins). CI completes the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL parsing so the unary `NOT` operator is no longer confused with identifiers starting with “not” (e.g., `note`, `notes`, `notify`, `not-field`, `notа`).
  * Kept existing behavior working for standalone `NOT` expressions like `NOT (status = 'x')`.
* **Tests**
  * Added coverage to ensure “not*” prefixed identifiers parse correctly while valid unary `NOT` syntax continues to parse as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->