### PR TITLE
ci: build taplo-cli with stable rustc

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -17,7 +17,7 @@ jobs:
         run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
       - name: Install Taplo
-        run: cargo install taplo-cli
+        run: cargo +stable install taplo-cli
 
       - name: Check Rust formatting
         run: cargo fmt --all -- --check


### PR DESCRIPTION
The format leg on #420 failed twice in its Install Taplo step, identically, without reading a line of that PR's diff: [first run](https://github.com/ankurah/ankurah/actions/runs/30180102106/job/89735105137), [rerun](https://github.com/ankurah/ankurah/actions/runs/30180102106/job/89735981851). Root cause: rust-toolchain.toml pins the repo to rolling nightly, and cargo install runs inside the checkout, so taplo-cli gets built in release by whatever nightly shipped that day. The 2026-07-25 nightly hits an internal compiler error compiling tokio in release. The same leg was green at 22:17 UTC, before that nightly.

taplo-cli is external tooling and its build was never meant to track the repo toolchain; the one-word +stable override outranks rust-toolchain.toml and scopes only the tool install. The nightly rustfmt component and everything else stay exactly as they were.

This PR's own format leg runs with the fix applied and is the demonstration. Once merged, #420 picks it up with its next push (a plain rerun would reuse the old merge snapshot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the formatting check workflow to install the Taplo CLI using Rust’s stable toolchain for more consistent automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->