### PR TITLE
core: a constant-false predicate installs no watchers

### DIFF
--- a/core/src/reactor/watcherset.rs
+++ b/core/src/reactor/watcherset.rs
@@ -211,7 +211,12 @@ impl WatcherSet {
                 }
             }
             Predicate::False => {
-                unimplemented!("Not sure how to implement this")
+                // Matches nothing, ever: no index or wildcard watcher can make
+                // an entity enter or leave the resultset, so Add installs
+                // nothing and Remove has nothing to tear down. Predicate
+                // algebra can legitimately produce False (fold rules,
+                // assume_null, PolicyAgent::filter_predicate narrowing a
+                // fully-denied principal), so this arm must be well-defined.
             }
             // Placeholder should be transformed before reaching this point
             Predicate::Placeholder => {


### PR DESCRIPTION
WatcherSet's recursive walk panicked with unimplemented! on Predicate::False. A constant-false predicate matches nothing, ever: no index or wildcard watcher can make an entity enter or leave the resultset, so Add installs nothing and Remove has nothing to tear down. Predicate algebra legitimately produces False (fold rules, assume_null, or a policy agent narrowing a fully denied principal), so the arm must be well-defined rather than a panic waiting for the first denied subscriber.

The panic predates the property-metadata work; the fix applies to main as-is. Carved out of #307 to shrink that review; once merged, #307 rebases over it and the commit drops out as already applied.

Verification: cherry-picks cleanly onto main; cargo test -p ankurah-core passes (206 tests). CI completes the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime failures when processing predicates that can never match.
  * Defined consistent “matches nothing” behavior for adding and removing watcher algebra outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->