### PR TITLE
tests: the simulation transport speaks the protocol's own display

### DIFF
--- a/proto/src/request.rs
+++ b/proto/src/request.rs
@@ -206,20 +206,37 @@ impl std::fmt::Display for NodeResponse {
 impl std::fmt::Display for NodeRequestBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NodeRequestBody::CommitTransaction { id, events } => {
-                write!(f, "CommitTransaction {id} [{}]", events.iter().map(|e| format!("{}", e)).collect::<Vec<_>>().join(", "))
+            // `id` (a `TransactionId`) is a fresh ULID minted by `::new()` on
+            // every send (including on every retry of the same commit); it
+            // carries no content of its own. The sorted event ids are a
+            // content hash of (entity_id, operations, parent), so they fully
+            // and stably identify what is being committed, unlike `id`, which
+            // would make two structurally identical commits render
+            // differently. Both the simulation harness's determinism digest
+            // (tests/src/sim/transport.rs) and a human scanning logs want the
+            // latter.
+            NodeRequestBody::CommitTransaction { events, .. } => {
+                let mut ids: Vec<String> = events.iter().map(|e| e.payload.id().to_base64_short()).collect();
+                ids.sort();
+                write!(f, "CommitTransaction [{}]", ids.join(", "))
             }
             NodeRequestBody::Get { collection, ids } => {
-                write!(f, "Get {collection} {}", ids.iter().map(|id| id.to_base64_short()).collect::<Vec<_>>().join(", "))
+                let mut ids: Vec<String> = ids.iter().map(|id| id.to_base64_short()).collect();
+                ids.sort();
+                write!(f, "Get {collection} {}", ids.join(", "))
             }
             NodeRequestBody::GetEvents { collection, event_ids } => {
-                write!(f, "GetEvents {collection} {}", event_ids.iter().map(|id| id.to_base64_short()).collect::<Vec<_>>().join(", "),)
+                let mut ids: Vec<String> = event_ids.iter().map(|id| id.to_base64_short()).collect();
+                ids.sort();
+                write!(f, "GetEvents {collection} {}", ids.join(", "))
             }
             NodeRequestBody::Fetch { collection, selection: query, known_matches } => {
                 write!(f, "Fetch {collection} {query} known:{}", known_matches.len())
             }
-            NodeRequestBody::SubscribeQuery { query_id, collection, selection: query, version, known_matches } => {
-                write!(f, "Subscribe {query_id} {collection} {query} v{version} known:{}", known_matches.len())
+            // `query_id` is excluded for the same reason `CommitTransaction`'s
+            // `id` is above: a fresh per-send ULID, not content.
+            NodeRequestBody::SubscribeQuery { collection, selection: query, version, known_matches, .. } => {
+                write!(f, "Subscribe {collection} {query} v{version} known:{}", known_matches.len())
             }
             NodeRequestBody::RegisterSchema { models } => {
                 write!(f, "RegisterSchema models:{} properties:{}", models.len(), models.iter().map(|m| m.properties.len()).sum::<usize>())
@@ -230,17 +247,23 @@ impl std::fmt::Display for NodeRequestBody {
 impl std::fmt::Display for NodeResponseBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NodeResponseBody::CommitComplete { id } => write!(f, "CommitComplete {id}"),
+            // See `NodeRequestBody::CommitTransaction`: `id` is a per-send ULID.
+            NodeResponseBody::CommitComplete { .. } => write!(f, "CommitComplete"),
             NodeResponseBody::Fetch(deltas) => {
                 write!(f, "Fetch [{}]", deltas.len()) // TODO display deltas
             }
             NodeResponseBody::Get(states) => {
-                write!(f, "Get [{}]", states.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(", "))
+                let mut ids: Vec<String> = states.iter().map(|s| s.payload.entity_id.to_base64_short()).collect();
+                ids.sort();
+                write!(f, "Get [{}]", ids.join(", "))
             }
             NodeResponseBody::GetEvents(events) => {
-                write!(f, "GetEvents [{}]", events.iter().map(|e| e.payload.to_string()).collect::<Vec<_>>().join(", "))
+                let mut ids: Vec<String> = events.iter().map(|e| e.payload.id().to_base64_short()).collect();
+                ids.sort();
+                write!(f, "GetEvents [{}]", ids.join(", "))
             }
-            NodeResponseBody::QuerySubscribed { query_id, deltas: initial } => write!(f, "Subscribed {query_id} initial:{}", initial.len()),
+            // See `NodeRequestBody::SubscribeQuery`: `query_id` is a per-send ULID.
+            NodeResponseBody::QuerySubscribed { deltas: initial, .. } => write!(f, "Subscribed initial:{}", initial.len()),
             NodeResponseBody::SchemaRegistered { models } => {
                 write!(
                     f,

--- a/tests/src/sim/transport.rs
+++ b/tests/src/sim/transport.rs
@@ -91,14 +91,21 @@ pub fn message_digest(message: &proto::NodeMessage) -> String {
 }
 
 /// Canonical, correlation-id-free description of a message's payload.
+///
+/// `Request`/`Response` delegate straight to `NodeRequestBody`'s /
+/// `NodeResponseBody`'s own `Display` (proto/src/request.rs) rather than
+/// hand-maintaining a second, parallel description of each variant: that
+/// duplication is exactly what used to drift whenever a variant changed.
+/// Those `Display` impls are themselves written to be correlation-id-free
+/// (no `TransactionId`/`QueryId`, which are fresh ULIDs per send) and to
+/// render id collections in sorted order, so they satisfy this function's
+/// determinism requirement directly. Only `request`/`response`'s own
+/// wrapper-level ids (`RequestId`, `UpdateId`) are skipped here, by
+/// descending into `.body` instead of formatting the wrapper.
 fn semantic_descriptor(message: &proto::NodeMessage) -> String {
     match message {
-        proto::NodeMessage::Request { request, .. } => {
-            format!("REQ {}", request_descriptor(&request.body))
-        }
-        proto::NodeMessage::Response(response) => {
-            format!("RESP {}", response_descriptor(&response.body))
-        }
+        proto::NodeMessage::Request { request, .. } => format!("REQ {}", request.body),
+        proto::NodeMessage::Response(response) => format!("RESP {}", response.body),
         proto::NodeMessage::Update(update) => {
             let proto::NodeUpdateBody::SubscriptionUpdate { items } = &update.body;
             let mut parts: Vec<String> = items.iter().map(update_item_descriptor).collect();
@@ -107,54 +114,6 @@ fn semantic_descriptor(message: &proto::NodeMessage) -> String {
         }
         proto::NodeMessage::UpdateAck(ack) => format!("ACK {}", matches!(ack.body, proto::NodeUpdateAckBody::Success)),
         proto::NodeMessage::UnsubscribeQuery { .. } => "UNSUB".to_string(),
-    }
-}
-
-fn event_ids(events: &[proto::Attested<proto::Event>]) -> String {
-    let mut ids: Vec<String> = events.iter().map(|e| e.payload.id().to_base64_short()).collect();
-    ids.sort();
-    ids.join("+")
-}
-
-fn request_descriptor(body: &proto::NodeRequestBody) -> String {
-    match body {
-        proto::NodeRequestBody::CommitTransaction { events, .. } => format!("commit {}", event_ids(events)),
-        proto::NodeRequestBody::Get { collection, ids } => {
-            let mut ss: Vec<String> = ids.iter().map(|i| i.to_base64_short()).collect();
-            ss.sort();
-            format!("get {} {}", collection, ss.join("+"))
-        }
-        proto::NodeRequestBody::GetEvents { collection, event_ids } => {
-            let mut ss: Vec<String> = event_ids.iter().map(|i| i.to_base64_short()).collect();
-            ss.sort();
-            format!("getevents {} {}", collection, ss.join("+"))
-        }
-        proto::NodeRequestBody::Fetch { collection, .. } => format!("fetch {}", collection),
-        proto::NodeRequestBody::SubscribeQuery { collection, .. } => format!("subscribe {}", collection),
-        proto::NodeRequestBody::RegisterSchema { models } => {
-            format!("registerschema {}m {}p", models.len(), models.iter().map(|m| m.properties.len()).sum::<usize>())
-        }
-    }
-}
-
-fn response_descriptor(body: &proto::NodeResponseBody) -> String {
-    match body {
-        proto::NodeResponseBody::CommitComplete { .. } => "commitcomplete".to_string(),
-        proto::NodeResponseBody::SchemaRegistered { models } => {
-            format!("schemaregistered {}m {}p", models.len(), models.iter().map(|m| m.properties.len()).sum::<usize>())
-        }
-        proto::NodeResponseBody::Fetch(deltas) => format!("fetch {}", deltas.len()),
-        proto::NodeResponseBody::Get(states) => {
-            let mut ss: Vec<String> = states.iter().map(|s| s.payload.entity_id.to_base64_short()).collect();
-            ss.sort();
-            format!("get [{}]", ss.join("+"))
-        }
-        proto::NodeResponseBody::GetEvents(events) => format!("getevents {}", event_ids(events)),
-        proto::NodeResponseBody::QuerySubscribed { deltas, .. } => format!("subscribed {}", deltas.len()),
-        proto::NodeResponseBody::Success => "success".to_string(),
-        // Include the error text so two distinct rejections are distinguishable
-        // in the trace (advisory path, but keeps the digest faithful).
-        proto::NodeResponseBody::Error(e) => format!("error:{e}"),
     }
 }
 


### PR DESCRIPTION
tests/src/sim/transport.rs had two hand written functions, request_descriptor and response_descriptor, producing a compact description of every NodeRequestBody and NodeResponseBody variant for the simulation harness's message digest. NodeRequestBody and NodeResponseBody already implement Display in proto/src/request.rs, matching over the same variants. The two were bound to drift apart whenever a variant changed, since nothing kept them in sync.

This change deletes request_descriptor, response_descriptor, and the event_ids helper, and has tests/src/sim/transport.rs format request.body and response.body directly through their own Display impls.

Two things in Display needed fixing first. It printed the raw TransactionId on CommitTransaction and the raw QueryId on SubscribeQuery, and the matching NodeResponseBody variants CommitComplete and QuerySubscribed did the same. Both id types are fresh ULIDs minted on every send. The simulation's determinism audit (tests/src/sim/scenario.rs, run_with_determinism_audit) runs one seed twice and requires the two traces to hash identically, and the per message hash is taken over this Display output (tests/src/sim/transport.rs, message_digest). A raw id there would make the same semantic commit hash differently on every run, since the id comes from real time and randomness, not the seeded scheduler. I confirmed this directly: temporarily putting the raw TransactionId back into the CommitTransaction Display arm and running the 500 seed swarm audit (cargo test -p ankurah-tests --test sim_swarm -- --ignored swarm_determinism_audit) failed all 500 seeds. With the id removed it passes at 0 mismatches. Display also rendered the Get and GetEvents id lists in whatever order the caller built them, while the old sim descriptor sorted them first. I kept the sort and moved it into Display. Both fixes live in proto/src/request.rs, so any other caller of these Display impls benefits too, not just the simulation.

Examples of what Display prints now: `CommitTransaction [TX1UOM]` for a commit (sorted, short, content derived event ids, no transaction id), `Subscribe simrecord TRUE v1 known:0` for a subscribe request (no query id), `CommitComplete` with no id, and `Error: boom` for an error response.

No test asserted on the literal text of request_descriptor or response_descriptor, so nothing needed updating for exact strings. tests/tests/sim_digest_check.rs pins the digest's determinism property through the Update path (update_item_descriptor and fragment_ids in tests/src/sim/transport.rs), which this change does not touch. The repository has no golden or log comparison files for this digest. The determinism audit compares two live runs against each other inside one test run, not against a stored value, so there was nothing to regenerate.

Gates run: `cargo check -p ankurah-tests -p ankurah-proto`, `cargo test -p ankurah-proto`, every sim test binary that compiles tests/src/sim/transport.rs (sim_coherence, sim_digest_check, sim_event_dag_shapes, sim_scenarios, sim_smoke, sim_swarm including the ignored 500 seed swarm_determinism_audit, and sim_wire_shapes), and the full default `cargo test -p ankurah-tests` suite. All passed. `cargo fmt` was run and `git status` shows only proto/src/request.rs and tests/src/sim/transport.rs changed.
