### PR TITLE
The catalog eats its own dogfood: typed row models and a self-feeding map

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Check standalone core WASM feature
-        run: cargo check -p ankurah-core --features wasm
+        run: cargo check -p ankurah-core --features wasm --target wasm32-unknown-unknown
 
       - name: Run WASM tests
         run: ./scripts/run-wasm-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown
 
+      - name: Check standalone core WASM feature
+        run: cargo check -p ankurah-core --features wasm
+
       - name: Run WASM tests
         run: ./scripts/run-wasm-tests.sh
         env:

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,20 @@
+# Coding Standards
+
+## Source files state their purpose and vocabulary
+
+Every source file touched by a change must begin with a module-level
+documentation comment (`//!` in Rust, or the language's equivalent) that
+states:
+
+- the file's single overarching purpose;
+- the important nouns it introduces or owns and what each noun means; and
+- any easily confused responsibility that explicitly belongs elsewhere.
+
+Write or revise this block before changing the implementation. It is an
+intention-setting and alignment step, not a description invented after the
+code is finished.
+
+If the purpose and nouns cannot be stated clearly and concisely, stop and
+reorganize the code until the file has a coherent responsibility. Treat a
+missing, vague, or stale purpose block as a structural problem, and keep the
+block current when the file's responsibility changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "futures-signals",
  "futures-timer",
  "futures-util",
+ "getrandom 0.3.4",
  "indexmap 2.12.1",
  "itertools 0.14.0",
  "js-sys",

--- a/core-types/src/lib.rs
+++ b/core-types/src/lib.rs
@@ -10,6 +10,7 @@ mod entity_id;
 mod error;
 mod model_id;
 mod property_id;
+mod unique_id;
 mod value;
 mod value_type;
 
@@ -17,5 +18,6 @@ pub use entity_id::EntityId;
 pub use error::{DecodeError, IdParseError};
 pub use model_id::{ModelId, SystemModel};
 pub use property_id::{PropertyId, SystemProperty};
+pub use unique_id::{UniqueFieldId, UniqueStructId};
 pub use value::{CastError, Value, ValueParseError};
 pub use value_type::ValueType;

--- a/core-types/src/model_id.rs
+++ b/core-types/src/model_id.rs
@@ -1,3 +1,12 @@
+//! Logical model identities shared across Ankurah's runtime and wire layers.
+//!
+//! A [`ModelId`] is the durable address carried by entities and operations:
+//! application models use the entity id of their catalog definition, while a
+//! [`SystemModel`] names one of the closed built-in bootstrap models. This file
+//! owns those value types, their stable serialized shape, and their textual
+//! representation. Resolving source labels to model ids belongs to the schema
+//! catalog; mapping an id to physical storage belongs to the storage layer.
+
 use serde::{Deserialize, Serialize};
 use std::fmt;
 

--- a/core-types/src/model_id.rs
+++ b/core-types/src/model_id.rs
@@ -29,12 +29,12 @@ impl fmt::Display for SystemModel {
 }
 
 /// The durable address of a model. Registered models use their real catalog
-/// entity id; built-ins use a closed logical identity, never a magic id.
+/// entity id; built-ins use a System ID, never a magic entity id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum ModelId {
     /// A user-registered model, identified by its catalog entity.
     EntityId(EntityId),
-    /// A built-in model with a closed logical identity.
+    /// A built-in model addressed by its System ID.
     System(SystemModel),
 }
 

--- a/core-types/src/property_id.rs
+++ b/core-types/src/property_id.rs
@@ -1,3 +1,13 @@
+//! Logical property identities shared across Ankurah's runtime and wire layers.
+//!
+//! A [`PropertyId`] addresses stored values independently of a field's current
+//! source label: registered properties use their catalog entity id, built-in
+//! fields use [`SystemProperty`], and [`PropertyId::Id`] names the entity-id
+//! pseudo-property. This file owns those value types, their stable serialized
+//! shape, and their exact text encoding. Resolving model-local names belongs to
+//! the schema catalog; choosing physical column or CRDT-root names belongs to
+//! storage backends.
+
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;

--- a/core-types/src/property_id.rs
+++ b/core-types/src/property_id.rs
@@ -78,7 +78,7 @@ pub enum PropertyId {
     Id,
     /// A registered property's real catalog entity id.
     EntityId(EntityId),
-    /// A closed built-in property identity.
+    /// A built-in property addressed by its System ID.
     System(SystemProperty),
 }
 

--- a/core-types/src/unique_id.rs
+++ b/core-types/src/unique_id.rs
@@ -1,0 +1,122 @@
+//! Deterministic source-derived identities for compiled models and fields.
+//!
+//! `#[derive(Model)]` computes one of these per struct and per active field,
+//! entirely at compile time, from source names alone: a struct id hashes
+//! `{module_path}::{StructName}` and a field id hashes
+//! `{module_path}::{StructName}::{field_name}`, FNV-1a with 128-bit
+//! parameters over the UTF-8 bytes. The same source names always produce the
+//! same id, on every build and every machine, so the id survives rebuilds,
+//! carries zero runtime cost, and keeps simulation runs byte-deterministic.
+//! Renaming a module, struct, or field changes the id; changing a field's
+//! TYPE does not, which is what a schema-migration hint wants to be true.
+//!
+//! The ids ride schema registration as optional hints. The server accepts
+//! and ignores them today; they exist so a future migration path can
+//! recognize a declaration across renames of everything else.
+
+use serde::{Deserialize, Serialize};
+
+/// The FNV-1a 128-bit offset basis: every hash starts from this value.
+const FNV_OFFSET_BASIS: u128 = 0x6c62272e07bb014262b821756295c58d;
+/// The FNV-1a 128-bit prime multiplier.
+const FNV_PRIME: u128 = 0x0000000001000000000000000000013b;
+
+/// Feed `bytes` through the FNV-1a round function, starting from `hash`:
+/// xor each byte in, then multiply by the prime.
+const fn fnv1a_extend(mut hash: u128, bytes: &[u8]) -> u128 {
+    let mut i = 0;
+    while i < bytes.len() {
+        hash ^= bytes[i] as u128;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+    hash
+}
+
+/// Hash path segments joined by `::` (without materializing the joined
+/// string, which const contexts cannot do).
+const fn hash_segments(segments: &[&str]) -> u128 {
+    let mut hash = FNV_OFFSET_BASIS;
+    let mut i = 0;
+    while i < segments.len() {
+        if i > 0 {
+            hash = fnv1a_extend(hash, b"::");
+        }
+        hash = fnv1a_extend(hash, segments[i].as_bytes());
+        i += 1;
+    }
+    hash
+}
+
+/// A model struct's deterministic source identity: the FNV-1a-128 hash of
+/// `{module_path}::{StructName}`. Computed const by `#[derive(Model)]` with
+/// the expanding crate's own `module_path!()`, so two structs sharing a name
+/// in different modules get distinct ids.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct UniqueStructId(u128);
+
+impl UniqueStructId {
+    /// Hash a struct identity from its module path and declared struct name.
+    pub const fn from_names(module_path: &str, struct_name: &str) -> Self { Self(hash_segments(&[module_path, struct_name])) }
+}
+
+/// A model field's deterministic source identity: the FNV-1a-128 hash of
+/// `{module_path}::{StructName}::{field_name}`. The input is names only, so
+/// the id survives a change of the field's type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct UniqueFieldId(u128);
+
+impl UniqueFieldId {
+    /// Hash a field identity from its module path, declared struct name, and
+    /// declared field name.
+    pub const fn from_names(module_path: &str, struct_name: &str, field_name: &str) -> Self {
+        Self(hash_segments(&[module_path, struct_name, field_name]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The hash is a pure function of its inputs, and its exact output is a
+    /// compatibility surface: these constants were computed independently
+    /// (FNV-1a, 128-bit offset basis and prime, over the `::`-joined names)
+    /// and must never change.
+    #[test]
+    fn hash_values_are_pinned() {
+        assert_eq!(UniqueStructId::from_names("a::b", "C"), UniqueStructId(0x082a2280294ff78da90bfe94e1a13963));
+        assert_eq!(UniqueFieldId::from_names("a::b", "C", "title"), UniqueFieldId(0x66830444d40c6f0182ac989f15e00253));
+        // Deterministic: recomputing yields the identical id.
+        assert_eq!(UniqueStructId::from_names("a::b", "C"), UniqueStructId::from_names("a::b", "C"));
+        assert_eq!(UniqueFieldId::from_names("a::b", "C", "title"), UniqueFieldId::from_names("a::b", "C", "title"));
+    }
+
+    /// Every name segment participates: the same field name under a
+    /// different module or struct, and a different field under the same
+    /// module and struct, all get distinct ids.
+    #[test]
+    fn every_segment_distinguishes() {
+        // Same struct and field names, different module.
+        assert_ne!(
+            UniqueFieldId::from_names("crate_a::rows", "Album", "title"),
+            UniqueFieldId::from_names("crate_b::rows", "Album", "title")
+        );
+        // Same module and struct, different field.
+        assert_ne!(
+            UniqueFieldId::from_names("crate_a::rows", "Album", "title"),
+            UniqueFieldId::from_names("crate_a::rows", "Album", "year")
+        );
+        // Same module and field, different struct.
+        assert_ne!(
+            UniqueFieldId::from_names("crate_a::rows", "Album", "title"),
+            UniqueFieldId::from_names("crate_a::rows", "Track", "title")
+        );
+        // Struct ids distinguish by module too.
+        assert_ne!(UniqueStructId::from_names("crate_a::rows", "Album"), UniqueStructId::from_names("crate_b::rows", "Album"));
+        // The separator keeps segment boundaries unambiguous: ("a::b", "C")
+        // and ("a", "b::C") produce the same joined string BY DESIGN (both
+        // name the path a::b::C); shifting a name across the boundary
+        // without reproducing the path does change the id.
+        assert_ne!(UniqueStructId::from_names("a::b", "C"), UniqueStructId::from_names("a::bC", ""));
+    }
+}

--- a/core-types/src/unique_id.rs
+++ b/core-types/src/unique_id.rs
@@ -12,7 +12,8 @@
 //!
 //! The ids ride schema registration as optional hints. The server accepts
 //! and ignores them today; they exist so a future migration path can
-//! recognize a declaration across renames of everything else.
+//! recognize a declaration by its source names when everything else about
+//! it has changed.
 
 use serde::{Deserialize, Serialize};
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -68,6 +68,9 @@ lru                  = "0.12"
 base64               = { version = "0.22" }
 uniffi               = { version = "0.29", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+
 [dev-dependencies]
 maplit         = "1.0"
 ankurah-derive = { path = "../derive", version = "=0.9.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,10 +17,9 @@ wasm = [
     "send_wrapper",
     "ankql/wasm",
     "ankurah-proto/wasm",
-    "ankurah-derive",
     "futures-timer/wasm-bindgen",
 ]
-uniffi = ["dep:uniffi", "ankurah-proto/uniffi", "ankurah-derive"]
+uniffi = ["dep:uniffi", "ankurah-proto/uniffi"]
 default = []
 instrument = []
 # Enables test helper methods for adversarial testing (e.g., creating phantom entities)
@@ -33,7 +32,7 @@ bench-internals = []
 
 [dependencies]
 # Internal dependencies
-ankurah-derive     = { path = "../derive", optional = true, version = "=0.9.0" }
+ankurah-derive     = { path = "../derive", version = "=0.9.0" }
 ankql              = { path = "../ankql", version = "=0.9.0" }
 ankurah-core-types = { path = "../core-types", version = "=0.9.0" }
 ankurah-proto      = { path = "../proto", version = "=0.9.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ repository    = "https://github.com/ankurah/ankurah"
 
 [features]
 wasm = [
+    "ankurah-derive/wasm",
     "wasm-bindgen",
     "wasm-bindgen-futures",
     "serde-wasm-bindgen",

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -75,8 +75,8 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         schema: &'static crate::schema::ModelStructDescriptor,
     ) -> Result<proto::ModelId, crate::schema::registration::RegistrationError> {
         // System models are pre-registered by definition: their identity is
-        // closed and compile-time, so no path here ever consults the catalog
-        // they describe.
+        // a compile-time System ID, so no path here ever consults the
+        // catalog they describe.
         if let Some(system) = schema.system {
             return Ok(proto::ModelId::System(system));
         }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -74,6 +74,12 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         &self,
         schema: &'static crate::schema::ModelStructDescriptor,
     ) -> Result<proto::ModelId, crate::schema::registration::RegistrationError> {
+        // System models are pre-registered by definition: their identity is
+        // closed and compile-time, so no path here ever consults the catalog
+        // they describe.
+        if let Some(system) = schema.system {
+            return Ok(proto::ModelId::System(system));
+        }
         self.node.catalog.ensure_schema_for_use(&self.cdata, schema).await
     }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,18 +1,19 @@
 //! A caller-scoped interface to one node.
 //!
-//! Here, a **context** means a [`crate::node::Node`] paired with the
-//! [`crate::policy::PolicyAgent::ContextData`] that must accompany every
-//! operation on behalf of one caller. It accepts typed fetch, live-query,
-//! entity-creation, and transaction requests; it ensures the relevant
-//! compiled schema is bound to this system, applies caller-specific policy,
-//! and delegates storage and replication to the node.
+//! Here, a **context** is the authority under which typed operations run on
+//! one [`crate::node::Node`]. A normal context pairs the node with one
+//! [`crate::policy::PolicyAgent::ContextData`] and applies caller policy. A
+//! **system-root context** is a core-only capability, constructible only for
+//! a durable node, that bypasses the application policy authority for the
+//! node's own system models. Both use the same fetch, live-query, model, and
+//! transaction machinery.
 //!
 //! [`Context`] is the public, generic-erased handle. [`NodeAndContext`] is
-//! the concrete implementation that retains the node and context data, while
-//! [`TContext`] is their object-safe boundary. Local transaction admission
+//! the concrete implementation that retains the node and its authority,
+//! while [`TContext`] is their object-safe boundary. Local transaction admission
 //! belongs here because this is the last caller-scoped boundary before events
 //! enter the node's trusted commit pipeline; protected system collections
-//! must never cross it as ordinary user writes.
+//! must never cross it as ordinary application writes.
 
 use crate::retrieval::SuspenseEvents;
 use crate::{
@@ -49,7 +50,15 @@ where
     PA: PolicyAgent + Send + Sync + 'static,
 {
     pub node: Node<SE, PA>,
-    pub cdata: PA::ContextData,
+    context_type: ContextType<PA::ContextData>,
+}
+
+/// The authority behind a Context. A Session carries application context
+/// data; SystemRoot is deliberately not a session and carries no application
+/// credentials.
+enum ContextType<CD> {
+    Session(CD),
+    SystemRoot,
 }
 
 #[async_trait]
@@ -96,7 +105,12 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         if let Some(system) = schema.system {
             return Ok(proto::ModelId::System(system));
         }
-        self.node.catalog.ensure_schema_for_use(&self.cdata, schema).await
+        match &self.context_type {
+            ContextType::Session(cdata) => self.node.catalog.ensure_schema_for_use(cdata, schema).await,
+            ContextType::SystemRoot => {
+                Err(crate::schema::registration::RegistrationError::SystemRootApplicationModel(schema.label.to_owned()))
+            }
+        }
     }
 
     fn node_id(&self) -> proto::EntityId { self.node.id }
@@ -104,7 +118,12 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         let primary_entity = self.node.entities.create(collection);
         primary_entity.snapshot(trx_alive)
     }
-    fn check_write(&self, entity: &Entity) -> Result<(), AccessDenied> { self.node.policy_agent.check_write(&self.cdata, entity, None) }
+    fn check_write(&self, entity: &Entity) -> Result<(), AccessDenied> {
+        match &self.context_type {
+            ContextType::Session(cdata) => self.node.policy_agent.check_write(cdata, entity, None),
+            ContextType::SystemRoot => Ok(()),
+        }
+    }
     async fn get_entity(&self, id: proto::EntityId, collection: &proto::CollectionId, cached: bool) -> Result<Entity, RetrievalError> {
         self.get_entity(collection, id, cached).await
     }
@@ -113,132 +132,136 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         self.fetch_entities(collection, args).await
     }
     async fn commit_local_trx(&self, trx: &Transaction) -> Result<Vec<Event>, MutationError> {
-        use std::sync::atomic::Ordering;
-
-        // Atomically mark transaction as no longer alive, preventing double-commit.
-        // compare_exchange returns Err if the value was already false (already committed/rolled back).
-        if trx.alive.compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire).is_err() {
-            return Err(MutationError::General("Transaction already committed or rolled back".into()));
-        }
-
-        // Generate events from the transaction entities
-        let trx_id = trx.id.clone();
-        let mut entity_events = Vec::new();
-        for entity in trx.entities.iter() {
-            if let Some(event) = entity.generate_commit_event()? {
-                let collection = event.collection.as_str();
-                if collection.starts_with(crate::schema::RESERVED_COLLECTION_PREFIX) {
-                    return Err(MutationError::General(
-                        format!("collection '{collection}' is protected and not writable by transactions").into(),
-                    ));
-                }
-                // Validate creation events: if parent is empty, this is a creation event
-                // and the entity must have been created in this transaction via create()
-                if event.is_entity_create() {
-                    let created_ids = trx.created_entity_ids.read().unwrap();
-                    if !created_ids.contains(&entity.id) {
-                        return Err(MutationError::General(
-                            format!(
-                                "Cannot commit phantom entity {}: entity has empty parent (creation event) \
-                             but was not created in this transaction via create()",
-                                entity.id
-                            )
-                            .into(),
-                        ));
-                    }
-                }
-                // Membership admissibility is a commit-path gate, mirrored on
-                // the remote funnel (commit_remote_transaction).
-                self.node.check_membership_admissibility(&event)?;
-                entity_events.push((entity.clone(), event));
-            }
-        }
-
-        // Now commit the events
-        let mut attested_events = Vec::new();
-        let mut entity_attested_events = Vec::new();
-
-        // Phase 1: check policy and collect attestations for EVERY event
-        // before persisting ANY of them, so a later denial leaves nothing
-        // durable (failure atomicity, V7).
-        for (entity, event) in entity_events {
-            // Create a temporary fork to apply the event for validation
-            use std::sync::atomic::AtomicBool;
-            let trx_alive = Arc::new(AtomicBool::new(true));
-            let forked = entity.snapshot(trx_alive);
-
-            // Get the canonical (upstream) entity for before state
-            let entity_before = match &entity.kind {
-                crate::entity::EntityKind::Transacted { upstream, .. } => upstream.clone(),
-                crate::entity::EntityKind::Primary => entity.clone(),
-            };
-
-            // Stage event and apply to fork for after state (no commit_event call here)
-            let collection_id = &event.collection;
-            let collection = self.node.collections.get(collection_id).await?;
-            let event_getter = crate::retrieval::LocalEventGetter::new(collection, self.node.durable);
-            event_getter.stage_event(event.clone());
-            forked.apply_event(&event_getter, &event).await?;
-
-            let attestation = self.node.policy_agent.check_event(&self.node, &self.cdata, &entity_before, &forked, &event)?;
-            let attested = Attested::opt(event.clone(), attestation);
-
-            attested_events.push(attested.clone());
-            entity_attested_events.push((entity, attested));
-        }
-
-        // Phase 2: all events attested; persist them.
-        for (_, attested) in &entity_attested_events {
-            let collection = self.node.collections.get(&attested.payload.collection).await?;
-            let event_getter = crate::retrieval::LocalEventGetter::new(collection, self.node.durable);
-            event_getter.commit_event(attested).await?;
-        }
-
-        // Update heads BEFORE relaying (makes entities visible to server echo)
-        for (entity, attested_event) in &entity_attested_events {
-            entity.commit_head(Clock::new([attested_event.payload.id()]));
-        }
-        // Relay to peers and wait for confirmation
-        self.node.relay_to_required_peers(&self.cdata, trx_id, &attested_events).await?;
-
-        // All peers confirmed, persist state to storage
-        let mut changes: Vec<EntityChange> = Vec::new();
-        for (entity, attested_event) in entity_attested_events {
-            let collection_id = &attested_event.payload.collection;
-            let collection = self.node.collections.get(collection_id).await?;
-
-            // Persist canonical entity (upstream for transactional forks, entity itself for primary)
-            let canonical_entity = match &entity.kind {
-                crate::entity::EntityKind::Transacted { upstream, .. } => {
-                    // Event is now in storage, construct fresh getter for upstream apply
-                    let event_getter = crate::retrieval::LocalEventGetter::new(collection.clone(), self.node.durable);
-                    upstream.apply_event(&event_getter, &attested_event.payload).await?;
-                    upstream.clone()
-                }
-                crate::entity::EntityKind::Primary => entity,
-            };
-
-            let state = canonical_entity.to_state()?;
-
-            let entity_state = EntityState { entity_id: canonical_entity.id(), collection: canonical_entity.collection().clone(), state };
-            let attestation = self.node.policy_agent.attest_state(&self.node, &entity_state);
-            let attested = Attested::opt(entity_state, attestation);
-            collection.set_state(attested).await?;
-
-            changes.push(EntityChange::new(canonical_entity, vec![attested_event])?);
-        }
-
-        // Notify reactor of ALL changes
-        self.node.reactor.notify_change(changes).await;
-
-        Ok(attested_events.into_iter().map(|a| a.payload).collect())
+        let authority = match &self.context_type {
+            ContextType::Session(cdata) => CommitAuthority::Session(cdata),
+            ContextType::SystemRoot => CommitAuthority::SystemRoot,
+        };
+        commit_local_transaction(&self.node, trx, authority).await
     }
     fn query(&self, collection_id: proto::CollectionId, args: MatchArgs) -> Result<EntityLiveQuery, RetrievalError> {
-        EntityLiveQuery::new(&self.node, collection_id, args, self.cdata.clone())
+        match &self.context_type {
+            ContextType::Session(cdata) => EntityLiveQuery::new(&self.node, collection_id, args, cdata.clone()),
+            ContextType::SystemRoot => EntityLiveQuery::new_system_root_weak_node(&self.node, collection_id, args),
+        }
     }
     async fn collection(&self, id: &proto::CollectionId) -> Result<StorageCollectionWrapper, RetrievalError> {
         self.node.system.collection(id).await
     }
+}
+
+#[derive(Clone, Copy)]
+enum CommitAuthority<'a, C> {
+    Session(&'a C),
+    SystemRoot,
+}
+
+/// Commit one ordinary typed transaction under either caller authority or
+/// the node's local system-root capability. The entity/event/storage/reactor
+/// path is shared; only application policy, protected-collection admission,
+/// state attestation, and session-authenticated relay differ.
+async fn commit_local_transaction<SE, PA>(
+    node: &Node<SE, PA>,
+    trx: &Transaction,
+    authority: CommitAuthority<'_, PA::ContextData>,
+) -> Result<Vec<Event>, MutationError>
+where
+    SE: StorageEngine + Send + Sync + 'static,
+    PA: PolicyAgent + Send + Sync + 'static,
+{
+    use std::sync::atomic::Ordering;
+
+    if trx.alive.compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire).is_err() {
+        return Err(MutationError::General("Transaction already committed or rolled back".into()));
+    }
+
+    let trx_id = trx.id.clone();
+    let mut entity_events = Vec::new();
+    for entity in trx.entities.iter() {
+        if let Some(event) = entity.generate_commit_event()? {
+            if matches!(authority, CommitAuthority::Session(_))
+                && event.collection.as_str().starts_with(crate::schema::RESERVED_COLLECTION_PREFIX)
+            {
+                return Err(MutationError::General(
+                    format!("collection '{}' is protected and not writable by application transactions", event.collection).into(),
+                ));
+            }
+            if event.is_entity_create() {
+                let created_ids = trx.created_entity_ids.read().unwrap();
+                if !created_ids.contains(&entity.id) {
+                    return Err(MutationError::General(
+                        format!(
+                            "Cannot commit phantom entity {}: entity has empty parent (creation event) \
+                             but was not created in this transaction via create()",
+                            entity.id
+                        )
+                        .into(),
+                    ));
+                }
+            }
+            node.check_membership_admissibility(&event)?;
+            entity_events.push((entity.clone(), event));
+        }
+    }
+
+    let mut attested_events = Vec::new();
+    let mut entity_attested_events = Vec::new();
+    for (entity, event) in entity_events {
+        let trx_alive = Arc::new(AtomicBool::new(true));
+        let forked = entity.snapshot(trx_alive);
+        let entity_before = match &entity.kind {
+            crate::entity::EntityKind::Transacted { upstream, .. } => upstream.clone(),
+            crate::entity::EntityKind::Primary => entity.clone(),
+        };
+        let collection = node.collections.get(&event.collection).await?;
+        let event_getter = crate::retrieval::LocalEventGetter::new(collection, node.durable);
+        event_getter.stage_event(event.clone());
+        forked.apply_event(&event_getter, &event).await?;
+
+        let attestation = match authority {
+            CommitAuthority::Session(cdata) => node.policy_agent.check_event(node, cdata, &entity_before, &forked, &event)?,
+            CommitAuthority::SystemRoot => None,
+        };
+        let attested = Attested::opt(event.clone(), attestation);
+        attested_events.push(attested.clone());
+        entity_attested_events.push((entity, attested));
+    }
+
+    for (_, attested) in &entity_attested_events {
+        let collection = node.collections.get(&attested.payload.collection).await?;
+        let event_getter = crate::retrieval::LocalEventGetter::new(collection, node.durable);
+        event_getter.commit_event(attested).await?;
+    }
+
+    for (entity, attested_event) in &entity_attested_events {
+        entity.commit_head(Clock::new([attested_event.payload.id()]));
+    }
+    if let CommitAuthority::Session(cdata) = authority {
+        node.relay_to_required_peers(cdata, trx_id, &attested_events).await?;
+    }
+
+    let mut changes: Vec<EntityChange> = Vec::new();
+    for (entity, attested_event) in entity_attested_events {
+        let collection = node.collections.get(&attested_event.payload.collection).await?;
+        let canonical_entity = match &entity.kind {
+            crate::entity::EntityKind::Transacted { upstream, .. } => {
+                let event_getter = crate::retrieval::LocalEventGetter::new(collection.clone(), node.durable);
+                upstream.apply_event(&event_getter, &attested_event.payload).await?;
+                upstream.clone()
+            }
+            crate::entity::EntityKind::Primary => entity,
+        };
+        let state = canonical_entity.to_state()?;
+        let entity_state = EntityState { entity_id: canonical_entity.id(), collection: canonical_entity.collection().clone(), state };
+        let attestation = match authority {
+            CommitAuthority::Session(_) => node.policy_agent.attest_state(node, &entity_state),
+            CommitAuthority::SystemRoot => None,
+        };
+        collection.set_state(Attested::opt(entity_state, attestation)).await?;
+        changes.push(EntityChange::new(canonical_entity, vec![attested_event])?);
+    }
+
+    node.reactor.notify_change(changes).await;
+    Ok(attested_events.into_iter().map(|a| a.payload).collect())
 }
 
 // This whole impl is conditionalized by the wasm feature flag
@@ -276,7 +299,22 @@ impl Context {
         node: Node<SE, PA>,
         data: PA::ContextData,
     ) -> Self {
-        Self(Arc::new(NodeAndContext { node, cdata: data }))
+        Self(Arc::new(NodeAndContext::new_session(node, data)))
+    }
+
+    /// Construct the core-only authority for a durable node's own system
+    /// models. It is crate-private and refuses ephemeral nodes, so neither an
+    /// application nor a remote request can turn ordinary credentials into
+    /// system-root authority.
+    pub(crate) fn new_system_root<SE, PA>(node: Node<SE, PA>) -> Result<Self, RetrievalError>
+    where
+        SE: StorageEngine + Send + Sync + 'static,
+        PA: PolicyAgent + Send + Sync + 'static,
+    {
+        if !node.durable {
+            return Err(RetrievalError::Other("a SystemRoot context requires a durable node".to_owned()));
+        }
+        Ok(Self(Arc::new(NodeAndContext { node, context_type: ContextType::SystemRoot })))
     }
 
     pub fn node_id(&self) -> proto::EntityId { self.0.node_id() }
@@ -367,6 +405,17 @@ where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
+    pub(crate) fn new_session(node: Node<SE, PA>, cdata: PA::ContextData) -> Self {
+        Self { node, context_type: ContextType::Session(cdata) }
+    }
+
+    fn session_cdata(&self) -> Option<&PA::ContextData> {
+        match &self.context_type {
+            ContextType::Session(cdata) => Some(cdata),
+            ContextType::SystemRoot => None,
+        }
+    }
+
     /// Retrieve a single entity, either by cloning the resident Entity from the Node's WeakEntitySet or fetching from storage
     pub(crate) async fn get_entity(
         &self,
@@ -376,9 +425,23 @@ where
     ) -> Result<Entity, RetrievalError> {
         debug!("Node({}).get_entity {:?}-{:?}", self.node.id, id, collection_id);
 
+        if matches!(&self.context_type, ContextType::SystemRoot) {
+            if let Some(local) = self.node.entities.get(&id).filter(|entity| entity.collection() == collection_id) {
+                return Ok(local);
+            }
+            let collection = self.node.collections.get(collection_id).await?;
+            let state = collection.get_state(id).await?;
+            let state_getter = crate::retrieval::LocalStateGetter::new(collection.clone());
+            let event_getter = crate::retrieval::LocalEventGetter::new(collection, true);
+            let (_, entity) =
+                self.node.entities.with_state(&state_getter, &event_getter, id, collection_id.clone(), state.payload.state).await?;
+            return Ok(entity);
+        }
+        let cdata = self.session_cdata().expect("session contexts carry ContextData");
+
         if !self.node.durable {
             // Fetch from peers and commit first response
-            match self.node.get_from_peer(collection_id, vec![id], &self.cdata).await {
+            match self.node.get_from_peer(collection_id, vec![id], cdata).await {
                 Ok(_) => (),
                 Err(RetrievalError::NoDurablePeers) if cached => (),
                 Err(e) => {
@@ -387,11 +450,11 @@ where
             }
         }
 
-        if let Some(local) = self.node.entities.get(&id) {
+        if let Some(local) = self.node.entities.get(&id).filter(|entity| entity.collection() == collection_id) {
             debug!("Node({}).get_entity found local entity - returning", self.node.id);
             let state = local.to_state()?;
             let entity_id = local.id();
-            self.node.policy_agent.check_read(&self.cdata, &entity_id, collection_id, &state)?;
+            self.node.policy_agent.check_read(cdata, &entity_id, collection_id, &state)?;
             return Ok(local);
         }
         debug!("{}.get_entity fetching from storage", self.node);
@@ -399,14 +462,9 @@ where
         let collection = self.node.collections.get(collection_id).await?;
         match collection.get_state(id).await {
             Ok(entity_state) => {
-                self.node.policy_agent.check_read(
-                    &self.cdata,
-                    &entity_state.payload.entity_id,
-                    collection_id,
-                    &entity_state.payload.state,
-                )?;
+                self.node.policy_agent.check_read(cdata, &entity_state.payload.entity_id, collection_id, &entity_state.payload.state)?;
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection.clone());
-                let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection, &self.node, &self.cdata);
+                let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection, &self.node, cdata);
                 let (_changed, entity) = self
                     .node
                     .entities
@@ -419,10 +477,15 @@ where
     }
     /// Fetch a list of entities based on a selection
     pub async fn fetch_entities(&self, collection_id: &CollectionId, mut args: MatchArgs) -> Result<Vec<Entity>, RetrievalError> {
-        self.node.policy_agent.can_access_collection(&self.cdata, collection_id)?;
+        if matches!(&self.context_type, ContextType::SystemRoot) {
+            args.selection = self.node.type_resolver.resolve_selection_types(args.selection);
+            return self.node.fetch_entities_from_local(collection_id, &args.selection).await;
+        }
+        let cdata = self.session_cdata().expect("session contexts carry ContextData");
+        self.node.policy_agent.can_access_collection(cdata, collection_id)?;
         // Fetch raw states from storage
 
-        args.selection.predicate = self.node.policy_agent.filter_predicate(&self.cdata, collection_id, args.selection.predicate)?;
+        args.selection.predicate = self.node.policy_agent.filter_predicate(cdata, collection_id, args.selection.predicate)?;
 
         // Resolve types in the AST (converts literals for JSON path comparisons)
         args.selection = self.node.type_resolver.resolve_selection_types(args.selection);
@@ -430,7 +493,7 @@ where
         // TODO implement cached: true
         if !self.node.durable {
             // Fetch from peers and commit first response
-            Ok(self.fetch_from_peer(collection_id, args.selection).await?)
+            Ok(self.fetch_from_peer(collection_id, args.selection, cdata).await?)
         } else {
             let storage_collection = self.node.collections.get(collection_id).await?;
             let states = storage_collection.fetch_states(&args.selection).await?;
@@ -438,7 +501,7 @@ where
             // Convert states to entities
             let mut entities = Vec::new();
             let state_getter = crate::retrieval::LocalStateGetter::new(storage_collection.clone());
-            let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), storage_collection, &self.node, &self.cdata);
+            let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), storage_collection, &self.node, cdata);
             for state in states {
                 let (_, entity) = self
                     .node
@@ -456,6 +519,7 @@ where
         &self,
         collection_id: &proto::CollectionId,
         selection: ankql::ast::Selection,
+        cdata: &PA::ContextData,
     ) -> Result<Vec<crate::entity::Entity>, RetrievalError> {
         let peer_id = self.node.get_durable_peer_random().ok_or(RetrievalError::NoDurablePeers)?;
 
@@ -471,13 +535,12 @@ where
         let selection_clone = selection.clone();
         match self
             .node
-            .request(peer_id, &self.cdata, proto::NodeRequestBody::Fetch { collection: collection_id.clone(), selection, known_matches })
+            .request(peer_id, cdata, proto::NodeRequestBody::Fetch { collection: collection_id.clone(), selection, known_matches })
             .await?
         {
             proto::NodeResponseBody::Fetch(deltas) => {
                 let collection = self.node.collections.get(collection_id).await?;
-                let event_getter =
-                    crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection.clone(), &self.node, &self.cdata);
+                let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection.clone(), &self.node, cdata);
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection);
 
                 // 3. Apply deltas to local storage using NodeApplier

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,3 +1,19 @@
+//! A caller-scoped interface to one node.
+//!
+//! Here, a **context** means a [`crate::node::Node`] paired with the
+//! [`crate::policy::PolicyAgent::ContextData`] that must accompany every
+//! operation on behalf of one caller. It accepts typed fetch, live-query,
+//! entity-creation, and transaction requests; it ensures the relevant
+//! compiled schema is bound to this system, applies caller-specific policy,
+//! and delegates storage and replication to the node.
+//!
+//! [`Context`] is the public, generic-erased handle. [`NodeAndContext`] is
+//! the concrete implementation that retains the node and context data, while
+//! [`TContext`] is their object-safe boundary. Local transaction admission
+//! belongs here because this is the last caller-scoped boundary before events
+//! enter the node's trusted commit pipeline; protected system collections
+//! must never cross it as ordinary user writes.
+
 use crate::retrieval::SuspenseEvents;
 use crate::{
     changes::EntityChange,
@@ -110,6 +126,12 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         let mut entity_events = Vec::new();
         for entity in trx.entities.iter() {
             if let Some(event) = entity.generate_commit_event()? {
+                let collection = event.collection.as_str();
+                if collection.starts_with(crate::schema::RESERVED_COLLECTION_PREFIX) {
+                    return Err(MutationError::General(
+                        format!("collection '{collection}' is protected and not writable by transactions").into(),
+                    ));
+                }
                 // Validate creation events: if parent is empty, this is a creation event
                 // and the entity must have been created in this transaction via create()
                 if event.is_entity_create() {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,4 +49,9 @@ pub use query_value::QueryValue;
 pub use type_resolver::TypeResolver;
 
 pub use ankurah_proto as proto;
+// Re-exported so derive-generated code can reach them core-relative: the
+// derive addresses everything through one base path (the facade's
+// `ankurah::core` externally, `crate` for core-internal models).
+pub use ankql;
 pub use ankurah_proto::{EntityId, ModelId};
+pub use ankurah_signals as signals;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,12 @@
+//! The runtime core of an Ankurah node.
+//!
+//! This crate assembles the node, contexts, entities, transactions, reactive
+//! queries, schema catalog, policy boundary, and storage interfaces, then
+//! re-exports the small vocabulary needed by applications and derive-generated
+//! code. The module root owns that public assembly and feature-gated surface;
+//! each child module owns its mechanism. Serialized protocol types live in
+//! `ankurah-proto`, while procedural code generation lives in `ankurah-derive`.
+
 pub mod changes;
 pub mod collation;
 pub mod connector;

--- a/core/src/livequery.rs
+++ b/core/src/livequery.rs
@@ -1,3 +1,13 @@
+//! Reactive query handles over the node's local Reactor and optional peer relay.
+//!
+//! [`EntityLiveQuery`] is the type-erased subscription lifetime and activation
+//! state; [`LiveQuery`] projects its result set into a generated model View;
+//! [`WeakEntityLiveQuery`] lets relay bookkeeping refer back without retaining
+//! the query. This file owns construction, activation, selection changes,
+//! initialization, typed projection, and node-lifetime behavior. The Reactor
+//! owns match maintenance, the subscription relay owns upstream transport, and
+//! Context decides which authority may create a query.
+
 use std::{
     marker::PhantomData,
     sync::{Arc, Weak},

--- a/core/src/livequery.rs
+++ b/core/src/livequery.rs
@@ -21,7 +21,7 @@ use crate::{
     node::{MatchArgs, NodeInner, TNodeErased},
     policy::PolicyAgent,
     reactor::{
-        fetch_gap::{GapFetcher, QueryGapFetcher},
+        fetch_gap::{GapFetcher, QueryGapFetcher, SystemRootGapFetcher},
         ReactorSubscription, ReactorUpdate,
     },
     resultset::{EntityResultSet, ResultSet},
@@ -212,15 +212,27 @@ where
 {
     node.policy_agent.can_access_collection(&cdata, &collection_id)?;
     args.selection.predicate = node.policy_agent.filter_predicate(&cdata, &collection_id, args.selection.predicate)?;
-
-    // Resolve types in the AST (converts literals for JSON path comparisons)
     args.selection = node.type_resolver.resolve_selection_types(args.selection);
+    let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(&node, cdata.clone()));
+    create_inner_with(node, node_ref, collection_id, args, gap_fetcher, node.subscription_relay.is_some())
+}
 
+fn create_inner_with<SE, PA>(
+    node: &Node<SE, PA>,
+    node_ref: Box<dyn NodeRef>,
+    collection_id: CollectionId,
+    args: MatchArgs,
+    gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>>,
+    has_relay: bool,
+) -> Result<(Arc<Inner>, proto::QueryId), RetrievalError>
+where
+    SE: StorageEngine + Send + Sync + 'static,
+    PA: PolicyAgent + Send + Sync + 'static,
+{
     let subscription = node.reactor.subscribe();
 
     let resultset = EntityResultSet::empty();
     let query_id = proto::QueryId::new();
-    let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(&node, cdata.clone()));
 
     let inner = Arc::new(Inner {
         query_id,
@@ -235,9 +247,6 @@ where
         collection_id: collection_id.clone(),
         gap_fetcher,
     });
-
-    // Check if this is a durable node (no relay) or ephemeral node (has relay)
-    let has_relay = node.subscription_relay.is_some();
 
     if args.cached || !has_relay {
         // Durable node: spawn initialization task directly (no remote subscription needed)
@@ -291,6 +300,28 @@ impl EntityLiveQuery {
     {
         let node_ref: Box<dyn NodeRef> = Box::new(WeakNodeRefImpl(Arc::downgrade(&node.0)));
         Self::new_with_node_ref(node, node_ref, collection_id, args, cdata)
+    }
+
+    /// A policy-free local query owned by a SystemRoot context. It is
+    /// durable-only and holds the node weakly so node-owned infrastructure
+    /// such as CatalogManager cannot form a reference cycle.
+    pub(crate) fn new_system_root_weak_node<SE, PA>(
+        node: &Node<SE, PA>,
+        collection_id: CollectionId,
+        mut args: MatchArgs,
+    ) -> Result<Self, RetrievalError>
+    where
+        SE: StorageEngine + Send + Sync + 'static,
+        PA: PolicyAgent + Send + Sync + 'static,
+    {
+        if !node.durable {
+            return Err(RetrievalError::Other("a SystemRoot live query requires a durable node".to_owned()));
+        }
+        args.selection = node.type_resolver.resolve_selection_types(args.selection);
+        let node_ref: Box<dyn NodeRef> = Box::new(WeakNodeRefImpl(Arc::downgrade(&node.0)));
+        let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(SystemRootGapFetcher::new(node));
+        let (inner, _) = create_inner_with(node, node_ref, collection_id, args, gap_fetcher, false)?;
+        Ok(Self(inner))
     }
 
     fn new_with_node_ref<SE, PA>(

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -1,3 +1,13 @@
+//! One Ankurah node's runtime ownership and peer-message boundary.
+//!
+//! [`Node`] is the shared public handle, [`NodeInner`] owns the storage,
+//! entities, Reactor, catalog, policy adapter, system lifecycle, and peer
+//! registries, and [`WeakNode`] is the non-owning form used by background
+//! components. [`PeerState`] tracks one connected peer; [`MatchArgs`] carries a
+//! prepared query request. This file composes those services and routes local
+//! and remote operations. Context owns caller authority, the Reactor owns query
+//! matching, and the schema catalog owns model/property identity resolution.
+
 use crate::schema::catalog::CatalogManager;
 use crate::selection::filter::Filterable;
 use ankurah_proto::{self as proto, Attested, CollectionId, EntityState};

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -178,14 +178,14 @@ where
     }
 
     fn build(engine: Arc<SE>, policy_agent: PA, durable: bool, rng: SmallRng) -> Self {
-        let collections = CollectionSet::new(engine.clone());
+        let collections = CollectionSet::new(engine);
         let entityset: WeakEntitySet = Default::default();
         let id = proto::EntityId::new();
         let reactor = Reactor::new();
         notice_info!("Node {id:#} created as {}", if durable { "durable" } else { "ephemeral" });
 
         let system_manager = SystemManager::new(collections.clone(), entityset.clone(), reactor.clone(), durable);
-        let catalog = CatalogManager::new(engine, durable);
+        let catalog = CatalogManager::new(durable);
 
         // Only ephemeral nodes relay subscriptions upstream to a durable peer.
         let subscription_relay = if durable { None } else { Some(SubscriptionRelay::new()) };

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -147,8 +147,9 @@ where PA: PolicyAgent
     pub(crate) policy_agent: PA,
     pub system: SystemManager<SE, PA>,
 
-    /// The metadata catalog map (write-only in this phase: registration
-    /// maintains it; nothing resolves through it yet).
+    /// The metadata catalog service. Durable nodes populate its projection
+    /// from typed SystemRoot live queries; registration and runtime schema
+    /// binding resolve through that projection.
     pub catalog: CatalogManager<SE, PA>,
 
     pub(crate) subscription_relay: Option<SubscriptionRelay<PA::ContextData, crate::livequery::WeakEntityLiveQuery>>,
@@ -462,8 +463,10 @@ where
                 }
             }
             proto::NodeRequestBody::RegisterSchema { models } => {
-                let cdata = cdata.iterable().exactly_one().map_err(|_| anyhow!("Only one cdata is permitted for RegisterSchema"))?;
-                match self.catalog.register_schema(cdata, models).await {
+                // Authentication has already admitted the request. Catalog
+                // materialization itself runs under local SystemRoot authority.
+                let _ = cdata.iterable().exactly_one().map_err(|_| anyhow!("Only one cdata is permitted for RegisterSchema"))?;
+                match self.catalog.register_schema(models).await {
                     // The resolved definitions ARE the response: the
                     // requester folds them into its catalog map on ack.
                     Ok(models) => Ok(proto::NodeResponseBody::SchemaRegistered { models }),

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -41,11 +41,6 @@ impl From<AccessDenied> for wasm_bindgen::JsValue {
 
 impl AccessDenied {}
 
-// The registration plan vocabulary (RegistrationPlan and friends) lives
-// with its builder in crate::schema::registration and is re-exported here
-// because it is part of this trait's surface.
-pub use crate::schema::registration::{PlannedModelPropertyMembership, PlannedUpdate, RegistrationPlan};
-
 /// PolicyAgents control access to resources, by:
 /// - signing requests which are sent to other nodes - this may come in the form of a bearer token, or a signature, or some other arbitrary method of authentication as defined by the PolicyAgent
 /// - checking access for requests. If approved, yield a ContextData
@@ -91,30 +86,6 @@ pub trait PolicyAgent: Clone + Send + Sync + 'static {
     /// or you could just return None if you don't want to attest to the event
     /// entity_before: Entity state before the event is applied
     /// entity_after: Entity state after the event has been applied (allows inspection of resulting state)
-    /// Gate a schema registration on its resolved effect. Called by
-    /// the registration executor after its lookup
-    /// phase and before any event is emitted, still under the allocation
-    /// mutex, with the request's actual consequences: what will be created,
-    /// what will be updated, what already exists. Agents may discriminate
-    /// on the principal (`cdata`: who may define schema) or on the object
-    /// (the planned definitions themselves); both styles are first-class.
-    /// Refusal fails the whole registration before anything is emitted.
-    /// Every emitted event still passes [`Self::check_event`] afterwards,
-    /// INDIVIDUALLY: the commit batch is not transactional, so an agent
-    /// that allows the plan but denies a constituent event aborts the
-    /// remainder and leaves earlier catalog events durable (accepted by
-    /// maintainer ruling 2026-07-06; the allocator's storage-checked
-    /// lookups keep identity convergent across such partials, and #313
-    /// tracks the transactional upgrade). The default allows.
-    fn check_schema_registration<SE: StorageEngine>(
-        &self,
-        _node: &Node<SE, Self>,
-        _cdata: &Self::ContextData,
-        _plan: &RegistrationPlan,
-    ) -> Result<(), AccessDenied> {
-        Ok(())
-    }
-
     fn check_event<SE: StorageEngine>(
         &self,
         node: &Node<SE, Self>,

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -1,3 +1,13 @@
+//! The application-defined authorization, authentication, and attestation seam.
+//!
+//! [`PolicyAgent`] is the contract a node calls to sign and validate requests,
+//! filter reads, authorize writes, and attest or validate replicated data.
+//! [`ContextData`] is its application credential value, [`AccessDenied`] is the
+//! common refusal, and [`PermissiveAgent`] is the allow-all implementation used
+//! where no application policy is required. This module does not create
+//! Context authority: the Context layer owns Session versus local SystemRoot,
+//! and SystemRoot deliberately bypasses this application-policy seam.
+
 use crate::util::Iterable;
 use crate::{
     entity::Entity,

--- a/core/src/reactor/fetch_gap.rs
+++ b/core/src/reactor/fetch_gap.rs
@@ -52,6 +52,24 @@ where
     pub fn new(node: &Node<SE, PA>, cdata: PA::ContextData) -> Self { Self { weak_node: Arc::downgrade(&node.0), cdata } }
 }
 
+/// Policy-free local gap fetcher for a durable SystemRoot context.
+#[derive(Clone)]
+pub(crate) struct SystemRootGapFetcher<SE, PA>
+where
+    SE: StorageEngine,
+    PA: PolicyAgent,
+{
+    weak_node: Weak<NodeInner<SE, PA>>,
+}
+
+impl<SE, PA> SystemRootGapFetcher<SE, PA>
+where
+    SE: StorageEngine,
+    PA: PolicyAgent,
+{
+    pub(crate) fn new(node: &Node<SE, PA>) -> Self { Self { weak_node: Arc::downgrade(&node.0) } }
+}
+
 #[async_trait]
 impl<SE, PA> GapFetcher<crate::entity::Entity> for QueryGapFetcher<SE, PA>
 where
@@ -73,31 +91,54 @@ where
 
         // Create a Node wrapper and NodeAndContext
         let node = Node(node_inner);
-        let node_context = NodeAndContext { node, cdata: self.cdata.clone() };
+        let node_context = NodeAndContext::new_session(node, self.cdata.clone());
 
-        // Build gap predicate if we have a last entity
-        let gap_selection = if let Some(last) = last_entity {
-            let gap_predicate = if let Some(ref order_by) = selection.order_by {
-                build_continuation_predicate(&selection.predicate, order_by, last)
-                    .map_err(|e| RetrievalError::storage(std::io::Error::other(e)))?
-            } else {
-                selection.predicate.clone()
-            };
-
-            ankql::ast::Selection { predicate: gap_predicate, order_by: selection.order_by.clone(), limit: Some(gap_size as u64) }
-        } else {
-            // No last entity, just use original selection with gap_size limit
-            ankql::ast::Selection {
-                predicate: selection.predicate.clone(),
-                order_by: selection.order_by.clone(),
-                limit: Some(gap_size as u64),
-            }
-        };
+        let gap_selection = gap_selection(selection, last_entity, gap_size)?;
 
         let match_args = MatchArgs { selection: gap_selection, cached: false };
 
         node_context.fetch_entities(collection_id, match_args).await
     }
+}
+
+#[async_trait]
+impl<SE, PA> GapFetcher<crate::entity::Entity> for SystemRootGapFetcher<SE, PA>
+where
+    SE: StorageEngine + 'static,
+    PA: PolicyAgent + 'static,
+{
+    async fn fetch_gap(
+        &self,
+        collection_id: &proto::CollectionId,
+        selection: &ankql::ast::Selection,
+        last_entity: Option<&crate::entity::Entity>,
+        gap_size: usize,
+    ) -> Result<Vec<crate::entity::Entity>, RetrievalError> {
+        let node = Node(
+            self.weak_node
+                .upgrade()
+                .ok_or_else(|| RetrievalError::storage(std::io::Error::other("Node has been dropped, cannot fill gap")))?,
+        );
+        node.fetch_entities_from_local(collection_id, &gap_selection(selection, last_entity, gap_size)?).await
+    }
+}
+
+fn gap_selection<E: AbstractEntity>(
+    selection: &ankql::ast::Selection,
+    last_entity: Option<&E>,
+    gap_size: usize,
+) -> Result<ankql::ast::Selection, RetrievalError> {
+    let predicate = if let Some(last) = last_entity {
+        if let Some(ref order_by) = selection.order_by {
+            build_continuation_predicate(&selection.predicate, order_by, last)
+                .map_err(|e| RetrievalError::storage(std::io::Error::other(e)))?
+        } else {
+            selection.predicate.clone()
+        }
+    } else {
+        selection.predicate.clone()
+    };
+    Ok(ankql::ast::Selection { predicate, order_by: selection.order_by.clone(), limit: Some(gap_size as u64) })
 }
 
 /// Build a supplemental predicate to fetch entities after the last entity in sort order

--- a/core/src/reactor/fetch_gap.rs
+++ b/core/src/reactor/fetch_gap.rs
@@ -1,3 +1,13 @@
+//! Backfill support for limited reactive result sets.
+//!
+//! A [`GapFetcher`] supplies rows when an ordered, limited LiveQuery loses a
+//! member and needs to refill its window. [`QueryGapFetcher`] performs that
+//! fetch under a session credential; [`SystemRootGapFetcher`] is the
+//! crate-private durable system equivalent. This file also owns construction
+//! of the continuation selection after the current last row. The Reactor owns
+//! result-set membership and query lifecycle; ordinary fetch execution and
+//! authorization remain in the node/context path.
+
 use crate::{
     context::NodeAndContext,
     error::RetrievalError,

--- a/core/src/schema/catalog.rs
+++ b/core/src/schema/catalog.rs
@@ -41,8 +41,11 @@ use tokio::sync::Notify;
 use tracing::{debug, error};
 
 use crate::{
+    entity::Entity,
     node::{Node, WeakNode},
     policy::PolicyAgent,
+    reactor::{GapFetcher, ReactorSubscription, ReactorUpdate},
+    resultset::EntityResultSet,
     storage::StorageEngine,
     util::request_fence::{RequestFence, RequestLease, RequestValidity},
 };
@@ -51,12 +54,32 @@ use super::{model_collection, model_property_collection, property_collection, re
 
 mod map;
 use map::{apply_entry, parse_state, CatalogMapInner, EnsuredSchemaBinding};
+
+pub mod rows;
 pub use map::{ModelDef, ModelPropertyMembershipDef, PropertyDef};
 
 // -- manager ----------------------------------------------------------------
 
 /// The three catalog collections warmed and maintained by this manager.
 fn catalog_collections() -> [ModelId; 3] { [model_collection(), property_collection(), model_property_collection()] }
+
+/// The catalog feed's gap fetcher. Its selections are limit-less, so the
+/// reactor never fills gaps and never calls this; it exists to satisfy the
+/// query-registration signature without borrowing a credentialed fetcher.
+struct NoopGapFetcher;
+
+#[async_trait::async_trait]
+impl GapFetcher<Entity> for NoopGapFetcher {
+    async fn fetch_gap(
+        &self,
+        _collection_id: &proto::CollectionId,
+        _selection: &ankql::ast::Selection,
+        _last_entity: Option<&Entity>,
+        _gap_size: usize,
+    ) -> Result<Vec<Entity>, crate::error::RetrievalError> {
+        Ok(Vec::new())
+    }
+}
 
 /// Maintains the in-memory catalog map for a node. Held by `Node` beside
 /// `SystemManager`; mirrors its `<SE, PA>` generics.
@@ -109,6 +132,13 @@ where PA: PolicyAgent
     /// field name, and display-name changes must not erase an established
     /// binding.
     ensured: RwLock<BTreeMap<String, Vec<EnsuredSchemaBinding>>>,
+    /// The durable map feed: a policy-free reactor subscription over the
+    /// three catalog collections (wildcard watchers; the reactor's own
+    /// initial fetch is the warm scan). Dropping either half unsubscribes,
+    /// so reset tears the feed down by clearing this and the next warm
+    /// re-establishes it. The listener holds a Weak of this inner (a strong
+    /// ref here would cycle through the guard's callback and leak).
+    durable_feed: RwLock<Option<(ReactorSubscription, ankurah_signals::SubscriptionGuard)>>,
     /// The manager stays generic over the node's PolicyAgent for its
     /// Node-taking methods (ensure_registered, ensure_subscribed).
     _pa: std::marker::PhantomData<PA>,
@@ -223,6 +253,7 @@ where
             setup_state: RwLock::new(CatalogSetupState::default()),
             setup_changed: Notify::new(),
             ensured: RwLock::new(BTreeMap::new()),
+            durable_feed: RwLock::new(None),
             _pa: std::marker::PhantomData,
         }))
     }
@@ -287,21 +318,54 @@ where
         }
     }
 
-    /// Durable path: warm the map by scanning the catalog collections, then
-    /// mark ready. Registration keeps the map fresh afterward: the executor
-    /// folds its own commits synchronously under the allocator mutex, and in
-    /// this write-only phase no other writer exists (peers forward
-    /// RegisterSchema rather than committing catalog entities directly). The
-    /// reactor-fed incremental subscription returns with the read flip.
+    /// Durable path: subscribe the map to the three catalog collections and
+    /// mark ready. The reactor subscription IS the warm: registering each
+    /// `Predicate::True` query runs the same local scan the old hand-rolled
+    /// warm did and delivers it through the listener, and every later
+    /// catalog commit (local or remote funnel; both end in `notify_change`)
+    /// arrives the same way. The executor still folds its own commits
+    /// synchronously under the allocator mutex -- the feed is asynchronous,
+    /// and consecutive registrations must observe their predecessors --
+    /// which is harmless because folds are idempotent by entity id.
     ///
-    /// A schema-less durable node has no catalog rows yet: it warms nothing
-    /// and is immediately ready with an empty (correct) map. Opening the
-    /// collections creates their empty materializations on first startup,
-    /// which is harmless and makes the catalog tables inspectable.
+    /// The subscription is policy-free by construction: `Reactor::subscribe`
+    /// and `add_query_and_notify` carry no credentials (policy lives in
+    /// EntityLiveQuery above the reactor), and the map is node
+    /// infrastructure, like `SystemManager`'s storage reads. The gap fetcher
+    /// is never invoked for a limit-less selection, so the noop is the
+    /// honest one.
+    ///
+    /// A schema-less durable node has no catalog rows yet: the fetches find
+    /// nothing and it is immediately ready with an empty (correct) map.
+    /// Opening the collections creates their empty materializations on
+    /// first startup, which is harmless and makes the catalog tables
+    /// inspectable.
     async fn warm_durable(&self, generation: u64) -> Result<(), crate::error::RetrievalError> {
         if self.0.setup_state.read().unwrap().generation != generation {
             return Ok(());
         }
+        let Some(node) = self.node() else {
+            return Err(crate::error::RetrievalError::Other("catalog warm ran without a node".to_owned()));
+        };
+
+        // Listener first, then queries: the queries' own fetches deliver the
+        // existing rows through this listener, so nothing can be missed
+        // between scan and subscribe. Gated on the warm's generation so a
+        // reset (which bumps the generation before clearing the map) mutes
+        // any straggler delivery from a torn-down feed.
+        let subscription = node.reactor.subscribe();
+        let guard = {
+            use ankurah_signals::Subscribe;
+            let weak = Arc::downgrade(&self.0);
+            subscription.subscribe(move |update: ReactorUpdate| {
+                if let Some(inner) = weak.upgrade() {
+                    let me = CatalogManager(inner);
+                    if me.0.setup_state.read().unwrap().generation == generation {
+                        me.apply_reactor_update(update);
+                    }
+                }
+            })
+        };
 
         let everything = ankql::ast::Selection { predicate: ankql::ast::Predicate::True, order_by: None, limit: None };
         for model in catalog_collections() {
@@ -309,25 +373,50 @@ where
                 ModelId::System(system) => crate::schema::system_collection_label(system),
                 ModelId::EntityId(_) => unreachable!("catalog collections are system models"),
             };
-            let states = self.0.storage.collection(&proto::CollectionId::fixed_name(label)).await?.fetch_states(&everything).await?;
-            let setup = self.0.setup_state.read().unwrap();
-            if setup.generation != generation {
-                return Ok(());
-            }
-            let mut map = self.0.map.write().unwrap();
-            for state in states {
-                if let Some(entry) = parse_state(&model, state.payload.entity_id, &state.payload) {
-                    apply_entry(&mut map, entry);
-                }
-            }
+            node.reactor
+                .add_query_and_notify(
+                    subscription.id(),
+                    proto::QueryId::new(),
+                    proto::CollectionId::fixed_name(label),
+                    everything.clone(),
+                    &node,
+                    EntityResultSet::empty(),
+                    Arc::new(NoopGapFetcher),
+                    (),
+                )
+                .await
+                .map_err(|e| crate::error::RetrievalError::Other(format!("catalog feed query failed: {e}")))?;
         }
 
         let setup = self.0.setup_state.read().unwrap();
         if setup.generation != generation {
             return Ok(());
         }
+        *self.0.durable_feed.write().unwrap() = Some((subscription, guard));
         self.mark_ready();
         Ok(())
+    }
+
+    /// Fold one reactor update into the map: the notified entities' states
+    /// through the same `parse_state`/`apply_entry` path the executor and
+    /// response folds use, keyed by each entity's collection. Idempotent by
+    /// entity id, so racing the executor's synchronous fold is harmless.
+    /// Membership removes are ignored: catalog rows never leave a
+    /// `Predicate::True` selection, and reset synthetics are muted by the
+    /// listener's generation gate.
+    fn apply_reactor_update(&self, update: ReactorUpdate) {
+        let mut map = self.0.map.write().unwrap();
+        for item in update.items {
+            let Some(model) = crate::schema::system_model_id(item.entity.collection().as_str()) else {
+                continue;
+            };
+            let Ok(state) = item.entity.to_entity_state() else {
+                continue;
+            };
+            if let Some(entry) = parse_state(&model, item.entity.id(), &state) {
+                apply_entry(&mut map, entry);
+            }
+        }
     }
 
     // -- readiness ----------------------------------------------------------
@@ -430,6 +519,9 @@ where
     /// setup may claim the next generation.
     fn finish_reset(&self) {
         let mut setup = self.0.setup_state.write().unwrap();
+        // Tear down the feed before clearing the map: dropping the handles
+        // unsubscribes, and the next generation's warm re-establishes it.
+        *self.0.durable_feed.write().unwrap() = None;
         self.0.map.write().unwrap().clear();
         *self.0.ready.write().unwrap() = false;
         // Allocations belong to one system and must not survive hard_reset

--- a/core/src/schema/catalog.rs
+++ b/core/src/schema/catalog.rs
@@ -1,21 +1,37 @@
-//! The in-memory catalog map and its maintenance.
+//! The per-node schema-catalog service.
 //!
-//! Every node keeps an in-memory view of the three catalog collections
-//! (`_ankurah_model`, `_ankurah_property`, `_ankurah_model_property`). In
-//! this write-only phase the map serves the catalog's own maintenance
-//! (registration duplicate checks and allocation), filling one of two ways:
+//! Here, the **catalog** is the runtime service that connects durable schema
+//! facts to one node's schema users. [`CatalogManager`] owns a materialized
+//! map projection, the exact bindings between compiled Rust descriptors
+//! and this system's allocated ids, and the readiness/reset epoch that makes
+//! both safe to consult. It accepts catalog entity updates and
+//! `SchemaRegistered` responses; it provides cheap identity lookups and the
+//! client-side entry points that ensure a compiled descriptor is registered.
+//! Durable allocation itself lives in [`super::registration`], and the
+//! catalog's typed read shapes live in [`rows`].
+//!
+//! The projection fills in one of two ways:
 //!
 //! - DURABLE nodes feed it from a policy-free reactor subscription over the
 //!   three collections: the initial fetch is the warm scan, and every later
 //!   catalog commit arrives through the same listener. The map is node
-//!   infrastructure like `SystemManager`; mutation stays gated by
-//!   `check_event` in the executor.
+//!   infrastructure like [`crate::system::SystemManager`]; catalog mutation
+//!   remains exclusive to durable schema registration.
 //! - EPHEMERAL nodes fold only SchemaRegistered responses to their own
-//!   forwarded registrations; relayed catalog subscriptions (and the
-//!   credential-scoped visibility they imply) return with the read flip.
+//!   forwarded registrations. They therefore know only definitions they
+//!   have registered or received in a response, not the whole system catalog.
 //!
-//! The map parses raw state buffers, never typed Views: resolving the
-//! catalog's own rows through catalog resolution would be circular.
+//! Reset is the service's main cross-cutting invariant. Each feed callback,
+//! warm, registration execution, and admitted response fold holds an epoch
+//! lease across its complete effect. Reset invalidates admission, drains
+//! those leases, and only then clears the projection and compiled bindings;
+//! an old-system effect can therefore neither survive nor resurrect state.
+//!
+//! TODO(organization): this file still co-locates two separable parts of the
+//! service: projection feed/reset lifecycle and compiled-binding/registration
+//! forwarding. They share one epoch today, so a safe extraction should first
+//! make that epoch owner an explicit boundary rather than mechanically split
+//! this `CatalogManager` impl.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, RwLock};
@@ -39,7 +55,7 @@ use crate::{
 use super::{registration::RegistrationError, ModelStructDescriptor};
 
 mod map;
-use map::{CatalogMapInner, EnsuredSchemaBinding};
+use map::CatalogMap;
 
 pub mod rows;
 pub use map::{ModelDef, ModelPropertyMembershipDef, PropertyDef};
@@ -77,7 +93,7 @@ struct CatalogInner<SE, PA: PolicyAgent> {
     /// lock and upserts its allocations before releasing it, so consecutive
     /// registrations observe each other and never double-allocate.
     allocator: tokio::sync::Mutex<()>,
-    map: RwLock<CatalogMapInner>,
+    map: RwLock<CatalogMap>,
     ready: RwLock<bool>,
     ready_notify: Notify,
     /// Warm generation and epoch fences: reset invalidates the generation
@@ -93,6 +109,23 @@ struct CatalogInner<SE, PA: PolicyAgent> {
     /// it. The listener holds a Weak of this inner (a strong ref would cycle
     /// through the guard's callback and leak).
     durable_feed: RwLock<Option<(ReactorSubscription, ankurah_signals::SubscriptionGuard)>>,
+    /// One-shot adversarial pauses used to pin reset interleavings without
+    /// adding timing assumptions to the integration tests.
+    #[cfg(feature = "test-helpers")]
+    next_registration_fold_pause: RwLock<Option<(Arc<Notify>, Arc<Notify>)>>,
+    #[cfg(feature = "test-helpers")]
+    next_feed_apply_hook: RwLock<Option<Arc<dyn Fn() + Send + Sync>>>,
+}
+
+/// One process-local proof that a compiled model shape resolves to a durable
+/// model identity in the current system. Field identities are re-derived
+/// from the descriptor and catalog projection when needed; `confirmed`
+/// records whether the allocator itself returned this binding.
+#[derive(Debug, Clone)]
+struct EnsuredSchemaBinding {
+    schema: &'static ModelStructDescriptor,
+    model: EntityId,
+    confirmed: bool,
 }
 
 #[derive(Debug, Default)]
@@ -101,9 +134,9 @@ struct CatalogSetupState {
     /// While true, no new warm may be claimed. SystemManager clears it only
     /// after storage and reactor reset finish.
     resetting: bool,
-    /// Quiescing owner fence for the current durable warm: one lease held
-    /// from before its first storage access through readiness publication,
-    /// so reset can invalidate and drain it before deleting storage.
+    /// Quiescing owner fence for the current durable feed: warming holds one
+    /// lease from its first storage access through readiness publication,
+    /// and every later callback holds another across its map effect.
     durable_fence: Option<RequestFence>,
     /// Owner fence for schema registration in the current system epoch:
     /// absent until a root is ready, rearmed only by the ready hook. Both
@@ -124,12 +157,16 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
             node: RwLock::new(None),
             durable,
             allocator: tokio::sync::Mutex::new(()),
-            map: RwLock::new(CatalogMapInner::default()),
+            map: RwLock::new(CatalogMap::default()),
             ready: RwLock::new(false),
             ready_notify: Notify::new(),
             setup_state: RwLock::new(CatalogSetupState::default()),
             ensured: RwLock::new(BTreeMap::new()),
             durable_feed: RwLock::new(None),
+            #[cfg(feature = "test-helpers")]
+            next_registration_fold_pause: RwLock::new(None),
+            #[cfg(feature = "test-helpers")]
+            next_feed_apply_hook: RwLock::new(None),
         }))
     }
 
@@ -177,7 +214,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
     /// credentials by construction (policy lives in EntityLiveQuery above
     /// the reactor). A schema-less durable node finds no rows and is
     /// immediately ready with an empty, correct map.
-    async fn warm_durable(&self, generation: u64) -> Result<(), RetrievalError> {
+    async fn warm_durable(&self, generation: u64, validity: RequestValidity) -> Result<(), RetrievalError> {
         if self.0.setup_state.read().unwrap().generation != generation {
             return Ok(());
         }
@@ -185,16 +222,16 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
 
         // Listener first, then queries: the queries' own fetches deliver the
         // existing rows through this listener, so nothing can be missed
-        // between scan and subscribe. Gated on the warm's generation so a
-        // reset (which bumps the generation before clearing the map) mutes
-        // any straggler delivery from a torn-down feed.
+        // between scan and subscribe. Every delivery acquires the durable
+        // epoch fence and holds it across the complete map effect: reset
+        // either rejects a straggler or drains it before clearing the map.
         let subscription = node.reactor.subscribe();
         use ankurah_signals::Subscribe;
         let weak = Arc::downgrade(&self.0);
         let guard = subscription.subscribe(move |update: ReactorUpdate| {
-            if let Some(inner) = weak.upgrade().filter(|inner| inner.setup_state.read().unwrap().generation == generation) {
-                CatalogManager(inner).apply_reactor_update(update);
-            }
+            let Some(_lease) = validity.try_acquire() else { return };
+            let Some(inner) = weak.upgrade() else { return };
+            CatalogManager(inner).apply_reactor_update(update);
         });
 
         let everything = Selection { predicate: Predicate::True, order_by: None, limit: None };
@@ -222,8 +259,12 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
     /// Idempotent by entity id, so racing the executor's synchronous fold is
     /// harmless. Membership removes are ignored: catalog rows never leave a
     /// `Predicate::True` selection, and reset synthetics are muted by the
-    /// listener's generation gate.
+    /// listener's epoch fence.
     fn apply_reactor_update(&self, update: ReactorUpdate) {
+        #[cfg(feature = "test-helpers")]
+        if let Some(hook) = self.0.next_feed_apply_hook.write().unwrap().take() {
+            hook();
+        }
         let mut map = self.0.map.write().unwrap();
         for item in update.items {
             let Some(model) = crate::schema::system_model_id(item.entity.collection().as_str()) else { continue };
@@ -316,10 +357,10 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
     /// fresh warm from here.
     fn finish_reset(&self) {
         let mut setup = self.0.setup_state.write().unwrap();
-        // Detach the feed before the map clear, but drop the handles only
-        // after the setup guard releases: dropping unsubscribes, and the
-        // listener takes a setup_state read on delivery. The next
-        // generation's warm re-establishes the feed.
+        // Detach the drained feed before the map clear, but drop its handles
+        // after the setup guard releases so unsubscribe teardown never runs
+        // under catalog setup synchronization. The next generation's warm
+        // re-establishes the feed.
         let feed = self.0.durable_feed.write().unwrap().take();
         self.0.map.write().unwrap().clear();
         *self.0.ready.write().unwrap() = false;
@@ -341,7 +382,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
     /// ready root. Every node kind gets exactly one registration fence; a
     /// durable node also claims its one pending storage warm.
     fn resume_after_system_ready(&self) {
-        let (generation, lease) = {
+        let (generation, lease, validity) = {
             let mut setup = self.0.setup_state.write().unwrap();
             if setup.resetting {
                 return;
@@ -355,13 +396,14 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
             setup.durable_resume_pending = false;
             let fence = RequestFence::new();
             let lease = fence.try_acquire().expect("a newly-created durable warm fence must admit its owner");
+            let validity = RequestValidity::fenced(fence.clone());
             setup.durable_fence = Some(fence);
-            (setup.generation, lease)
+            (setup.generation, lease, validity)
         };
         let me = self.clone();
         crate::task::spawn(async move {
             let _lease = lease;
-            if let Err(e) = me.warm_durable(generation).await {
+            if let Err(e) = me.warm_durable(generation, validity).await {
                 error!("CatalogManager durable warm failed; catalog feed absent until the next reset: {e}");
                 // Readiness must still latch even on failure: registration's
                 // wait parks on it, and one failed warm must not become a
@@ -412,6 +454,25 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         move || weak.upgrade().is_some()
     }
 
+    /// TEST ONLY: pause the next admitted registration response after it has
+    /// acquired its reset lease and before it folds any catalog state.
+    #[cfg(feature = "test-helpers")]
+    pub fn pause_next_registration_fold(&self, entered: Arc<Notify>, release: Arc<Notify>) {
+        *self.0.next_registration_fold_pause.write().unwrap() = Some((entered, release));
+    }
+
+    /// TEST ONLY: run `hook` in the next admitted durable feed callback after
+    /// it has acquired its reset lease and before it folds the update.
+    #[cfg(feature = "test-helpers")]
+    pub fn hook_next_feed_apply(&self, hook: impl Fn() + Send + Sync + 'static) {
+        *self.0.next_feed_apply_hook.write().unwrap() = Some(Arc::new(hook));
+    }
+
+    /// TEST ONLY: whether the current system epoch is still admitting schema
+    /// registration effects. Reset removes this owner before awaiting drains.
+    #[cfg(feature = "test-helpers")]
+    pub fn registration_epoch_is_current(&self) -> bool { self.registration_validity().is_some_and(|validity| validity.is_current()) }
+
     /// Return the current catalog definition for a durable property identity.
     pub fn property_by_id(&self, id: &EntityId) -> Option<PropertyDef> { self.0.map.read().unwrap().properties.get(id).cloned() }
 
@@ -447,9 +508,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
 
     /// Property ids sharing display name `name` across ALL contracts (the
     /// map's global name index, which also backs [`Self::property_by_name`]).
-    pub fn siblings_by_name(&self, name: &str) -> Vec<EntityId> {
-        self.0.map.read().unwrap().names_global.get(name).into_iter().flat_map(|s| s.iter().copied()).collect()
-    }
+    pub fn siblings_by_name(&self, name: &str) -> Vec<EntityId> { self.0.map.read().unwrap().siblings_by_name(name) }
 
     // -- registration lifecycle --------------------------------------------
 
@@ -529,6 +588,21 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
     }
 
     fn store_binding(&self, binding: EnsuredSchemaBinding) {
+        // TODO(schema-binding-telemetry): Extend the compiled/wire
+        // declaration with identity metadata, then emit a best-effort
+        // asynchronous observation whenever this gate accepts a binding.
+        // `CARGO_PKG_NAME` and `CARGO_PKG_VERSION`, expanded by the derive,
+        // reliably identify the crate declaring the model; final application
+        // name and source revision are not reliably available there and
+        // should be supplied by the application/runtime when practical.
+        // Record those identities with the source UniqueStructId/
+        // UniqueFieldId values, resolved durable ModelId/PropertyId values,
+        // current labels, match basis, and binding source. This must never
+        // delay or reject schema use. Operators need the observations to
+        // distinguish applications or builds whose identical-looking
+        // declarations require different treatment, audit deployed label
+        // dependencies before migrations, and prepare Unique-ID fallback
+        // mappings for affected builds.
         let mut ensured = self.0.ensured.write().unwrap();
         let bindings = ensured.entry(binding.schema.label.to_string()).or_default();
         match bindings.iter_mut().find(|known| *known.schema == *binding.schema) {
@@ -663,15 +737,21 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         still_current()?;
         let request = proto::NodeRequestBody::RegisterSchema { models: vec![request_model] };
         let response = node.request(peer, cdata, request).await.map_err(|e| reg_err(format!("{e:?}")))?;
-        // The response applies only while still wanted: recheck before
-        // folding so reset clears before or after the complete effect,
-        // never between.
-        still_current()?;
+        // A lease, not a sample: reset drains admitted effects before
+        // clearing and rejects responses that arrive after invalidation.
+        let _fold_lease = validity.try_acquire().ok_or(RegistrationError::SystemNotReady)?;
         let models = match response {
             proto::NodeResponseBody::SchemaRegistered { models } => models,
             proto::NodeResponseBody::Error(e) => return Err(reg_err(e)),
             other => return Err(reg_err(format!("unexpected response to RegisterSchema: {other}"))),
         };
+        #[cfg(feature = "test-helpers")]
+        let fold_pause = self.0.next_registration_fold_pause.write().unwrap().take();
+        #[cfg(feature = "test-helpers")]
+        if let Some((entered, release)) = fold_pause {
+            entered.notify_one();
+            release.notified().await;
+        }
         // Fold the response in on ack so binding proceeds ahead of the feed.
         self.upsert_registered(&models);
         self.mark_schema_ensured(schema, &models)

--- a/core/src/schema/catalog.rs
+++ b/core/src/schema/catalog.rs
@@ -8,15 +8,15 @@
 //! `SchemaRegistered` responses; it provides cheap identity lookups and the
 //! client-side entry points that ensure a compiled descriptor is registered.
 //! Durable allocation itself lives in [`super::registration`], and the
-//! catalog's typed read shapes live in [`rows`].
+//! catalog's typed model shapes live in [`rows`].
 //!
 //! The projection fills in one of two ways:
 //!
-//! - DURABLE nodes feed it from a policy-free reactor subscription over the
-//!   three collections: the initial fetch is the warm scan, and every later
-//!   catalog commit arrives through the same listener. The map is node
-//!   infrastructure like [`crate::system::SystemManager`]; catalog mutation
-//!   remains exclusive to durable schema registration.
+//! - DURABLE nodes feed it from three ordinary typed LiveQueries opened by a
+//!   local SystemRoot context. Their initial results warm the projection and
+//!   every later catalog commit arrives through the same subscriptions. The
+//!   map is node infrastructure like [`crate::system::SystemManager`];
+//!   catalog mutation remains exclusive to durable schema registration.
 //! - EPHEMERAL nodes fold only SchemaRegistered responses to their own
 //!   forwarded registrations. They therefore know only definitions they
 //!   have registered or received in a response, not the whole system catalog.
@@ -42,12 +42,12 @@ use tokio::sync::Notify;
 use tracing::{debug, error};
 
 use crate::{
-    entity::Entity,
+    changes::ChangeSet,
+    context::Context,
     error::RetrievalError,
+    livequery::LiveQuery,
     node::{Node, WeakNode},
     policy::PolicyAgent,
-    reactor::{GapFetcher, ReactorSubscription, ReactorUpdate},
-    resultset::EntityResultSet,
     storage::StorageEngine,
     util::request_fence::{RequestFence, RequestValidity},
 };
@@ -56,6 +56,7 @@ use super::{registration::RegistrationError, ModelStructDescriptor};
 
 mod map;
 use map::CatalogMap;
+use rows::{SysModelPropertyRowView, SysModelRowView, SysPropertyRowView};
 
 pub mod rows;
 pub use map::{ModelDef, ModelPropertyMembershipDef, PropertyDef};
@@ -63,16 +64,11 @@ pub use map::{ModelDef, ModelPropertyMembershipDef, PropertyDef};
 /// A registration failure with a plain-text cause.
 fn reg_err(msg: String) -> RegistrationError { RegistrationError::Retrieval(RetrievalError::Other(msg)) }
 
-/// The catalog feed's gap fetcher: never called (limit-less selections have
-/// no gaps); it satisfies the query-registration signature without borrowing
-/// a credentialed fetcher.
-struct NoopGapFetcher;
-
-#[async_trait::async_trait]
-impl GapFetcher<Entity> for NoopGapFetcher {
-    async fn fetch_gap(&self, _: &proto::CollectionId, _: &Selection, _: Option<&Entity>, _: usize) -> Result<Vec<Entity>, RetrievalError> {
-        Ok(Vec::new())
-    }
+struct DurableCatalogFeed {
+    _models: LiveQuery<SysModelRowView>,
+    _properties: LiveQuery<SysPropertyRowView>,
+    _memberships: LiveQuery<SysModelPropertyRowView>,
+    _guards: [ankurah_signals::SubscriptionGuard; 3],
 }
 
 /// Maintains the in-memory catalog map for a node. Held by `Node` beside
@@ -108,7 +104,7 @@ struct CatalogInner<SE, PA: PolicyAgent> {
     /// tears the feed down by clearing this and the next warm re-establishes
     /// it. The listener holds a Weak of this inner (a strong ref would cycle
     /// through the guard's callback and leak).
-    durable_feed: RwLock<Option<(ReactorSubscription, ankurah_signals::SubscriptionGuard)>>,
+    durable_feed: RwLock<Option<DurableCatalogFeed>>,
     /// One-shot adversarial pauses used to pin reset interleavings without
     /// adding timing assumptions to the integration tests.
     #[cfg(feature = "test-helpers")]
@@ -146,7 +142,7 @@ struct CatalogSetupState {
     /// retried `hard_reset` drains the same fences instead of bypassing
     /// work whose first waiter was canceled.
     draining_fences: Vec<RequestFence>,
-    /// A durable hard reset drops its reactor subscription. Once the new
+    /// A durable hard reset drops its typed LiveQuery subscriptions. Once the new
     /// system root is ready, one warm must attach the current generation.
     durable_resume_pending: bool,
 }
@@ -203,46 +199,50 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         }
     }
 
-    /// Durable path: subscribe the map to the three catalog collections and
-    /// mark ready. The reactor subscription IS the warm: registering each
-    /// `Predicate::True` query runs the local scan through the listener, and
-    /// every later catalog commit (local or remote funnel) arrives the same
-    /// way. The executor still folds its own commits synchronously under the
-    /// allocator mutex (the feed is asynchronous, and consecutive
-    /// registrations must observe their predecessors); folds are idempotent
-    /// by entity id, so the overlap is harmless. The subscription carries no
-    /// credentials by construction (policy lives in EntityLiveQuery above
-    /// the reactor). A schema-less durable node finds no rows and is
-    /// immediately ready with an empty, correct map.
+    /// Durable path: use the normal typed Context/LiveQuery/View stack for
+    /// all three catalog collections. SystemRoot is the local durable-node
+    /// authority for this system data; it bypasses application policy but
+    /// otherwise exercises the same query machinery as application models.
     async fn warm_durable(&self, generation: u64, validity: RequestValidity) -> Result<(), RetrievalError> {
         if self.0.setup_state.read().unwrap().generation != generation {
             return Ok(());
         }
         let node = self.node().ok_or_else(|| RetrievalError::Other("catalog warm ran without a node".to_owned()))?;
-
-        // Listener first, then queries: the queries' own fetches deliver the
-        // existing rows through this listener, so nothing can be missed
-        // between scan and subscribe. Every delivery acquires the durable
-        // epoch fence and holds it across the complete map effect: reset
-        // either rejects a straggler or drains it before clearing the map.
-        let subscription = node.reactor.subscribe();
-        use ankurah_signals::Subscribe;
-        let weak = Arc::downgrade(&self.0);
-        let guard = subscription.subscribe(move |update: ReactorUpdate| {
-            let Some(_lease) = validity.try_acquire() else { return };
-            let Some(inner) = weak.upgrade() else { return };
-            CatalogManager(inner).apply_reactor_update(update);
-        });
-
+        let context = Context::new_system_root(node)?;
         let everything = Selection { predicate: Predicate::True, order_by: None, limit: None };
-        let (sub, noop) = (subscription.id(), Arc::new(NoopGapFetcher));
-        for label in [super::MODEL_COLLECTION_ID, super::PROPERTY_COLLECTION_ID, super::MODEL_PROPERTY_COLLECTION_ID] {
-            let (qid, cid) = (proto::QueryId::new(), proto::CollectionId::fixed_name(label));
-            node.reactor
-                .add_query_and_notify(sub, qid, cid, everything.clone(), &node, EntityResultSet::empty(), noop.clone(), ())
-                .await
-                .map_err(|e| RetrievalError::Other(format!("catalog feed query failed: {e}")))?;
-        }
+        let models = context.query::<SysModelRowView>(everything.clone())?;
+        let properties = context.query::<SysPropertyRowView>(everything.clone())?;
+        let memberships = context.query::<SysModelPropertyRowView>(everything)?;
+
+        // Subscribe before awaiting initialization so the initial View rows
+        // are observed by the same callbacks as later updates.
+        use ankurah_signals::Subscribe;
+        let model_guard = {
+            let (weak, validity) = (Arc::downgrade(&self.0), validity.clone());
+            models.subscribe(move |changes| {
+                let Some(_lease) = validity.try_acquire() else { return };
+                let Some(inner) = weak.upgrade() else { return };
+                CatalogManager(inner).apply_model_changes(changes);
+            })
+        };
+        let property_guard = {
+            let (weak, validity) = (Arc::downgrade(&self.0), validity.clone());
+            properties.subscribe(move |changes| {
+                let Some(_lease) = validity.try_acquire() else { return };
+                let Some(inner) = weak.upgrade() else { return };
+                CatalogManager(inner).apply_property_changes(changes);
+            })
+        };
+        let membership_guard = {
+            let weak = Arc::downgrade(&self.0);
+            memberships.subscribe(move |changes| {
+                let Some(_lease) = validity.try_acquire() else { return };
+                let Some(inner) = weak.upgrade() else { return };
+                CatalogManager(inner).apply_membership_changes(changes);
+            })
+        };
+
+        tokio::join!(models.wait_initialized(), properties.wait_initialized(), memberships.wait_initialized());
 
         // The held setup guard excludes a reset's generation bump (a setup
         // write) between this check and feed/readiness publication.
@@ -250,27 +250,52 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         if setup.generation != generation {
             return Ok(());
         }
-        *self.0.durable_feed.write().unwrap() = Some((subscription, guard));
+        *self.0.durable_feed.write().unwrap() = Some(DurableCatalogFeed {
+            _models: models,
+            _properties: properties,
+            _memberships: memberships,
+            _guards: [model_guard, property_guard, membership_guard],
+        });
         self.mark_ready();
         Ok(())
     }
 
-    /// Fold one reactor update into the map, keyed by entity collection.
-    /// Idempotent by entity id, so racing the executor's synchronous fold is
-    /// harmless. Membership removes are ignored: catalog rows never leave a
-    /// `Predicate::True` selection, and reset synthetics are muted by the
-    /// listener's epoch fence.
-    fn apply_reactor_update(&self, update: ReactorUpdate) {
+    fn before_feed_apply(&self) {
         #[cfg(feature = "test-helpers")]
         if let Some(hook) = self.0.next_feed_apply_hook.write().unwrap().take() {
             hook();
         }
+    }
+
+    fn apply_model_changes(&self, changes: ChangeSet<SysModelRowView>) {
+        self.before_feed_apply();
         let mut map = self.0.map.write().unwrap();
-        for item in update.items {
-            let Some(model) = crate::schema::system_model_id(item.entity.collection().as_str()) else { continue };
-            match item.entity.to_entity_state() {
-                Ok(state) => map.apply_state(&model, item.entity.id(), &state),
-                Err(e) => debug!("catalog feed skip {:#} {}: {e}", item.entity.id(), item.entity.collection()),
+        for change in changes.changes {
+            let row = change.entity();
+            if let Err(error) = map.apply_model(row) {
+                error!("catalog feed skipped malformed model row {}: {error}", row.id());
+            }
+        }
+    }
+
+    fn apply_property_changes(&self, changes: ChangeSet<SysPropertyRowView>) {
+        self.before_feed_apply();
+        let mut map = self.0.map.write().unwrap();
+        for change in changes.changes {
+            let row = change.entity();
+            if let Err(error) = map.apply_property(row) {
+                error!("catalog feed skipped malformed property row {}: {error}", row.id());
+            }
+        }
+    }
+
+    fn apply_membership_changes(&self, changes: ChangeSet<SysModelPropertyRowView>) {
+        self.before_feed_apply();
+        let mut map = self.0.map.write().unwrap();
+        for change in changes.changes {
+            let row = change.entity();
+            if let Err(error) = map.apply_membership(row) {
+                error!("catalog feed skipped malformed membership row {}: {error}", row.id());
             }
         }
     }
@@ -644,11 +669,11 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         }
     }
 
-    /// Fold resolved definitions into the map: called by the executor
-    /// synchronously post-commit (before releasing the allocator mutex) and
-    /// by `ensure_registered` with a SchemaRegistered response, so binding
-    /// proceeds ahead of the feed. Idempotent by entity id; the reactor's
-    /// later re-delivery is harmless.
+    /// Fold resolved definitions into the map on an ephemeral node after a
+    /// `SchemaRegistered` response. Ephemeral nodes do not yet subscribe to
+    /// the complete catalog, so the response is their catalog source. The
+    /// same helper seeds deterministic test fixtures; durable registration
+    /// reaches the map only through its typed LiveQueries.
     pub fn upsert_registered(&self, models: &[RegisteredModel]) {
         let mut map = self.0.map.write().unwrap();
         for m in models {
@@ -692,12 +717,13 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
     /// `Context::register_model` and, via `ensure_schema_for_use`, first-use
     /// registration on mutating and typed-read paths. Fast-returns only when
     /// this exact compiled shape is already ensured in this process. DURABLE
-    /// nodes execute locally (the executor updates the map under the
-    /// allocator mutex); EPHEMERAL nodes forward RegisterSchema to a durable
-    /// peer and consume the response into the map, and with NO peer fail
+    /// nodes execute locally (the typed catalog LiveQueries update the map
+    /// synchronously before the allocator mutex is released); EPHEMERAL nodes
+    /// forward RegisterSchema to a durable peer and consume the response into
+    /// the map, and with NO peer fail
     /// with NoDurablePeer (only the durable allocator may allocate ids, so
-    /// there is no offline queue). Re-assertion resolves to a no-op plan
-    /// whose response still feeds the map. Success latches; every error path
+    /// there is no offline queue). An unchanged re-assertion performs no
+    /// transaction while its response still feeds the map. Success latches; every error path
     /// returns WITHOUT latching, so a later attempt retries.
     pub async fn ensure_registered(
         &self,
@@ -720,7 +746,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
             // snapshotted before execution: reacquiring afterward could grab
             // a post-reset fence and fold old definitions into the new epoch.
             let _lease = initial_lease;
-            let models = self.register_schema(cdata, vec![request_model]).await?;
+            let models = self.register_schema(vec![request_model]).await?;
             self.mark_schema_ensured(schema, &models)?;
             return Ok(());
         }
@@ -752,7 +778,8 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
             entered.notify_one();
             release.notified().await;
         }
-        // Fold the response in on ack so binding proceeds ahead of the feed.
+        // Ephemeral nodes have no complete catalog feed yet; the acknowledged
+        // allocation response is their source for these definitions.
         self.upsert_registered(&models);
         self.mark_schema_ensured(schema, &models)
     }

--- a/core/src/schema/catalog.rs
+++ b/core/src/schema/catalog.rs
@@ -227,8 +227,9 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         let mut map = self.0.map.write().unwrap();
         for item in update.items {
             let Some(model) = crate::schema::system_model_id(item.entity.collection().as_str()) else { continue };
-            if let Ok(state) = item.entity.to_entity_state() {
-                map.apply_state(&model, item.entity.id(), &state);
+            match item.entity.to_entity_state() {
+                Ok(state) => map.apply_state(&model, item.entity.id(), &state),
+                Err(e) => debug!("catalog feed skip {:#} {}: {e}", item.entity.id(), item.entity.collection()),
             }
         }
     }
@@ -315,9 +316,11 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
     /// fresh warm from here.
     fn finish_reset(&self) {
         let mut setup = self.0.setup_state.write().unwrap();
-        // Feed teardown before map clear: dropping the handles unsubscribes,
-        // and the next generation's warm re-establishes them.
-        *self.0.durable_feed.write().unwrap() = None;
+        // Detach the feed before the map clear, but drop the handles only
+        // after the setup guard releases: dropping unsubscribes, and the
+        // listener takes a setup_state read on delivery. The next
+        // generation's warm re-establishes the feed.
+        let feed = self.0.durable_feed.write().unwrap().take();
         self.0.map.write().unwrap().clear();
         *self.0.ready.write().unwrap() = false;
         // Allocations belong to one system: a node re-joining a different
@@ -327,6 +330,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         setup.resetting = false;
         setup.durable_resume_pending = self.0.durable;
         drop(setup);
+        drop(feed);
         // Wake waiters to observe the cleared state rather than sleeping on
         // a readiness that will never come.
         self.0.ready_notify.notify_waiters();
@@ -358,7 +362,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         crate::task::spawn(async move {
             let _lease = lease;
             if let Err(e) = me.warm_durable(generation).await {
-                error!("CatalogManager durable warm failed: {}", e);
+                error!("CatalogManager durable warm failed; catalog feed absent until the next reset: {e}");
                 // Readiness must still latch even on failure: registration's
                 // wait parks on it, and one failed warm must not become a
                 // hang. Later registrations reject loudly on their storage

--- a/core/src/schema/catalog.rs
+++ b/core/src/schema/catalog.rs
@@ -1,249 +1,126 @@
-//! The in-memory catalog map and its maintenance
-//!.
+//! The in-memory catalog map and its maintenance.
 //!
 //! Every node keeps an in-memory view of the three catalog collections
 //! (`_ankurah_model`, `_ankurah_property`, `_ankurah_model_property`). In
-//! this write-only phase the map exists for the catalog's own maintenance
-//! (registration duplicate checks and allocation), and it fills two ways,
-//! mirroring how the two node kinds already replicate:
+//! this write-only phase the map serves the catalog's own maintenance
+//! (registration duplicate checks and allocation), filling one of two ways:
 //!
-//! - DURABLE nodes have the catalog in local storage. Once the system is
-//!   ready the manager warms the map by scanning the three collections
-//!   (`fetch_states` with `Predicate::True`, the same move
-//!   `SystemManager::load_system_catalog` makes for the system collection).
-//!   Afterward the registration executor folds its own commits into the map
-//!   synchronously under the allocator mutex; no other catalog writer
-//!   exists this phase. The POLICY-FREE reactor subscription that keeps the
-//!   map fresh under the read flip returns with that PR (the map is node
-//!   infrastructure like `SystemManager`, which reads storage with no
-//!   policy; mutation stays gated by `check_event` in the executor).
-//! - EPHEMERAL nodes fill their map only by folding SchemaRegistered
-//!   responses to their own forwarded registrations. The three catalog
-//!   subscriptions through the ordinary relay (and the credential-scoped
-//!   visibility they imply) return with the read flip.
+//! - DURABLE nodes feed it from a policy-free reactor subscription over the
+//!   three collections: the initial fetch is the warm scan, and every later
+//!   catalog commit arrives through the same listener. The map is node
+//!   infrastructure like `SystemManager`; mutation stays gated by
+//!   `check_event` in the executor.
+//! - EPHEMERAL nodes fold only SchemaRegistered responses to their own
+//!   forwarded registrations; relayed catalog subscriptions (and the
+//!   credential-scoped visibility they imply) return with the read flip.
 //!
-//! Catalog entities are SYSTEM MODELS: they are read
-//! through the raw state-buffer interface, never a `View`, because
-//! deriving a `Model` for a catalog collection would be the
-//! self-description ouroboros: resolving the catalog's own rows through
-//! catalog resolution would be circular. Storage states are parsed
-//! through `LWWBackend::from_state_buffer` + `property_values`, exactly as
-//! `registration::catalog_entity_values` does.
+//! The map parses raw state buffers, never typed Views: resolving the
+//! catalog's own rows through catalog resolution would be circular.
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::{Arc, RwLock},
-};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, RwLock};
 
-use crate::ModelId;
-use ankurah_proto::{self as proto, EntityId, PropertyId, SystemProperty};
+use ankql::ast::{Predicate, Selection};
+use ankurah_proto::{self as proto, EntityId, PropertyId, RegisteredModel, SystemProperty};
 use tokio::sync::Notify;
 use tracing::{debug, error};
 
 use crate::{
     entity::Entity,
+    error::RetrievalError,
     node::{Node, WeakNode},
     policy::PolicyAgent,
     reactor::{GapFetcher, ReactorSubscription, ReactorUpdate},
     resultset::EntityResultSet,
     storage::StorageEngine,
-    util::request_fence::{RequestFence, RequestLease, RequestValidity},
+    util::request_fence::{RequestFence, RequestValidity},
 };
 
-use super::{model_collection, model_property_collection, property_collection, registration::RegistrationError, ModelStructDescriptor};
+use super::{registration::RegistrationError, ModelStructDescriptor};
 
 mod map;
-use map::{apply_entry, parse_state, CatalogMapInner, EnsuredSchemaBinding};
+use map::{CatalogMapInner, EnsuredSchemaBinding};
 
 pub mod rows;
 pub use map::{ModelDef, ModelPropertyMembershipDef, PropertyDef};
 
-// -- manager ----------------------------------------------------------------
+/// A registration failure with a plain-text cause.
+fn reg_err(msg: String) -> RegistrationError { RegistrationError::Retrieval(RetrievalError::Other(msg)) }
 
-/// The three catalog collections warmed and maintained by this manager.
-fn catalog_collections() -> [ModelId; 3] { [model_collection(), property_collection(), model_property_collection()] }
-
-/// The catalog feed's gap fetcher. Its selections are limit-less, so the
-/// reactor never fills gaps and never calls this; it exists to satisfy the
-/// query-registration signature without borrowing a credentialed fetcher.
+/// The catalog feed's gap fetcher: never called (limit-less selections have
+/// no gaps); it satisfies the query-registration signature without borrowing
+/// a credentialed fetcher.
 struct NoopGapFetcher;
 
 #[async_trait::async_trait]
 impl GapFetcher<Entity> for NoopGapFetcher {
-    async fn fetch_gap(
-        &self,
-        _collection_id: &proto::CollectionId,
-        _selection: &ankql::ast::Selection,
-        _last_entity: Option<&Entity>,
-        _gap_size: usize,
-    ) -> Result<Vec<Entity>, crate::error::RetrievalError> {
+    async fn fetch_gap(&self, _: &proto::CollectionId, _: &Selection, _: Option<&Entity>, _: usize) -> Result<Vec<Entity>, RetrievalError> {
         Ok(Vec::new())
     }
 }
 
 /// Maintains the in-memory catalog map for a node. Held by `Node` beside
 /// `SystemManager`; mirrors its `<SE, PA>` generics.
-pub struct CatalogManager<SE, PA>(Arc<CatalogInner<SE, PA>>)
-where PA: PolicyAgent;
+pub struct CatalogManager<SE, PA: PolicyAgent>(Arc<CatalogInner<SE, PA>>);
 
-impl<SE, PA> Clone for CatalogManager<SE, PA>
-where PA: PolicyAgent
-{
+impl<SE, PA: PolicyAgent> Clone for CatalogManager<SE, PA> {
     fn clone(&self) -> Self { Self(self.0.clone()) }
 }
 
-struct CatalogInner<SE, PA>
-where PA: PolicyAgent
-{
-    storage: Arc<SE>,
+struct CatalogInner<SE, PA: PolicyAgent> {
     /// The owning node, installed by `start` (weak: the node owns the
     /// manager, never the reverse). Registration executes and forwards
     /// through it.
     node: RwLock<Option<WeakNode<SE, PA>>>,
     durable: bool,
-    /// The allocator mutex: the registration
-    /// executor serializes every RegisterSchema execution on this lock and
-    /// upserts its allocations into the map synchronously before releasing
-    /// it, so consecutive registrations observe each other and never
-    /// double-allocate.
+    /// The registration executor serializes every RegisterSchema on this
+    /// lock and upserts its allocations before releasing it, so consecutive
+    /// registrations observe each other and never double-allocate.
     allocator: tokio::sync::Mutex<()>,
     map: RwLock<CatalogMapInner>,
     ready: RwLock<bool>,
     ready_notify: Notify,
-    /// Monotonic catalog-warm generation plus the ephemeral first-call-wins
-    /// latch. Reset invalidates the generation before clearing the catalog so
-    /// neither a detached ephemeral warm nor a slow durable startup warm can
-    /// publish afterward.
+    /// Warm generation and epoch fences: reset invalidates the generation
+    /// before clearing the catalog, so a slow warm cannot publish afterward.
     setup_state: RwLock<CatalogSetupState>,
-    /// Wakes detached ephemeral warm tasks when reset invalidates their
-    /// generation, so they promptly remove in-flight relay entries rather
-    /// than waiting for a response or the grace deadline.
-    setup_changed: Notify,
-    /// Collections whose registration has been ENSURED for this process
-    ///. Latched on a successful durable
-    /// execution or a successful forwarded RegisterSchema (the response
-    /// consumed into the map). A strict error (executor/policy refusal, or
-    /// a never-registered offline error) does NOT latch. Cleared by
-    /// `reset` (allocated ids belong to one system and must not survive
-    /// hard_reset).
-    /// Exact compiled-schema bindings successfully checked in this process,
-    /// grouped by collection. Collection-only latching is insufficient: two
-    /// model declarations can use different identities for the same local
-    /// field name, and display-name changes must not erase an established
-    /// binding.
+    /// Exact compiled-schema bindings admitted in this process, by
+    /// collection. Latched only on success; reset clears the latch
+    /// (allocated ids belong to one system). Collection-only latching would
+    /// be insufficient: two declarations can bind one label with two shapes.
     ensured: RwLock<BTreeMap<String, Vec<EnsuredSchemaBinding>>>,
-    /// The durable map feed: a policy-free reactor subscription over the
-    /// three catalog collections (wildcard watchers; the reactor's own
-    /// initial fetch is the warm scan). Dropping either half unsubscribes,
-    /// so reset tears the feed down by clearing this and the next warm
-    /// re-establishes it. The listener holds a Weak of this inner (a strong
-    /// ref here would cycle through the guard's callback and leak).
+    /// The durable map feed. Dropping either half unsubscribes, so reset
+    /// tears the feed down by clearing this and the next warm re-establishes
+    /// it. The listener holds a Weak of this inner (a strong ref would cycle
+    /// through the guard's callback and leak).
     durable_feed: RwLock<Option<(ReactorSubscription, ankurah_signals::SubscriptionGuard)>>,
-    /// The manager stays generic over the node's PolicyAgent for its
-    /// Node-taking methods (ensure_registered, ensure_subscribed).
-    _pa: std::marker::PhantomData<PA>,
 }
 
 #[derive(Debug, Default)]
 struct CatalogSetupState {
     generation: u64,
-    ephemeral_active: bool,
-    /// While true, `ensure_subscribed` may wait but cannot claim a new warm.
-    /// SystemManager clears it only after storage and reactor reset finish.
+    /// While true, no new warm may be claimed. SystemManager clears it only
+    /// after storage and reactor reset finish.
     resetting: bool,
-    /// Quiescing owner fence for initial relay responses. Reset invalidates it
-    /// before storage deletion and waits for responses already admitted at
-    /// schema ingress to finish NodeApplier.
-    ephemeral_fence: Option<RequestFence>,
-    /// Quiescing owner fence for the current durable storage warm. The warm
-    /// retains one lease from before its first storage access through
-    /// subscription/readiness publication, so reset can invalidate the
-    /// generation and drain it before deleting storage.
+    /// Quiescing owner fence for the current durable warm: one lease held
+    /// from before its first storage access through readiness publication,
+    /// so reset can invalidate and drain it before deleting storage.
     durable_fence: Option<RequestFence>,
-    /// Owner fence for schema registration in the current system epoch.
-    /// It remains absent while no system is ready and is rearmed only by the
-    /// ready hook after startup or reset. Both allocator execution and
-    /// forwarded-response folding retain leases across their map effects.
+    /// Owner fence for schema registration in the current system epoch:
+    /// absent until a root is ready, rearmed only by the ready hook. Both
+    /// execution and response folding retain leases across their map effects.
     registration_fence: Option<RequestFence>,
-    /// Invalidated owners retained until reset finishes. `hard_reset` is
-    /// cancellation-safe at the barrier: a retry while `resetting` clones and
-    /// drains the same fences instead of bypassing work whose first waiter was
-    /// canceled.
+    /// Invalidated owners retained until reset finishes, so a canceled and
+    /// retried `hard_reset` drains the same fences instead of bypassing
+    /// work whose first waiter was canceled.
     draining_fences: Vec<RequestFence>,
     /// A durable hard reset drops its reactor subscription. Once the new
     /// system root is ready, one warm must attach the current generation.
     durable_resume_pending: bool,
 }
 
-impl<SE, PA> CatalogInner<SE, PA>
-where PA: PolicyAgent
-{
-    /// Resolve a compiled alias through identities retained at registration.
-    /// This applies to ordinary and explicit fields alike: both must survive a
-    /// later display-name change. Multiple admitted declarations mapping the
-    /// same local name to different ids are ambiguous and fail closed.
-    fn resolve_property(&self, model: EntityId, collection: &str, name: &str) -> anyhow::Result<Option<EntityId>> {
-        let matching_properties: Vec<_> = self
-            .ensured
-            .read()
-            .unwrap()
-            .get(collection)
-            .into_iter()
-            .flat_map(|bindings| bindings.iter())
-            .filter(|binding| binding.model == model)
-            .filter_map(|binding| binding.fields.get(name).copied())
-            .collect();
-        if matching_properties.is_empty() {
-            return self.map.read().unwrap().resolve(collection, name);
-        }
-
-        let map = self.map.read().unwrap();
-        let mut candidates = BTreeSet::new();
-        for property in matching_properties {
-            if map.membership(&model, &property).is_some() && map.properties.contains_key(&property) {
-                candidates.insert(property);
-            }
-        }
-
-        if candidates.len() > 1 {
-            anyhow::bail!(
-                "property '{name}' in model '{}' is ambiguous across {} admitted durable identities",
-                proto::ModelId::EntityId(model),
-                candidates.len()
-            );
-        }
-
-        Ok(candidates.iter().next().copied())
-    }
-}
-
-// The name-to-id lookup behind `CatalogManager::resolve`. The wider catalog
-// metadata surface (model listing, reverse name lookups) becomes the
-// CatalogResolver trait in the propertyid-resolution PR.
-impl<SE, PA> CatalogInner<SE, PA>
-where
-    SE: StorageEngine + Send + Sync + 'static,
-    PA: PolicyAgent + Send + Sync + 'static,
-{
-    pub(crate) fn resolve_model_property(&self, model: &proto::ModelId, name: &str) -> anyhow::Result<Option<PropertyId>> {
-        let proto::ModelId::EntityId(id) = model else {
-            return Ok(SystemProperty::from_name(name).map(PropertyId::System));
-        };
-        let Some(label) = self.map.read().unwrap().models.get(id).map(|model| model.label.clone()) else {
-            return Ok(None);
-        };
-        Ok(self.resolve_property(*id, &label, name)?.map(PropertyId::EntityId))
-    }
-}
-
-impl<SE, PA> CatalogManager<SE, PA>
-where
-    SE: StorageEngine + Send + Sync + 'static,
-    PA: PolicyAgent + Send + Sync + 'static,
-{
-    pub(crate) fn new(storage: Arc<SE>, durable: bool) -> Self {
+impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 'static> CatalogManager<SE, PA> {
+    pub(crate) fn new(durable: bool) -> Self {
         Self(Arc::new(CatalogInner {
-            storage,
             node: RwLock::new(None),
             durable,
             allocator: tokio::sync::Mutex::new(()),
@@ -251,102 +128,60 @@ where
             ready: RwLock::new(false),
             ready_notify: Notify::new(),
             setup_state: RwLock::new(CatalogSetupState::default()),
-            setup_changed: Notify::new(),
             ensured: RwLock::new(BTreeMap::new()),
             durable_feed: RwLock::new(None),
-            _pa: std::marker::PhantomData,
         }))
     }
 
     /// Called right after the `NodeInner` Arc exists (beside
-    /// `policy_agent.on_node_ready`). It installs the hard-reset/readiness
-    /// hooks. Durable nodes arm a warm that the system-ready hook launches;
-    /// ephemeral catalog setup remains driven by `ensure_subscribed`.
+    /// `policy_agent.on_node_ready`); installs the hard-reset/readiness hooks
+    /// and, on durable nodes, arms the warm the system-ready hook launches.
     pub(crate) fn start(&self, node: WeakNode<SE, PA>) {
         let Some(strong) = node.upgrade() else { return };
         *self.0.node.write().unwrap() = Some(node);
 
-        // Install the hard-reset flush hook on the system manager so
-        // SystemManager::hard_reset can clear the catalog in-place (it does
-        // not hold the CatalogManager directly).
-        {
-            let begin_manager = self.clone();
-            let finish_manager = self.clone();
-            let resume_manager = self.clone();
-            strong.system.set_catalog_reset_hook(
-                Arc::new(move || {
-                    let manager = begin_manager.clone();
-                    Box::pin(async move { manager.begin_reset().await })
-                }),
-                Arc::new(move || finish_manager.finish_reset()),
-                Arc::new(move || resume_manager.resume_after_system_ready()),
-            );
-        }
+        // SystemManager::hard_reset clears the catalog through these hooks;
+        // it does not hold the CatalogManager directly.
+        let (begin, finish, resume) = (self.clone(), self.clone(), self.clone());
+        strong.system.set_catalog_reset_hook(
+            Arc::new(move || {
+                let manager = begin.clone();
+                Box::pin(async move { manager.begin_reset().await })
+            }),
+            Arc::new(move || finish.finish_reset()),
+            Arc::new(move || resume.resume_after_system_ready()),
+        );
 
         if self.0.durable {
-            // A durable node may remain deliberately uninitialized. Do not
-            // spawn a task that owns the managers while waiting indefinitely
-            // for a system root. Instead, arm exactly one warm and let
-            // SystemManager's create/load-ready transition call the hook.
+            // A durable node may stay deliberately uninitialized: spawn no
+            // root-waiting task that owns the managers, just arm exactly one
+            // warm for SystemManager's ready transition to launch.
             self.0.setup_state.write().unwrap().durable_resume_pending = true;
         }
 
-        // Every ready system epoch gets one registration fence, on either
-        // node kind. If loading/joining won the race before hook installation,
-        // this claims the missed transition; otherwise SystemManager calls it.
+        // If loading/joining won the race before hook installation, claim
+        // the missed ready transition; otherwise SystemManager calls it.
         if strong.system.is_system_ready() {
             self.resume_after_system_ready();
         }
     }
 
-    /// Run one generation's durable warm and always release readiness for a
-    /// still-current generation. The system-ready hook launches both startup
-    /// and post-reset generations; no task waits indefinitely for a root.
-    async fn run_durable_warm(&self, generation: u64, _lease: RequestLease) {
-        if let Err(e) = self.warm_durable(generation).await {
-            error!("CatalogManager durable warm failed: {}", e);
-            // Readiness must still latch: registration's readiness wait
-            // (`wait_catalog_ready_if_current`) parks on it, and a permanently
-            // un-ready catalog would turn one failed warm into a hang.
-            // With a partial map, later registrations reject loudly on their
-            // storage double-checks instead, which is the retryable failure
-            // mode we want.
-            let setup = self.0.setup_state.read().unwrap();
-            if setup.generation == generation {
-                self.mark_ready();
-            }
-        }
-    }
-
     /// Durable path: subscribe the map to the three catalog collections and
     /// mark ready. The reactor subscription IS the warm: registering each
-    /// `Predicate::True` query runs the same local scan the old hand-rolled
-    /// warm did and delivers it through the listener, and every later
-    /// catalog commit (local or remote funnel; both end in `notify_change`)
-    /// arrives the same way. The executor still folds its own commits
-    /// synchronously under the allocator mutex -- the feed is asynchronous,
-    /// and consecutive registrations must observe their predecessors --
-    /// which is harmless because folds are idempotent by entity id.
-    ///
-    /// The subscription is policy-free by construction: `Reactor::subscribe`
-    /// and `add_query_and_notify` carry no credentials (policy lives in
-    /// EntityLiveQuery above the reactor), and the map is node
-    /// infrastructure, like `SystemManager`'s storage reads. The gap fetcher
-    /// is never invoked for a limit-less selection, so the noop is the
-    /// honest one.
-    ///
-    /// A schema-less durable node has no catalog rows yet: the fetches find
-    /// nothing and it is immediately ready with an empty (correct) map.
-    /// Opening the collections creates their empty materializations on
-    /// first startup, which is harmless and makes the catalog tables
-    /// inspectable.
-    async fn warm_durable(&self, generation: u64) -> Result<(), crate::error::RetrievalError> {
+    /// `Predicate::True` query runs the local scan through the listener, and
+    /// every later catalog commit (local or remote funnel) arrives the same
+    /// way. The executor still folds its own commits synchronously under the
+    /// allocator mutex (the feed is asynchronous, and consecutive
+    /// registrations must observe their predecessors); folds are idempotent
+    /// by entity id, so the overlap is harmless. The subscription carries no
+    /// credentials by construction (policy lives in EntityLiveQuery above
+    /// the reactor). A schema-less durable node finds no rows and is
+    /// immediately ready with an empty, correct map.
+    async fn warm_durable(&self, generation: u64) -> Result<(), RetrievalError> {
         if self.0.setup_state.read().unwrap().generation != generation {
             return Ok(());
         }
-        let Some(node) = self.node() else {
-            return Err(crate::error::RetrievalError::Other("catalog warm ran without a node".to_owned()));
-        };
+        let node = self.node().ok_or_else(|| RetrievalError::Other("catalog warm ran without a node".to_owned()))?;
 
         // Listener first, then queries: the queries' own fetches deliver the
         // existing rows through this listener, so nothing can be missed
@@ -354,40 +189,26 @@ where
         // reset (which bumps the generation before clearing the map) mutes
         // any straggler delivery from a torn-down feed.
         let subscription = node.reactor.subscribe();
-        let guard = {
-            use ankurah_signals::Subscribe;
-            let weak = Arc::downgrade(&self.0);
-            subscription.subscribe(move |update: ReactorUpdate| {
-                if let Some(inner) = weak.upgrade() {
-                    let me = CatalogManager(inner);
-                    if me.0.setup_state.read().unwrap().generation == generation {
-                        me.apply_reactor_update(update);
-                    }
-                }
-            })
-        };
+        use ankurah_signals::Subscribe;
+        let weak = Arc::downgrade(&self.0);
+        let guard = subscription.subscribe(move |update: ReactorUpdate| {
+            if let Some(inner) = weak.upgrade().filter(|inner| inner.setup_state.read().unwrap().generation == generation) {
+                CatalogManager(inner).apply_reactor_update(update);
+            }
+        });
 
-        let everything = ankql::ast::Selection { predicate: ankql::ast::Predicate::True, order_by: None, limit: None };
-        for model in catalog_collections() {
-            let label = match model {
-                ModelId::System(system) => crate::schema::system_collection_label(system),
-                ModelId::EntityId(_) => unreachable!("catalog collections are system models"),
-            };
+        let everything = Selection { predicate: Predicate::True, order_by: None, limit: None };
+        let (sub, noop) = (subscription.id(), Arc::new(NoopGapFetcher));
+        for label in [super::MODEL_COLLECTION_ID, super::PROPERTY_COLLECTION_ID, super::MODEL_PROPERTY_COLLECTION_ID] {
+            let (qid, cid) = (proto::QueryId::new(), proto::CollectionId::fixed_name(label));
             node.reactor
-                .add_query_and_notify(
-                    subscription.id(),
-                    proto::QueryId::new(),
-                    proto::CollectionId::fixed_name(label),
-                    everything.clone(),
-                    &node,
-                    EntityResultSet::empty(),
-                    Arc::new(NoopGapFetcher),
-                    (),
-                )
+                .add_query_and_notify(sub, qid, cid, everything.clone(), &node, EntityResultSet::empty(), noop.clone(), ())
                 .await
-                .map_err(|e| crate::error::RetrievalError::Other(format!("catalog feed query failed: {e}")))?;
+                .map_err(|e| RetrievalError::Other(format!("catalog feed query failed: {e}")))?;
         }
 
+        // The held setup guard excludes a reset's generation bump (a setup
+        // write) between this check and feed/readiness publication.
         let setup = self.0.setup_state.read().unwrap();
         if setup.generation != generation {
             return Ok(());
@@ -397,55 +218,31 @@ where
         Ok(())
     }
 
-    /// Fold one reactor update into the map: the notified entities' states
-    /// through the same `parse_state`/`apply_entry` path the executor and
-    /// response folds use, keyed by each entity's collection. Idempotent by
-    /// entity id, so racing the executor's synchronous fold is harmless.
-    /// Membership removes are ignored: catalog rows never leave a
+    /// Fold one reactor update into the map, keyed by entity collection.
+    /// Idempotent by entity id, so racing the executor's synchronous fold is
+    /// harmless. Membership removes are ignored: catalog rows never leave a
     /// `Predicate::True` selection, and reset synthetics are muted by the
     /// listener's generation gate.
     fn apply_reactor_update(&self, update: ReactorUpdate) {
         let mut map = self.0.map.write().unwrap();
         for item in update.items {
-            let Some(model) = crate::schema::system_model_id(item.entity.collection().as_str()) else {
-                continue;
-            };
-            let Ok(state) = item.entity.to_entity_state() else {
-                continue;
-            };
-            if let Some(entry) = parse_state(&model, item.entity.id(), &state) {
-                apply_entry(&mut map, entry);
+            let Some(model) = crate::schema::system_model_id(item.entity.collection().as_str()) else { continue };
+            if let Ok(state) = item.entity.to_entity_state() {
+                map.apply_state(&model, item.entity.id(), &state);
             }
         }
     }
 
     // -- readiness ----------------------------------------------------------
 
-    /// The owning node, while it lives: present from `start` (called in
-    /// `Node::build`) until the node is dropped.
+    /// The owning node, from `start` (called in `Node::build`) until drop.
     pub(crate) fn node(&self) -> Option<Node<SE, PA>> { self.0.node.read().unwrap().clone()?.upgrade() }
 
     /// Whether the catalog map is authoritative for the current system epoch.
     pub fn is_catalog_ready(&self) -> bool { *self.0.ready.read().unwrap() }
 
-    /// Wait until the catalog map is authoritative for the current system epoch.
-    pub async fn wait_catalog_ready(&self) {
-        // `Notify::notify_waiters` wakes only waiters REGISTERED at that
-        // moment (it stores no permit), so the `Notified` future must be
-        // created BEFORE the readiness check: checking first and creating the
-        // future after would lose a `mark_ready` that lands in between and
-        // hang this waiter (and its query) forever. Loop because `reset` can
-        // flip readiness back off between the wake and our re-check.
-        loop {
-            let notified = self.0.ready_notify.notified();
-            tokio::pin!(notified);
-            notified.as_mut().enable();
-            if self.is_catalog_ready() {
-                return;
-            }
-            notified.await;
-        }
-    }
+    /// Wait until [`Self::is_catalog_ready`].
+    pub async fn wait_catalog_ready(&self) { self.ready_unless(|| false).await; }
 
     /// Snapshot the current system epoch's schema-registration owner. It is
     /// absent before a root is ready and throughout hard reset; callers must
@@ -458,11 +255,22 @@ where
     /// allocator request. The caller acquires the validity lease after this
     /// returns, closing the ready-to-reset race atomically at the fence.
     pub(crate) async fn wait_catalog_ready_if_current(&self, validity: &RequestValidity) -> bool {
+        self.ready_unless(|| !validity.is_current()).await
+    }
+
+    /// Readiness wait, abandoned whenever `cancelled` answers true. The
+    /// `Notified` future must exist BEFORE each check: `notify_waiters`
+    /// wakes only waiters registered at that moment (no permit is stored),
+    /// so checking first would lose a `mark_ready` landing in between and
+    /// hang this waiter forever. Loop because reset can flip readiness back
+    /// off between wake and re-check; reset notifies too, so `cancelled` is
+    /// re-polled promptly.
+    async fn ready_unless(&self, cancelled: impl Fn() -> bool) -> bool {
         loop {
             let notified = self.0.ready_notify.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            if !validity.is_current() {
+            if cancelled() {
                 return false;
             }
             if self.is_catalog_ready() {
@@ -477,11 +285,9 @@ where
         self.0.ready_notify.notify_waiters();
     }
 
-    /// Begin SystemManager's reset barrier. Invalidate the generation and all
-    /// epoch owners synchronously, tear down old live queries before waiting,
-    /// then drain durable warming, ephemeral setup/local/wire application, and
-    /// schema-registration effects. Storage deletion cannot begin until this
-    /// returns.
+    /// Begin SystemManager's reset barrier: invalidate the generation and
+    /// all epoch owners synchronously, then drain durable warming and
+    /// registration effects. Storage deletion waits for this to return.
     async fn begin_reset(&self) {
         let draining_fences = {
             let mut setup = self.0.setup_state.write().unwrap();
@@ -489,16 +295,7 @@ where
                 setup.resetting = true;
                 setup.generation = setup.generation.wrapping_add(1);
             }
-            setup.ephemeral_active = false;
-            if let Some(fence) = setup.ephemeral_fence.take() {
-                fence.invalidate();
-                setup.draining_fences.push(fence);
-            }
-            if let Some(fence) = setup.durable_fence.take() {
-                fence.invalidate();
-                setup.draining_fences.push(fence);
-            }
-            if let Some(fence) = setup.registration_fence.take() {
+            for fence in [setup.durable_fence.take(), setup.registration_fence.take()].into_iter().flatten() {
                 fence.invalidate();
                 setup.draining_fences.push(fence);
             }
@@ -506,7 +303,6 @@ where
             setup.draining_fences.clone()
         };
 
-        self.0.setup_changed.notify_waiters();
         self.0.ready_notify.notify_waiters();
 
         for fence in draining_fences {
@@ -514,29 +310,25 @@ where
         }
     }
 
-    /// Finish SystemManager's reset only after storage, system state, and the
-    /// reactor have been cleared. This is the point where a new ephemeral
-    /// setup may claim the next generation.
+    /// Finish SystemManager's reset only after storage, system state, and
+    /// the reactor have been cleared; the next ready transition claims a
+    /// fresh warm from here.
     fn finish_reset(&self) {
         let mut setup = self.0.setup_state.write().unwrap();
-        // Tear down the feed before clearing the map: dropping the handles
-        // unsubscribes, and the next generation's warm re-establishes it.
+        // Feed teardown before map clear: dropping the handles unsubscribes,
+        // and the next generation's warm re-establishes them.
         *self.0.durable_feed.write().unwrap() = None;
         self.0.map.write().unwrap().clear();
         *self.0.ready.write().unwrap() = false;
-        // Allocations belong to one system and must not survive hard_reset
-        //: a node re-joining a different system must re-register
-        // everything against the new system's allocator.
+        // Allocations belong to one system: a node re-joining a different
+        // system must re-register everything against the new allocator.
         self.0.ensured.write().unwrap().clear();
         setup.draining_fences.clear();
         setup.resetting = false;
         setup.durable_resume_pending = self.0.durable;
-        // Wake any ensure_subscribed waiters so they observe the cleared
-        // latch instead of sleeping on a readiness that will never come, and
-        // cancel the detached owner so it removes its relay attempts before a
-        // held stale response can reach NodeApplier.
         drop(setup);
-        self.0.setup_changed.notify_waiters();
+        // Wake waiters to observe the cleared state rather than sleeping on
+        // a readiness that will never come.
         self.0.ready_notify.notify_waiters();
         debug!("CatalogManager reset (map cleared, not ready)");
     }
@@ -545,7 +337,7 @@ where
     /// ready root. Every node kind gets exactly one registration fence; a
     /// durable node also claims its one pending storage warm.
     fn resume_after_system_ready(&self) {
-        let durable_claim = {
+        let (generation, lease) = {
             let mut setup = self.0.setup_state.write().unwrap();
             if setup.resetting {
                 return;
@@ -562,23 +354,54 @@ where
             setup.durable_fence = Some(fence);
             (setup.generation, lease)
         };
-        let (generation, lease) = durable_claim;
         let me = self.clone();
-        crate::task::spawn(async move { me.run_durable_warm(generation, lease).await });
+        crate::task::spawn(async move {
+            let _lease = lease;
+            if let Err(e) = me.warm_durable(generation).await {
+                error!("CatalogManager durable warm failed: {}", e);
+                // Readiness must still latch even on failure: registration's
+                // wait parks on it, and one failed warm must not become a
+                // hang. Later registrations reject loudly on their storage
+                // double-checks instead, the retryable failure mode we want.
+                // The held setup guard excludes a reset's generation bump
+                // between the check and the latch.
+                let setup = me.0.setup_state.read().unwrap();
+                if setup.generation == generation {
+                    me.mark_ready();
+                }
+            }
+        });
     }
 
     // -- public lookup API (cheap clones) -----------------------------------
 
-    /// The property addressed by `name` in `model`: prefer retained exact
-    /// bindings for admitted ordinary or explicit fields, fail closed if those
-    /// bindings disagree, and otherwise consult the current display-name map.
+    /// The property addressed by `name` in `model`. An admitted explicit
+    /// compiled id pins its identity through display renames and fails
+    /// closed (None) when admitted declarations disagree; ordinary names
+    /// consult the current display-name index.
     pub fn resolve(&self, model: &proto::ModelId, name: &str) -> Option<PropertyId> {
-        self.0.resolve_model_property(model, name).ok().flatten()
+        let proto::ModelId::EntityId(id) = model else {
+            return SystemProperty::from_name(name).map(PropertyId::System);
+        };
+        let map = self.0.map.read().unwrap();
+        let label = map.models.get(id)?.label.clone();
+        let mut pinned = BTreeSet::new();
+        for binding in self.0.ensured.read().unwrap().get(label.as_str()).into_iter().flatten().filter(|b| b.model == *id) {
+            let Some(explicit) = binding.schema.properties.iter().find(|f| f.name == name).and_then(|f| f.explicit_id) else { continue };
+            let property = super::compiled::parse_explicit_id(explicit);
+            if map.membership(id, &property).is_some() && map.properties.contains_key(&property) {
+                pinned.insert(property);
+            }
+        }
+        match (pinned.len(), pinned.first()) {
+            (0, _) => map.resolve(&label, name).ok().flatten().map(PropertyId::EntityId),
+            (1, Some(property)) => Some(PropertyId::EntityId(*property)),
+            _ => None,
+        }
     }
 
-    /// Test-only probe for detecting catalog ownership cycles after a node is
-    /// dropped. The closure owns only a weak pointer and therefore does not
-    /// affect the lifetime it observes.
+    /// Test-only probe for catalog ownership cycles after a node drop; the
+    /// closure holds only a weak pointer, never extending what it observes.
     #[cfg(feature = "test-helpers")]
     pub fn liveness_probe(&self) -> impl Fn() -> bool + Send + Sync + 'static {
         let weak = Arc::downgrade(&self.0);
@@ -588,30 +411,16 @@ where
     /// Return the current catalog definition for a durable property identity.
     pub fn property_by_id(&self, id: &EntityId) -> Option<PropertyDef> { self.0.map.read().unwrap().properties.get(id).cloned() }
 
-    /// Return the model currently registered under a source label.
-    ///
-    /// This is catalog metadata, not a storage-engine materialization lookup.
+    /// The model currently registered under a source label (catalog
+    /// metadata, not a storage-engine materialization lookup).
     pub fn model_by_label(&self, label: &str) -> Option<ModelDef> {
         let map = self.0.map.read().unwrap();
-        let id = map.by_label.get(label)?;
-        map.models.get(id).cloned()
+        map.models.get(map.by_label.get(label)?).cloned()
     }
 
-    /// Whether this catalog recognizes a wire model identity. System models
-    /// are the bootstrap base case, answerable on a stone-cold node; allocated
-    /// ids must already be present in the catalog map. A miss after descriptor
-    /// shipping is a protocol violation.
-    pub fn knows_model(&self, model: &proto::ModelId) -> bool {
-        match model {
-            proto::ModelId::System(_) => true,
-            proto::ModelId::EntityId(id) => self.0.map.read().unwrap().models.contains_key(id),
-        }
-    }
-
-    /// Catalog lookup for the model definition currently bound to a declared
-    /// model label. This is schema information, not the authoritative
-    /// storage materialization reverse map; wire egress must ask the storage
-    /// engine for that mapping.
+    /// The model id currently bound to a declared label. Schema information
+    /// only, not the authoritative storage materialization reverse map; wire
+    /// egress must ask the storage engine for that.
     pub fn model_id_for(&self, label: &str) -> Option<proto::ModelId> {
         crate::schema::system_model_id(label)
             .or_else(|| self.0.map.read().unwrap().by_label.get(label).copied().map(proto::ModelId::EntityId))
@@ -621,14 +430,7 @@ where
     /// Unlike `model_id_for`, this never performs a name lookup: the identity
     /// comes from the registration response (or a proven compatible binding).
     pub fn model_id_for_schema(&self, schema: &ModelStructDescriptor) -> Option<proto::ModelId> {
-        self.0
-            .ensured
-            .read()
-            .unwrap()
-            .get(schema.label)?
-            .iter()
-            .find(|binding| *binding.schema == *schema)
-            .map(|binding| proto::ModelId::EntityId(binding.model))
+        self.0.ensured.read().unwrap().get(schema.label)?.iter().find(|b| *b.schema == *schema).map(|b| proto::ModelId::EntityId(b.model))
     }
 
     /// Return the membership connecting `model` and `property`, if present.
@@ -647,102 +449,67 @@ where
 
     // -- registration lifecycle --------------------------------------------
 
-    // -- allocator support ---------------------
-
     /// Serialize a registration execution. The executor holds this across
     /// its whole lookup/allocate/commit/upsert sequence.
     pub(crate) async fn lock_allocator(&self) -> tokio::sync::MutexGuard<'_, ()> { self.0.allocator.lock().await }
 
-    /// The property lookup key: (minting
-    /// model, current name). Backend and value_type left the key with the
-    /// canonical value_type ruling: a same-name registration with a different
-    /// type is a COMPATIBILITY question against the found definition, never a
-    /// second identity. Used by the executor's upsert and the rename hint
-    /// pre-pass.
     /// The property `name` currently addresses within `model`'s membership
-    /// set. Membership is the lookup scope -- a property shared into this
-    /// model resolves here regardless of where it was minted; `minted_for`
-    /// is provenance metadata, never a matching key.
+    /// set. Membership is the whole lookup scope: `minted_for` is
+    /// provenance, never a matching key, and backend/value_type are no part
+    /// of the key either (a same-name registration with a different type is
+    /// a compatibility question, never a second identity).
     pub fn property_by_name(&self, model: &EntityId, name: &str) -> Option<PropertyDef> {
         let map = self.0.map.read().unwrap();
-        map.memberships_of(model)
-            .into_iter()
-            .find_map(|membership| map.properties.get(&membership.property).filter(|p| p.name == name).cloned())
+        map.memberships_of(model).into_iter().find_map(|m| map.properties.get(&m.property).filter(|p| p.name == name).cloned())
     }
 
-    /// Build the confirmed binding from the allocator's response itself.
-    /// Registration results are the only race-free authority for the ids this
-    /// exact request resolved; reconstructing them from mutable display names
-    /// after the response could observe a concurrent rename or name reuse.
-    fn registered_binding(
-        &self,
-        schema: &'static ModelStructDescriptor,
-        models: &[proto::RegisteredModel],
-    ) -> Option<EnsuredSchemaBinding> {
+    /// Build the confirmed binding from the allocator's response itself: the
+    /// response is the only race-free authority for the ids this exact
+    /// request resolved (display names can rename or be reused concurrently).
+    fn registered_binding(&self, schema: &'static ModelStructDescriptor, models: &[RegisteredModel]) -> Option<EnsuredSchemaBinding> {
         let model_def = models.iter().find(|model| model.label == schema.label)?;
-        let model = model_def.id;
-        if schema.explicit_id.is_some_and(|id| super::compiled::parse_explicit_id(id) != model) {
+        if schema.explicit_id.is_some_and(|id| super::compiled::parse_explicit_id(id) != model_def.id) {
             return None;
         }
-
-        let mut fields = BTreeMap::new();
         for field in schema.properties {
             // A nested response row IS the membership; matching it proves
             // the field is bound to this model.
-            let property = match field.explicit_id {
-                Some(id) => {
-                    let id = super::compiled::parse_explicit_id(id);
-                    model_def.properties.iter().find(|property| property.id == id)?
-                }
-                None => model_def.properties.iter().find(|property| property.name == field.name)?,
-            };
-            if property.backend != field.backend || !super::registration::value_types_compatible(&property.value_type, field.value_type) {
-                return None;
+            match field.explicit_id {
+                Some(id) => model_def.properties.iter().find(|p| p.id == super::compiled::parse_explicit_id(id)),
+                None => model_def.properties.iter().find(|p| p.name == field.name),
             }
-            fields.insert(field.name, property.id);
+            .filter(|p| p.backend == field.backend && super::registration::value_types_compatible(&p.value_type, field.value_type))?;
         }
-
-        Some(EnsuredSchemaBinding { schema, model, fields, confirmed: true })
+        Some(EnsuredSchemaBinding { schema, model: model_def.id, confirmed: true })
     }
 
     /// Derive the exact binding an already-populated catalog proves for this
-    /// compiled declaration.
-    ///
-    /// Ordinary fields resolve within the model's MEMBERSHIP SET by current
-    /// name (the same scope the allocator uses; a property shared into the
-    /// model counts, and an ambiguous name fails the proof). An explicit
-    /// model id must itself be the label's live model. Every field then
-    /// needs a compatible immutable backend/type pair.
+    /// compiled declaration: ordinary fields resolve by current name within
+    /// the model's MEMBERSHIP SET (the allocator's own scope; ambiguity
+    /// fails the proof), an explicit model id must be the label's live
+    /// model, and every field needs a compatible immutable backend/type pair.
     fn compatible_binding(&self, schema: &'static ModelStructDescriptor, confirmed: bool) -> Option<EnsuredSchemaBinding> {
         let map = self.0.map.read().unwrap();
+        // `by_label` maps a label to the model whose CURRENT label it is, so
+        // one index check covers liveness and label match for an explicit id.
         let model = match schema.explicit_id {
-            Some(id) => {
-                let id = super::compiled::parse_explicit_id(id);
-                let def = map.models.get(&id)?;
-                if def.label != schema.label || map.by_label.get(schema.label) != Some(&id) {
-                    return None;
-                }
-                id
-            }
+            Some(id) => super::compiled::parse_explicit_id(id),
             None => *map.by_label.get(schema.label)?,
         };
-
-        let mut fields = BTreeMap::new();
+        if map.by_label.get(schema.label) != Some(&model) {
+            return None;
+        }
         for field in schema.properties {
             let id = match field.explicit_id {
                 Some(id) => super::compiled::parse_explicit_id(id),
                 None => map.resolve(schema.label, field.name).ok().flatten()?,
             };
-            if map.membership(&model, &id).is_none() {
-                return None;
-            }
-            let def = map.properties.get(&id)?;
-            if def.backend != field.backend || !super::registration::value_types_compatible(&def.value_type, field.value_type) {
-                return None;
-            }
-            fields.insert(field.name, id);
+            map.membership(&model, &id)?;
+            map.properties.get(&id).filter(|def| {
+                def.backend == field.backend && super::registration::value_types_compatible(&def.value_type, field.value_type)
+            })?;
         }
-        Some(EnsuredSchemaBinding { schema, model, fields, confirmed })
+        Some(EnsuredSchemaBinding { schema, model, confirmed })
     }
 
     /// Record an exact binding proven from an already-compatible catalog.
@@ -751,8 +518,7 @@ where
         // Bind proof and publication to one ready system epoch. Reset either
         // invalidates before admission (fail closed) or waits for this lease
         // before clearing, so old ids cannot be stored after the clear.
-        let Some(validity) = self.registration_validity() else { return false };
-        let Some(_lease) = validity.try_acquire() else { return false };
+        let Some(_lease) = self.registration_validity().and_then(|validity| validity.try_acquire()) else { return false };
         let Some(binding) = self.compatible_binding(schema, false) else { return false };
         self.store_binding(binding);
         true
@@ -761,17 +527,20 @@ where
     fn store_binding(&self, binding: EnsuredSchemaBinding) {
         let mut ensured = self.0.ensured.write().unwrap();
         let bindings = ensured.entry(binding.schema.label.to_string()).or_default();
-        if let Some(existing) = bindings.iter_mut().find(|known| *known.schema == *binding.schema) {
-            // Confirmation belongs to the exact ids returned by the
-            // allocator. A later local proof may not replace those ids while
-            // inheriting their confirmation; only another confirmed result
-            // can replace a confirmed binding.
-            if binding.confirmed || !existing.confirmed {
-                *existing = binding;
-            }
-        } else {
-            bindings.push(binding);
+        match bindings.iter_mut().find(|known| *known.schema == *binding.schema) {
+            // Confirmation belongs to the exact ids the allocator returned:
+            // a later local proof may not replace them while inheriting
+            // their confirmation; only another confirmed result may.
+            Some(existing) if binding.confirmed || !existing.confirmed => *existing = binding,
+            Some(_) => {}
+            None => bindings.push(binding),
         }
+    }
+
+    /// The exact model identity retained for `schema`, or a loud failure
+    /// naming the `step` that should have retained it.
+    fn retained_model_id(&self, schema: &ModelStructDescriptor, step: &str) -> Result<proto::ModelId, RegistrationError> {
+        self.model_id_for_schema(schema).ok_or_else(|| reg_err(format!("{step} of '{}' lost its exact model identity", schema.label)))
     }
 
     /// Automatic schema use (mutation or predicate) tries the allocator first.
@@ -783,42 +552,26 @@ where
         schema: &'static ModelStructDescriptor,
     ) -> Result<proto::ModelId, RegistrationError> {
         match self.ensure_registered(cdata, schema).await {
-            Ok(()) => self.model_id_for_schema(schema).ok_or_else(|| {
-                RegistrationError::Retrieval(crate::error::RetrievalError::Other(format!(
-                    "registration of '{}' did not retain its exact model identity",
-                    schema.label
-                )))
-            }),
+            Ok(()) => self.retained_model_id(schema, "registration"),
             Err(error @ RegistrationError::NoDurablePeer(_)) if self.bind_compatible_schema(schema) => {
-                tracing::warn!(
-                    "schema reassertion for fully bound collection '{}' has no durable peer; proceeding with proven canonical identities: {}",
-                    schema.label,
-                    error
-                );
-                self.model_id_for_schema(schema).ok_or_else(|| {
-                    RegistrationError::Retrieval(crate::error::RetrievalError::Other(format!(
-                        "compatible binding for '{}' did not retain its exact model identity",
-                        schema.label
-                    )))
-                })
+                tracing::warn!("fully bound '{}' has no durable peer; proceeding on proven identities: {}", schema.label, error);
+                self.retained_model_id(schema, "compatible binding")
             }
-            // A known label whose compiled shape could not be proven bound is
-            // an unconfirmed schema, not an unregistered collection; saying
-            // "never registered" for it would be false.
-            Err(RegistrationError::NoDurablePeer(label)) if self.model_by_label(schema.label).is_some() => {
+            // A known label whose compiled shape could not be proven bound
+            // is an unconfirmed schema; "never registered" would be false.
+            Err(RegistrationError::NoDurablePeer(label)) if self.model_by_label(&label).is_some() => {
                 Err(RegistrationError::UnconfirmedSchema(label))
             }
             Err(error) => Err(error),
         }
     }
 
-    /// Fold resolved definitions into the map: the executor calls this
-    /// synchronously post-commit (before releasing the allocator mutex),
-    /// and `ensure_registered` calls it with a SchemaRegistered response so
-    /// binding proceeds ahead of the catalog subscription.
-    /// Idempotent (keyed by entity id); the reactor later re-delivers the
-    /// same entities harmlessly.
-    pub fn upsert_registered(&self, models: &[proto::RegisteredModel]) {
+    /// Fold resolved definitions into the map: called by the executor
+    /// synchronously post-commit (before releasing the allocator mutex) and
+    /// by `ensure_registered` with a SchemaRegistered response, so binding
+    /// proceeds ahead of the feed. Idempotent by entity id; the reactor's
+    /// later re-delivery is harmless.
+    pub fn upsert_registered(&self, models: &[RegisteredModel]) {
         let mut map = self.0.map.write().unwrap();
         for m in models {
             map.upsert_model(ModelDef { id: m.id, label: m.label.clone(), name: m.name.clone() });
@@ -842,54 +595,40 @@ where
     }
 
     /// TEST ONLY: seed deterministic catalog rows and admit their exact
-    /// compiled-schema binding without writing catalog entities.
-    ///
-    /// Deterministic protocol simulators forge stable entity, model, and
-    /// property identities so two runs have byte-identical traces. They cannot
-    /// use the production allocator, whose fresh ULIDs would intentionally
-    /// differ between runs. This helper keeps the compiled binding complete
-    /// (every field proven against the supplied rows) while making the
-    /// fixture's deliberate storage bypass explicit.
+    /// compiled-schema binding without writing catalog entities. Protocol
+    /// simulators need stable identities for byte-identical traces, which
+    /// the allocator's fresh ULIDs cannot give them; the binding stays
+    /// complete (every field proven against the supplied rows) while the
+    /// fixture's storage bypass stays explicit.
     #[cfg(feature = "test-helpers")]
     pub fn seed_registered_schema(
         &self,
         schema: &'static ModelStructDescriptor,
-        models: &[proto::RegisteredModel],
+        models: &[RegisteredModel],
     ) -> Result<(), RegistrationError> {
         self.upsert_registered(models);
         self.mark_schema_ensured(schema, models)
     }
 
-    /// Ensure registration. Called by explicit [`crate::context::Context::register_model`]
-    /// and, through [`Self::ensure_schema_for_use`], by first-use
-    /// registration on mutating and typed-read paths. An existing schema
-    /// resolves to a no-op plan, so re-asserting emits nothing and skips the
-    /// policy verb while the response feeds the map. Fast-returns only if
-    /// this exact compiled schema shape is already ensured in this process,
-    /// then durably registers:
-    ///
-    /// - DURABLE node: execute the registration locally
-    ///   ([`Node::execute_schema_registration`], which updates the map
-    ///   itself under the allocator mutex); latch on Ok.
-    /// - EPHEMERAL node with a durable peer: forward RegisterSchema and
-    ///   consume the SchemaRegistered response into the map; latch on Ok.
-    /// - EPHEMERAL node with NO durable peer: registration is impossible
-    ///   without the allocator, so this returns
-    ///   [`RegistrationError::NoDurablePeer`] without latching. The automatic
-    ///   caller may proceed only if the local catalog proves the exact model
-    ///   and every field's compatible canonical binding.
-    ///
-    /// Every error path returns WITHOUT latching, so a later attempt
-    /// retries.
+    /// Ensure registration: the entry point for explicit
+    /// `Context::register_model` and, via `ensure_schema_for_use`, first-use
+    /// registration on mutating and typed-read paths. Fast-returns only when
+    /// this exact compiled shape is already ensured in this process. DURABLE
+    /// nodes execute locally (the executor updates the map under the
+    /// allocator mutex); EPHEMERAL nodes forward RegisterSchema to a durable
+    /// peer and consume the response into the map, and with NO peer fail
+    /// with NoDurablePeer (only the durable allocator may allocate ids, so
+    /// there is no offline queue). Re-assertion resolves to a no-op plan
+    /// whose response still feeds the map. Success latches; every error path
+    /// returns WITHOUT latching, so a later attempt retries.
     pub async fn ensure_registered(
         &self,
         cdata: &PA::ContextData,
         schema: &'static ModelStructDescriptor,
     ) -> Result<(), RegistrationError> {
-        let collection = schema.label.to_string();
-        // Snapshot and enter the epoch before consulting the latch. Checking
-        // first would allow reset to clear the latch and install a new fence
-        // between the stale boolean and our admission (an ABA false success).
+        // Enter the epoch before consulting the latch: checking first would
+        // let reset clear the latch and install a new fence between the
+        // stale boolean and our admission (an ABA false success).
         let validity = self.registration_validity().ok_or(RegistrationError::SystemNotReady)?;
         let initial_lease = validity.try_acquire().ok_or(RegistrationError::SystemNotReady)?;
         if self.is_schema_ensured(schema) {
@@ -899,61 +638,39 @@ where
         let request_model = proto::RegisterModel::from(schema);
 
         if self.0.durable {
-            // A durable node executes registration itself (no forwarding);
-            // the executor upserts the map before returning. Retain one
-            // outer lease across the executor and exact-schema latch. It must
-            // be snapshotted before execution: reacquiring afterward could
-            // grab a post-reset fence and fold old definitions into the new
-            // epoch (an ABA error).
+            // Retain one outer lease across the executor and latch,
+            // snapshotted before execution: reacquiring afterward could grab
+            // a post-reset fence and fold old definitions into the new epoch.
             let _lease = initial_lease;
             let models = self.register_schema(cdata, vec![request_model]).await?;
             self.mark_schema_ensured(schema, &models)?;
             return Ok(());
         }
 
-        // A forwarded request may be arbitrarily slow. Do not make reset wait
-        // for the network; response admission reacquires this same old fence
-        // and rejects it before schema ingestion if reset invalidated it.
+        // A forwarded request may be arbitrarily slow, and reset must not
+        // wait on the network: the rechecks below reject a stale response
+        // instead, after reset invalidates this epoch's fence.
         drop(initial_lease);
-
-        // Ephemeral: forward to a connected durable peer. There is no offline
-        // registration queue because only the durable allocator may mint ids.
+        let still_current = || validity.is_current().then_some(()).ok_or(RegistrationError::SystemNotReady);
         let node = self.node().ok_or(RegistrationError::SystemNotReady)?;
-        match node.get_durable_peers().first().copied() {
-            Some(peer) => {
-                let body = proto::NodeRequestBody::RegisterSchema { models: vec![request_model] };
-                if !validity.is_current() {
-                    return Err(RegistrationError::SystemNotReady);
-                }
-                match node.request(peer, cdata, body).await {
-                    Ok(body) => {
-                        // The response applies only while this attempt is
-                        // still wanted: recheck before folding so reset
-                        // clears either before or after the complete effect,
-                        // never between them.
-                        if !validity.is_current() {
-                            return Err(RegistrationError::SystemNotReady);
-                        }
-                        let proto::NodeResponseBody::SchemaRegistered { models } = body else {
-                            return match body {
-                                proto::NodeResponseBody::Error(e) => {
-                                    Err(RegistrationError::Retrieval(crate::error::RetrievalError::Other(e)))
-                                }
-                                other => Err(RegistrationError::Retrieval(crate::error::RetrievalError::Other(format!(
-                                    "unexpected response to RegisterSchema: {other}"
-                                )))),
-                            };
-                        };
-                        // The response is the fast path into the map: fold it in on ack so binding proceeds now.
-                        self.upsert_registered(&models);
-                        self.mark_schema_ensured(schema, &models)?;
-                        Ok(())
-                    }
-                    Err(e) => Err(RegistrationError::Retrieval(crate::error::RetrievalError::Other(format!("{e:?}")))),
-                }
-            }
-            None => Err(RegistrationError::NoDurablePeer(collection)),
-        }
+        let Some(peer) = node.get_durable_peers().first().copied() else {
+            return Err(RegistrationError::NoDurablePeer(schema.label.to_string()));
+        };
+        still_current()?;
+        let request = proto::NodeRequestBody::RegisterSchema { models: vec![request_model] };
+        let response = node.request(peer, cdata, request).await.map_err(|e| reg_err(format!("{e:?}")))?;
+        // The response applies only while still wanted: recheck before
+        // folding so reset clears before or after the complete effect,
+        // never between.
+        still_current()?;
+        let models = match response {
+            proto::NodeResponseBody::SchemaRegistered { models } => models,
+            proto::NodeResponseBody::Error(e) => return Err(reg_err(e)),
+            other => return Err(reg_err(format!("unexpected response to RegisterSchema: {other}"))),
+        };
+        // Fold the response in on ack so binding proceeds ahead of the feed.
+        self.upsert_registered(&models);
+        self.mark_schema_ensured(schema, &models)
     }
 
     /// Whether this collection's registration is latched (durably executed
@@ -963,31 +680,18 @@ where
     }
 
     pub(crate) fn is_schema_ensured(&self, schema: &ModelStructDescriptor) -> bool {
-        self.0
-            .ensured
-            .read()
-            .unwrap()
-            .get(schema.label)
-            .is_some_and(|bindings| bindings.iter().any(|known| known.confirmed && *known.schema == *schema))
+        self.0.ensured.read().unwrap().get(schema.label).is_some_and(|b| b.iter().any(|k| k.confirmed && *k.schema == *schema))
     }
 
-    fn mark_schema_ensured(
-        &self,
-        schema: &'static ModelStructDescriptor,
-        models: &[proto::RegisteredModel],
-    ) -> Result<(), RegistrationError> {
-        let binding = self.registered_binding(schema, models).ok_or_else(|| {
-            RegistrationError::Retrieval(crate::error::RetrievalError::Other(format!(
-                "registration of '{}' succeeded without a complete compatible catalog binding",
-                schema.label
-            )))
-        })?;
+    fn mark_schema_ensured(&self, schema: &'static ModelStructDescriptor, models: &[RegisteredModel]) -> Result<(), RegistrationError> {
+        let binding = self
+            .registered_binding(schema, models)
+            .ok_or_else(|| reg_err(format!("registration of '{}' left no complete compatible catalog binding", schema.label)))?;
         self.store_binding(binding);
         Ok(())
     }
 
-    /// TEST/INTROSPECTION: number of parsed entities of each kind
-    /// (models, properties, memberships).
+    /// TEST/INTROSPECTION: (models, properties, memberships) counts.
     #[cfg(any(test, feature = "test-helpers"))]
     pub fn counts(&self) -> (usize, usize, usize) {
         let map = self.0.map.read().unwrap();

--- a/core/src/schema/catalog/map.rs
+++ b/core/src/schema/catalog/map.rs
@@ -1,9 +1,9 @@
 //! The catalog's node-local materialized projection.
 //!
 //! Here, a **map** means the parsed, indexed read model derived from the
-//! catalog's three entity collections. It accepts raw catalog
-//! [`ankurah_proto::EntityState`] values or already-resolved definitions and
-//! produces identity and membership lookups for registration and runtime
+//! catalog's three entity collections. It accepts the catalog's generated
+//! typed Views or already-resolved definitions and produces identity and
+//! membership lookups for registration and runtime
 //! schema resolution. It is not catalog storage, an allocator, a feed
 //! lifecycle, or a cache of compiled Rust-schema bindings; the parent
 //! [`super::CatalogManager`] service owns those concerns.
@@ -11,23 +11,20 @@
 //! This module owns consistency between each definition table and its
 //! secondary indexes. Upserting an entity must remove stale label, name, or
 //! model-membership entries before publishing the new ones, and set-valued
-//! indexes never retain empty buckets. Parsing deliberately reads raw LWW
-//! state: using the typed catalog Views here would make catalog resolution
-//! depend on the projection it is trying to build.
+//! indexes never retain empty buckets. A malformed typed row is rejected by
+//! its accessor and contributes no definition; callers log that failure and
+//! continue processing unrelated rows.
 
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
 };
 
-use ankurah_proto::{self as proto, EntityId};
+use ankurah_proto::EntityId;
 
-use crate::{
-    property::backend::{LWWBackend, PropertyBackend},
-    schema::{model_collection, model_property_collection, property_collection},
-    value::Value,
-    ModelId,
-};
+use crate::property::PropertyError;
+
+use super::rows::{SysModelPropertyRowView, SysModelRowView, SysPropertyRowView};
 
 /// A parsed model definition entity (`_ankurah_model`): the durable model
 /// identity `id`, the source-level registration lookup key `label`, and the
@@ -114,29 +111,31 @@ impl<K: Ord> EntitySetIndex<K> {
 impl CatalogMap {
     pub(super) fn clear(&mut self) { *self = Self::default(); }
 
-    /// Fold one catalog entity state into the map, keyed by its collection.
-    /// Idempotent by entity id; non-catalog collections and unparseable
-    /// states are ignored.
-    pub(super) fn apply_state(&mut self, collection: &ModelId, id: EntityId, state: &proto::EntityState) {
-        let Some(buffer) = state.state.state_buffers.0.get("lww") else { return };
-        let Ok(backend) = LWWBackend::from_state_buffer(buffer) else { return };
-        let values = backend.property_values();
-        let text = |field: &str| if let Some(Some(Value::String(v))) = values.get(field) { Some(v.clone()) } else { None };
-        let eid = |field: &str| if let Some(Some(Value::EntityId(v))) = values.get(field) { Some(*v) } else { None };
+    pub(super) fn apply_model(&mut self, row: &SysModelRowView) -> Result<(), PropertyError> {
+        self.upsert_model(ModelDef { id: row.id(), label: row.label()?, name: row.name()? });
+        Ok(())
+    }
 
-        if *collection == model_collection() {
-            let Some(label) = text("label") else { return };
-            let name = text("name").unwrap_or_else(|| label.clone());
-            self.upsert_model(ModelDef { id, label, name });
-        } else if *collection == property_collection() {
-            let (Some(name), Some(backend), Some(value_type)) = (text("name"), text("backend"), text("value_type")) else { return };
-            let (minted_for, target_model) = (eid("minted_for"), eid("target_model"));
-            self.upsert_property(PropertyDef { id, minted_for, name, backend, value_type, target_model });
-        } else if *collection == model_property_collection() {
-            let (Some(model), Some(property)) = (eid("model"), eid("property")) else { return };
-            let optional = if let Some(Some(Value::Bool(v))) = values.get("optional") { Some(*v) } else { None };
-            self.upsert_membership(ModelPropertyMembershipDef { id, model, property, optional });
-        }
+    pub(super) fn apply_property(&mut self, row: &SysPropertyRowView) -> Result<(), PropertyError> {
+        self.upsert_property(PropertyDef {
+            id: row.id(),
+            minted_for: row.minted_for()?,
+            name: row.name()?,
+            backend: row.backend()?,
+            value_type: row.value_type()?,
+            target_model: row.target_model()?,
+        });
+        Ok(())
+    }
+
+    pub(super) fn apply_membership(&mut self, row: &SysModelPropertyRowView) -> Result<(), PropertyError> {
+        self.upsert_membership(ModelPropertyMembershipDef {
+            id: row.id(),
+            model: row.model()?,
+            property: row.property()?,
+            optional: Some(row.optional()?),
+        });
+        Ok(())
     }
 
     pub(super) fn upsert_model(&mut self, def: ModelDef) {
@@ -208,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_name_resolution_fails_closed_on_ambiguous_memberships() {
+    fn name_resolution_fails_closed_on_ambiguous_memberships() {
         let (model, first, second) = (id(1), id(2), id(3));
         let mut map = CatalogMap::default();
         map.upsert_model(ModelDef { id: model, label: "report".to_owned(), name: "Report".to_owned() });

--- a/core/src/schema/catalog/map.rs
+++ b/core/src/schema/catalog/map.rs
@@ -1,10 +1,30 @@
-use std::collections::{BTreeMap, BTreeSet};
+//! The catalog's node-local materialized projection.
+//!
+//! Here, a **map** means the parsed, indexed read model derived from the
+//! catalog's three entity collections. It accepts raw catalog
+//! [`ankurah_proto::EntityState`] values or already-resolved definitions and
+//! produces identity and membership lookups for registration and runtime
+//! schema resolution. It is not catalog storage, an allocator, a feed
+//! lifecycle, or a cache of compiled Rust-schema bindings; the parent
+//! [`super::CatalogManager`] service owns those concerns.
+//!
+//! This module owns consistency between each definition table and its
+//! secondary indexes. Upserting an entity must remove stale label, name, or
+//! model-membership entries before publishing the new ones, and set-valued
+//! indexes never retain empty buckets. Parsing deliberately reads raw LWW
+//! state: using the typed catalog Views here would make catalog resolution
+//! depend on the projection it is trying to build.
+
+use std::{
+    borrow::Borrow,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use ankurah_proto::{self as proto, EntityId};
 
 use crate::{
     property::backend::{LWWBackend, PropertyBackend},
-    schema::{model_collection, model_property_collection, property_collection, ModelStructDescriptor},
+    schema::{model_collection, model_property_collection, property_collection},
     value::Value,
     ModelId,
 };
@@ -44,37 +64,54 @@ pub struct ModelPropertyMembershipDef {
     pub optional: Option<bool>,
 }
 
-/// The durable model identity admitted for one compiled model shape. Field
-/// identities are re-derived from the schema and the catalog map on demand.
-#[derive(Debug, Clone)]
-pub(super) struct EnsuredSchemaBinding {
-    pub(super) schema: &'static ModelStructDescriptor,
-    pub(super) model: EntityId,
-    pub(super) confirmed: bool,
-}
-
 /// Indexed in-memory view of the catalog entities.
 #[derive(Debug, Default)]
-pub(super) struct CatalogMapInner {
+pub(super) struct CatalogMap {
     pub(super) properties: BTreeMap<EntityId, PropertyDef>,
     pub(super) models: BTreeMap<EntityId, ModelDef>,
     pub(super) memberships: BTreeMap<EntityId, ModelPropertyMembershipDef>,
     pub(super) by_label: BTreeMap<String, EntityId>,
-    model_memberships: BTreeMap<EntityId, BTreeSet<EntityId>>,
-    pub(super) names_global: BTreeMap<String, BTreeSet<EntityId>>,
+    model_memberships: EntitySetIndex<EntityId>,
+    names_global: EntitySetIndex<String>,
 }
 
-/// Remove one id from a set-valued index, dropping emptied entries.
-fn deindex<K: Ord>(index: &mut BTreeMap<K, BTreeSet<EntityId>>, key: &K, id: &EntityId) {
-    if let Some(set) = index.get_mut(key) {
-        set.remove(id);
-        if set.is_empty() {
-            index.remove(key);
+/// A set-valued secondary index whose empty buckets are unobservable and
+/// removed eagerly. Both property-name and model-membership indexes need
+/// this same maintenance invariant when an entity changes its indexed key.
+#[derive(Debug)]
+struct EntitySetIndex<K>(BTreeMap<K, BTreeSet<EntityId>>);
+
+impl<K> Default for EntitySetIndex<K> {
+    fn default() -> Self { Self(BTreeMap::new()) }
+}
+
+impl<K: Ord> EntitySetIndex<K> {
+    fn insert(&mut self, key: K, id: EntityId) { self.0.entry(key).or_default().insert(id); }
+
+    fn remove<Q>(&mut self, key: &Q, id: &EntityId)
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let empty = self.0.get_mut(key).is_some_and(|ids| {
+            ids.remove(id);
+            ids.is_empty()
+        });
+        if empty {
+            self.0.remove(key);
         }
+    }
+
+    fn get<Q>(&self, key: &Q) -> Option<&BTreeSet<EntityId>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.0.get(key)
     }
 }
 
-impl CatalogMapInner {
+impl CatalogMap {
     pub(super) fn clear(&mut self) { *self = Self::default(); }
 
     /// Fold one catalog entity state into the map, keyed by its collection.
@@ -116,20 +153,20 @@ impl CatalogMapInner {
 
     pub(super) fn upsert_property(&mut self, mut def: PropertyDef) {
         if let Some(old) = self.properties.get(&def.id) {
-            deindex(&mut self.names_global, &old.name, &old.id);
+            self.names_global.remove(&old.name, &old.id);
             // `minted_for` is provenance: once learned, it survives an
             // upsert that does not know it.
             def.minted_for = def.minted_for.or(old.minted_for);
         }
-        self.names_global.entry(def.name.clone()).or_default().insert(def.id);
+        self.names_global.insert(def.name.clone(), def.id);
         self.properties.insert(def.id, def);
     }
 
     pub(super) fn upsert_membership(&mut self, def: ModelPropertyMembershipDef) {
         if let Some(old) = self.memberships.get(&def.id).filter(|old| old.model != def.model) {
-            deindex(&mut self.model_memberships, &old.model, &def.id);
+            self.model_memberships.remove(&old.model, &def.id);
         }
-        self.model_memberships.entry(def.model).or_default().insert(def.id);
+        self.model_memberships.insert(def.model, def.id);
         self.memberships.insert(def.id, def);
     }
 
@@ -154,6 +191,10 @@ impl CatalogMapInner {
     pub(super) fn membership(&self, model: &EntityId, property: &EntityId) -> Option<ModelPropertyMembershipDef> {
         self.model_memberships.get(model)?.iter().find_map(|id| self.memberships.get(id).filter(|m| m.property == *property).cloned())
     }
+
+    pub(super) fn siblings_by_name(&self, name: &str) -> Vec<EntityId> {
+        self.names_global.get(name).into_iter().flat_map(|ids| ids.iter().copied()).collect()
+    }
 }
 
 #[cfg(test)]
@@ -169,7 +210,7 @@ mod tests {
     #[test]
     fn raw_name_resolution_fails_closed_on_ambiguous_memberships() {
         let (model, first, second) = (id(1), id(2), id(3));
-        let mut map = CatalogMapInner::default();
+        let mut map = CatalogMap::default();
         map.upsert_model(ModelDef { id: model, label: "report".to_owned(), name: "Report".to_owned() });
         map.upsert_property(property(first, "status"));
         map.upsert_property(property(second, "status"));
@@ -183,12 +224,36 @@ mod tests {
     #[test]
     fn duplicate_memberships_for_one_property_are_not_name_ambiguity() {
         let (model, property_id) = (id(1), id(2));
-        let mut map = CatalogMapInner::default();
+        let mut map = CatalogMap::default();
         map.upsert_model(ModelDef { id: model, label: "report".to_owned(), name: "Report".to_owned() });
         map.upsert_property(property(property_id, "status"));
         map.upsert_membership(ModelPropertyMembershipDef { id: id(3), model, property: property_id, optional: Some(false) });
         map.upsert_membership(ModelPropertyMembershipDef { id: id(4), model, property: property_id, optional: Some(false) });
 
         assert_eq!(map.resolve("report", "status").unwrap(), Some(property_id));
+    }
+
+    #[test]
+    fn moving_a_membership_removes_it_from_the_old_model_index() {
+        let (old_model, new_model, property_id, membership_id) = (id(1), id(2), id(3), id(4));
+        let mut map = CatalogMap::default();
+        map.upsert_membership(ModelPropertyMembershipDef {
+            id: membership_id,
+            model: old_model,
+            property: property_id,
+            optional: Some(false),
+        });
+        map.upsert_membership(ModelPropertyMembershipDef {
+            id: membership_id,
+            model: new_model,
+            property: property_id,
+            optional: Some(false),
+        });
+
+        assert!(map.memberships_of(&old_model).is_empty());
+        assert_eq!(
+            map.memberships_of(&new_model),
+            vec![ModelPropertyMembershipDef { id: membership_id, model: new_model, property: property_id, optional: Some(false) }]
+        );
     }
 }

--- a/core/src/schema/catalog/map.rs
+++ b/core/src/schema/catalog/map.rs
@@ -103,8 +103,12 @@ impl CatalogMapInner {
     }
 
     pub(super) fn upsert_model(&mut self, def: ModelDef) {
+        // A relabel detaches the old label only while this model still owns
+        // the index entry (another model may have claimed the label since).
         if let Some(old) = self.models.get(&def.id).filter(|old| old.label != def.label) {
-            self.by_label.remove(&old.label);
+            if self.by_label.get(&old.label) == Some(&def.id) {
+                self.by_label.remove(&old.label);
+            }
         }
         self.by_label.insert(def.label.clone(), def.id);
         self.models.insert(def.id, def);

--- a/core/src/schema/catalog/map.rs
+++ b/core/src/schema/catalog/map.rs
@@ -1,62 +1,55 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::ModelId;
 use ankurah_proto::{self as proto, EntityId};
 
 use crate::{
     property::backend::{LWWBackend, PropertyBackend},
     schema::{model_collection, model_property_collection, property_collection, ModelStructDescriptor},
     value::Value,
+    ModelId,
 };
 
-/// A parsed model definition entity (`_ankurah_model`).
+/// A parsed model definition entity (`_ankurah_model`): the durable model
+/// identity `id`, the source-level registration lookup key `label`, and the
+/// current display `name`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModelDef {
-    /// The catalog entity that durably identifies this model.
     pub id: EntityId,
-    /// The source-level label used as the registration lookup key.
     pub label: String,
-    /// The model's current registered display name.
     pub name: String,
 }
 
-/// A parsed property definition entity (`_ankurah_property`).
+/// A parsed property definition entity (`_ankurah_property`). `minted_for`
+/// records the model in whose lookup scope the property was allocated
+/// (provenance only, never a matching key); `target_model` is the referenced
+/// model for an entity-reference property.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PropertyDef {
-    /// The catalog entity that durably identifies this property.
     pub id: EntityId,
-    /// The model in whose lookup scope this property was minted.
     pub minted_for: Option<EntityId>,
-    /// The property's current registered display name.
     pub name: String,
-    /// The registered state-backend identifier.
     pub backend: String,
-    /// The registered logical value-type spelling.
     pub value_type: String,
-    /// The referenced model for an entity-reference property.
     pub target_model: Option<EntityId>,
 }
 
 /// A parsed model-property membership entity (`_ankurah_model_property`).
+/// `optional` stays `None` (treated as optional) until the `optional`
+/// follow-up event arrives.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModelPropertyMembershipDef {
-    /// The catalog entity that durably identifies this membership.
     pub id: EntityId,
-    /// The model participating in the membership.
     pub model: EntityId,
-    /// The property participating in the membership.
     pub property: EntityId,
-    /// `None` until the `optional` follow-up event arrives. Until then the
-    /// membership is treated as optional.
     pub optional: Option<bool>,
 }
 
-/// Exact durable identities admitted for one compiled model shape.
+/// The durable model identity admitted for one compiled model shape. Field
+/// identities are re-derived from the schema and the catalog map on demand.
 #[derive(Debug, Clone)]
 pub(super) struct EnsuredSchemaBinding {
     pub(super) schema: &'static ModelStructDescriptor,
     pub(super) model: EntityId,
-    pub(super) fields: BTreeMap<&'static str, EntityId>,
     pub(super) confirmed: bool,
 }
 
@@ -71,159 +64,91 @@ pub(super) struct CatalogMapInner {
     pub(super) names_global: BTreeMap<String, BTreeSet<EntityId>>,
 }
 
+/// Remove one id from a set-valued index, dropping emptied entries.
+fn deindex<K: Ord>(index: &mut BTreeMap<K, BTreeSet<EntityId>>, key: &K, id: &EntityId) {
+    if let Some(set) = index.get_mut(key) {
+        set.remove(id);
+        if set.is_empty() {
+            index.remove(key);
+        }
+    }
+}
+
 impl CatalogMapInner {
-    pub(super) fn clear(&mut self) {
-        self.properties.clear();
-        self.models.clear();
-        self.memberships.clear();
-        self.by_label.clear();
-        self.model_memberships.clear();
-        self.names_global.clear();
+    pub(super) fn clear(&mut self) { *self = Self::default(); }
+
+    /// Fold one catalog entity state into the map, keyed by its collection.
+    /// Idempotent by entity id; non-catalog collections and unparseable
+    /// states are ignored.
+    pub(super) fn apply_state(&mut self, collection: &ModelId, id: EntityId, state: &proto::EntityState) {
+        let Some(buffer) = state.state.state_buffers.0.get("lww") else { return };
+        let Ok(backend) = LWWBackend::from_state_buffer(buffer) else { return };
+        let values = backend.property_values();
+        let text = |field: &str| if let Some(Some(Value::String(v))) = values.get(field) { Some(v.clone()) } else { None };
+        let eid = |field: &str| if let Some(Some(Value::EntityId(v))) = values.get(field) { Some(*v) } else { None };
+
+        if *collection == model_collection() {
+            let Some(label) = text("label") else { return };
+            let name = text("name").unwrap_or_else(|| label.clone());
+            self.upsert_model(ModelDef { id, label, name });
+        } else if *collection == property_collection() {
+            let (Some(name), Some(backend), Some(value_type)) = (text("name"), text("backend"), text("value_type")) else { return };
+            let (minted_for, target_model) = (eid("minted_for"), eid("target_model"));
+            self.upsert_property(PropertyDef { id, minted_for, name, backend, value_type, target_model });
+        } else if *collection == model_property_collection() {
+            let (Some(model), Some(property)) = (eid("model"), eid("property")) else { return };
+            let optional = if let Some(Some(Value::Bool(v))) = values.get("optional") { Some(*v) } else { None };
+            self.upsert_membership(ModelPropertyMembershipDef { id, model, property, optional });
+        }
     }
 
-    // The live-Entity upsert/remove surface (reactor updates parsed through
-    // AbstractEntity, including de-indexing on catalog entity removal)
-    // returns with the read flip's reactor feed; state-buffer parsing below
-    // serves the durable warm.
-
     pub(super) fn upsert_model(&mut self, def: ModelDef) {
-        if let Some(old) = self.models.get(&def.id) {
-            if old.label != def.label {
-                self.by_label.remove(&old.label);
-            }
+        if let Some(old) = self.models.get(&def.id).filter(|old| old.label != def.label) {
+            self.by_label.remove(&old.label);
         }
         self.by_label.insert(def.label.clone(), def.id);
         self.models.insert(def.id, def);
     }
 
     pub(super) fn upsert_property(&mut self, mut def: PropertyDef) {
-        if let Some(old) = self.properties.get(&def.id).cloned() {
-            self.deindex_property_names(&old);
-            // minted_for is provenance metadata; an upsert that does not
-            // know it must not erase what the catalog already learned.
-            if def.minted_for.is_none() {
-                def.minted_for = old.minted_for;
-            }
+        if let Some(old) = self.properties.get(&def.id) {
+            deindex(&mut self.names_global, &old.name, &old.id);
+            // `minted_for` is provenance: once learned, it survives an
+            // upsert that does not know it.
+            def.minted_for = def.minted_for.or(old.minted_for);
         }
         self.names_global.entry(def.name.clone()).or_default().insert(def.id);
         self.properties.insert(def.id, def);
     }
 
     pub(super) fn upsert_membership(&mut self, def: ModelPropertyMembershipDef) {
-        if let Some(old) = self.memberships.get(&def.id) {
-            if old.model != def.model {
-                if let Some(set) = self.model_memberships.get_mut(&old.model) {
-                    set.remove(&def.id);
-                    if set.is_empty() {
-                        self.model_memberships.remove(&old.model);
-                    }
-                }
-            }
+        if let Some(old) = self.memberships.get(&def.id).filter(|old| old.model != def.model) {
+            deindex(&mut self.model_memberships, &old.model, &def.id);
         }
         self.model_memberships.entry(def.model).or_default().insert(def.id);
         self.memberships.insert(def.id, def);
     }
 
-    fn deindex_property_names(&mut self, def: &PropertyDef) {
-        if let Some(set) = self.names_global.get_mut(&def.name) {
-            set.remove(&def.id);
-            if set.is_empty() {
-                self.names_global.remove(&def.name);
-            }
-        }
-    }
-
     pub(super) fn resolve(&self, label: &str, name: &str) -> anyhow::Result<Option<EntityId>> {
-        let Some(model_id) = self.by_label.get(label) else { return Ok(None) };
-        let Some(membership_ids) = self.model_memberships.get(model_id) else { return Ok(None) };
-        let mut found = None;
-        for membership_id in membership_ids {
-            let Some(membership) = self.memberships.get(membership_id) else { continue };
-            let Some(property) = self.properties.get(&membership.property) else { continue };
-            if property.name != name {
-                continue;
-            }
-            match found {
-                None => found = Some(property.id),
-                Some(first) if first == property.id => {}
-                Some(first) => {
-                    anyhow::bail!("property '{name}' in model '{label}' is ambiguous across durable identities {first} and {}", property.id)
-                }
-            }
+        let Some(ids) = self.by_label.get(label).and_then(|model| self.model_memberships.get(model)) else { return Ok(None) };
+        let found: BTreeSet<EntityId> = ids
+            .iter()
+            .filter_map(|id| self.properties.get(&self.memberships.get(id)?.property))
+            .filter(|property| property.name == name)
+            .map(|property| property.id)
+            .collect();
+        if found.len() > 1 {
+            anyhow::bail!("property '{name}' in model '{label}' is ambiguous across durable identities {found:?}");
         }
-        Ok(found)
+        Ok(found.first().copied())
     }
 
     pub(super) fn memberships_of(&self, model: &EntityId) -> Vec<ModelPropertyMembershipDef> {
-        self.model_memberships
-            .get(model)
-            .into_iter()
-            .flat_map(|ids| ids.iter())
-            .filter_map(|id| self.memberships.get(id).cloned())
-            .collect()
+        self.model_memberships.get(model).into_iter().flatten().filter_map(|id| self.memberships.get(id).cloned()).collect()
     }
 
     pub(super) fn membership(&self, model: &EntityId, property: &EntityId) -> Option<ModelPropertyMembershipDef> {
-        self.model_memberships.get(model)?.iter().find_map(|id| {
-            let membership = self.memberships.get(id)?;
-            (membership.property == *property).then(|| membership.clone())
-        })
-    }
-}
-
-pub(super) fn parse_state(collection: &ModelId, id: EntityId, state: &proto::EntityState) -> Option<Entry> {
-    let buffer = state.state.state_buffers.0.get("lww")?;
-    let backend = LWWBackend::from_state_buffer(buffer).ok()?;
-    let values = backend.property_values();
-    let get_string = |field: &str| match values.get(field) {
-        Some(Some(Value::String(value))) => Some(value.clone()),
-        _ => None,
-    };
-    let get_entity_id = |field: &str| match values.get(field) {
-        Some(Some(Value::EntityId(value))) => Some(*value),
-        _ => None,
-    };
-    let get_bool = |field: &str| match values.get(field) {
-        Some(Some(Value::Bool(value))) => Some(*value),
-        _ => None,
-    };
-
-    if *collection == model_collection() {
-        let label = get_string("label")?;
-        let name = get_string("name").unwrap_or_else(|| label.clone());
-        Some(Entry::Model(ModelDef { id, label, name }))
-    } else if *collection == property_collection() {
-        Some(Entry::Property(PropertyDef {
-            id,
-            minted_for: get_entity_id("minted_for"),
-            name: get_string("name")?,
-            backend: get_string("backend")?,
-            value_type: get_string("value_type")?,
-            target_model: get_entity_id("target_model"),
-        }))
-    } else if *collection == model_property_collection() {
-        Some(Entry::Membership(ModelPropertyMembershipDef {
-            id,
-            model: get_entity_id("model")?,
-            property: get_entity_id("property")?,
-            optional: get_bool("optional"),
-        }))
-    } else {
-        None
-    }
-}
-
-pub(super) enum Entry {
-    Model(ModelDef),
-    Property(PropertyDef),
-    Membership(ModelPropertyMembershipDef),
-}
-
-pub(super) fn apply_entry(map: &mut CatalogMapInner, entry: Entry) {
-    match entry {
-        Entry::Model(definition) => map.upsert_model(definition),
-        Entry::Property(definition) => map.upsert_property(definition),
-        Entry::Membership(definition) => map.upsert_membership(definition),
+        self.model_memberships.get(model)?.iter().find_map(|id| self.memberships.get(id).filter(|m| m.property == *property).cloned())
     }
 }
 
@@ -234,21 +159,12 @@ mod tests {
     fn id(byte: u8) -> EntityId { EntityId::from_bytes([byte; 16]) }
 
     fn property(id: EntityId, name: &str) -> PropertyDef {
-        PropertyDef {
-            id,
-            minted_for: None,
-            name: name.to_owned(),
-            backend: "lww".to_owned(),
-            value_type: "string".to_owned(),
-            target_model: None,
-        }
+        PropertyDef { id, minted_for: None, name: name.into(), backend: "lww".into(), value_type: "string".into(), target_model: None }
     }
 
     #[test]
     fn raw_name_resolution_fails_closed_on_ambiguous_memberships() {
-        let model = id(1);
-        let first = id(2);
-        let second = id(3);
+        let (model, first, second) = (id(1), id(2), id(3));
         let mut map = CatalogMapInner::default();
         map.upsert_model(ModelDef { id: model, label: "report".to_owned(), name: "Report".to_owned() });
         map.upsert_property(property(first, "status"));
@@ -262,8 +178,7 @@ mod tests {
 
     #[test]
     fn duplicate_memberships_for_one_property_are_not_name_ambiguity() {
-        let model = id(1);
-        let property_id = id(2);
+        let (model, property_id) = (id(1), id(2));
         let mut map = CatalogMapInner::default();
         map.upsert_model(ModelDef { id: model, label: "report".to_owned(), name: "Report".to_owned() });
         map.upsert_property(property(property_id, "status"));

--- a/core/src/schema/catalog/rows.rs
+++ b/core/src/schema/catalog/rows.rs
@@ -1,17 +1,28 @@
-//! Typed row Models for the catalog's system collections, derived like any
-//! app model. `base = "crate"` repoints the generated code at core itself
-//! (core cannot address itself through the `::ankurah` facade), and
-//! `system = "..."` pins each model's built-in System ID: every
-//! registration path short-circuits on it, so these models never consult
-//! the catalog they describe. Expect more system tables to live here over
-//! time.
+//! Canonical typed read shapes for the catalog's three entity collections.
+//!
+//! Here, a **row** means the persisted fields of one model definition,
+//! property definition, or model-property membership. These structs make
+//! catalog data available through the same generated `View` API as
+//! application data and keep that typed schema beside the raw parser it must
+//! agree with. The durable registration executor still emits raw bootstrap
+//! events, and ordinary transactions may not mutate system collections; the
+//! generated `Mutable` surface grants a Rust representation, not write
+//! authority.
+//!
+//! `base = "crate"` makes generated code address core directly rather than
+//! through the `::ankurah` facade. `system = "..."` pins a built-in
+//! [`ankurah_proto::SystemModel`] identity, so first use never tries to
+//! register the catalog row through the catalog it describes. `no_ffi`
+//! deliberately omits WASM and UniFFI bindings for these private catalog
+//! implementation types; choosing an alternate `base` does not itself alter
+//! a model's FFI surface.
 
 use ankurah_derive::Model;
 use ankurah_proto::EntityId;
 
 /// One `_ankurah_model` row: a registered model definition.
 #[derive(Model, Debug, Clone)]
-#[model(base = "crate", system = "Model")]
+#[model(base = "crate", system = "Model", no_ffi)]
 pub struct SysModelRow {
     #[active_type(LWW)]
     pub label: String,
@@ -23,7 +34,7 @@ pub struct SysModelRow {
 /// `minted_for` and `target_model` are optional in the data (folds preserve
 /// absent provenance; only reference properties have targets).
 #[derive(Model, Debug, Clone)]
-#[model(base = "crate", system = "Property")]
+#[model(base = "crate", system = "Property", no_ffi)]
 pub struct SysPropertyRow {
     #[active_type(LWW)]
     pub name: String,
@@ -37,7 +48,7 @@ pub struct SysPropertyRow {
 
 /// One `_ankurah_model_property` row: a property's membership in a model.
 #[derive(Model, Debug, Clone)]
-#[model(base = "crate", system = "ModelProperty")]
+#[model(base = "crate", system = "ModelProperty", no_ffi)]
 pub struct SysModelPropertyRow {
     pub model: EntityId,
     pub property: EntityId,

--- a/core/src/schema/catalog/rows.rs
+++ b/core/src/schema/catalog/rows.rs
@@ -1,0 +1,200 @@
+//! Typed row Models for the three catalog collections: the catalog eating
+//! its own dogfood.
+//!
+//! These are ordinary [`crate::model::Model`] implementations whose identity
+//! is a built-in [`SystemModel`], pinned at compile time. Nothing here is
+//! registered: `descriptor().system` short-circuits first-use registration
+//! to the closed identity, so reading or writing these rows never consults
+//! the catalog they describe. That is what dissolves the old
+//! self-description worry: resolution for a system model is a compile-time
+//! constant, not a catalog lookup.
+//!
+//! The impls are written by hand rather than `#[derive(Model)]` because the
+//! derive emits `::ankurah::` facade paths that this crate cannot name (the
+//! facade depends on core). They implement the same traits the derive
+//! targets and stay field-for-field identical to what the registration
+//! executor writes (core/src/schema/registration.rs `creation`).
+
+use ankurah_core_types::{EntityId, SystemModel};
+use ankurah_proto::CollectionId;
+
+use crate::entity::Entity;
+use crate::model::{Model, Mutable, View};
+use crate::property::backend::LWWBackend;
+use crate::property::{Property, PropertyError, PropertyName};
+use crate::schema::{ModelStructDescriptor, StructProperty};
+
+/// Read one typed property off an entity's LWW backend.
+fn get<T: Property>(entity: &Entity, name: &str) -> Result<T, PropertyError> {
+    let backend = entity.get_backend::<LWWBackend>().map_err(|e| PropertyError::RetrievalError(e))?;
+    T::from_value(backend.get(&PropertyName::from(name)))
+}
+
+/// Write one typed property into an entity's LWW backend.
+fn set<T: Property>(entity: &Entity, name: &str, value: &T) -> Result<(), PropertyError> {
+    let backend = entity.get_backend::<LWWBackend>().map_err(|e| PropertyError::RetrievalError(e))?;
+    backend.set(PropertyName::from(name), value.into_value()?);
+    Ok(())
+}
+
+/// Define one catalog row model: the struct, its `Model` impl bound to a
+/// [`SystemModel`], and its View/Mutable pair with typed accessors.
+macro_rules! catalog_row_model {
+    (
+        $(#[$meta:meta])*
+        $model:ident / $view:ident / $mutable:ident $(/ $refwrap:ident)?,
+        $system:ident, $collection:literal,
+        { $( $field:ident : $ty:ty = $value_type:literal ),+ $(,)? }
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq)]
+        pub struct $model {
+            $( pub $field: $ty, )+
+        }
+
+        #[derive(Debug, Clone)]
+        pub struct $view(Entity);
+
+        #[derive(Debug)]
+        pub struct $mutable(Entity);
+
+        impl Model for $model {
+            type View = $view;
+            type Mutable = $mutable;
+            $( #[cfg(feature = "wasm")] type RefWrapper = $refwrap; )?
+
+            fn collection() -> CollectionId { CollectionId::fixed_name($collection) }
+
+            fn descriptor() -> &'static ModelStructDescriptor {
+                static DESCRIPTOR: ModelStructDescriptor = ModelStructDescriptor {
+                    label: $collection,
+                    name: stringify!($model),
+                    properties: &[
+                        $( StructProperty {
+                            field: stringify!($field),
+                            name: stringify!($field),
+                            renamed_from: None,
+                            backend: "lww",
+                            value_type: $value_type,
+                            target_label: None,
+                            optional: false,
+                            explicit_id: None,
+                        }, )+
+                    ],
+                    explicit_id: None,
+                    system: Some(SystemModel::$system),
+                };
+                &DESCRIPTOR
+            }
+
+            fn initialize_new_entity(&self, entity: &Entity, model_id: ankurah_proto::ModelId) {
+                entity.add_membership(model_id);
+                $( let _ = set(entity, stringify!($field), &self.$field); )+
+            }
+        }
+
+        impl View for $view {
+            type Model = $model;
+            type Mutable = $mutable;
+            fn entity(&self) -> &Entity { &self.0 }
+            fn from_entity(inner: Entity) -> Self { Self(inner) }
+            fn to_model(&self) -> anyhow::Result<$model, PropertyError> {
+                Ok($model { $( $field: get(&self.0, stringify!($field))?, )+ })
+            }
+        }
+
+        impl $view {
+            pub fn id(&self) -> EntityId { self.0.id() }
+            $( pub fn $field(&self) -> Result<$ty, PropertyError> { get(&self.0, stringify!($field)) } )+
+        }
+
+        impl Mutable for $mutable {
+            type Model = $model;
+            type View = $view;
+            fn entity(&self) -> &Entity { &self.0 }
+            fn new(entity: Entity) -> Self { Self(entity) }
+        }
+
+        impl $mutable {
+            $( pub fn $field(&self, value: &$ty) -> Result<(), PropertyError> { set(&self.0, stringify!($field), value) } )+
+        }
+
+        $(
+            /// WASM Ref wrapper satisfying the Model associated-type bound; a
+            /// plain newtype, no bindgen surface (catalog rows are internal).
+            #[cfg(feature = "wasm")]
+            pub struct $refwrap(crate::property::Ref<$model>);
+            #[cfg(feature = "wasm")]
+            impl From<crate::property::Ref<$model>> for $refwrap {
+                fn from(r: crate::property::Ref<$model>) -> Self { Self(r) }
+            }
+            #[cfg(feature = "wasm")]
+            impl From<$refwrap> for crate::property::Ref<$model> {
+                fn from(w: $refwrap) -> Self { w.0 }
+            }
+        )?
+    };
+}
+
+catalog_row_model!(
+    /// One `_ankurah_model` row: a registered model definition.
+    SysModelRow / SysModelRowView / SysModelRowMut / SysModelRowRef,
+    Model, "_ankurah_model",
+    { label: String = "string", name: String = "string" }
+);
+
+catalog_row_model!(
+    /// One `_ankurah_property` row: a registered property definition.
+    /// `minted_for` and `target_model` are optional in the data (folds
+    /// preserve absent provenance; only reference properties have targets).
+    SysPropertyRow / SysPropertyRowView / SysPropertyRowMut / SysPropertyRowRef,
+    Property, "_ankurah_property",
+    {
+        name: String = "string",
+        backend: String = "string",
+        value_type: String = "string",
+        minted_for: Option<EntityId> = "entityid",
+        target_model: Option<EntityId> = "entityid",
+    }
+);
+
+catalog_row_model!(
+    /// One `_ankurah_model_property` row: a property's membership in a model.
+    SysModelPropertyRow / SysModelPropertyRowView / SysModelPropertyRowMut / SysModelPropertyRowRef,
+    ModelProperty, "_ankurah_model_property",
+    {
+        model: EntityId = "entityid",
+        property: EntityId = "entityid",
+        optional: bool = "bool",
+    }
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::system_collection_label;
+
+    /// Every row model's collection is the canonical system label and its
+    /// descriptor pins the matching SystemModel: the compile-time binding
+    /// the short-circuits rely on.
+    #[test]
+    fn row_models_pin_their_system_identity() {
+        assert_eq!(SysModelRow::collection().as_str(), system_collection_label(SystemModel::Model));
+        assert_eq!(SysModelRow::descriptor().system, Some(SystemModel::Model));
+        assert_eq!(SysPropertyRow::collection().as_str(), system_collection_label(SystemModel::Property));
+        assert_eq!(SysPropertyRow::descriptor().system, Some(SystemModel::Property));
+        assert_eq!(SysModelPropertyRow::collection().as_str(), system_collection_label(SystemModel::ModelProperty));
+        assert_eq!(SysModelPropertyRow::descriptor().system, Some(SystemModel::ModelProperty));
+    }
+
+    /// The row fields match the executor's writers field-for-field
+    /// (registration.rs `creation` calls), so a typed View reads exactly
+    /// what registration writes.
+    #[test]
+    fn row_fields_match_executor_writers() {
+        let fields: Vec<&str> = SysPropertyRow::descriptor().properties.iter().map(|p| p.name).collect();
+        assert_eq!(fields, ["name", "backend", "value_type", "minted_for", "target_model"]);
+        let fields: Vec<&str> = SysModelPropertyRow::descriptor().properties.iter().map(|p| p.name).collect();
+        assert_eq!(fields, ["model", "property", "optional"]);
+    }
+}

--- a/core/src/schema/catalog/rows.rs
+++ b/core/src/schema/catalog/rows.rs
@@ -1,9 +1,10 @@
 //! Typed row Models for the catalog's system collections, derived like any
 //! app model. `base = "crate"` repoints the generated code at core itself
-//! (there is no facade below the facade), and `system = "..."` pins each
-//! model's closed built-in identity: every registration path
-//! short-circuits on it, so these models never consult the catalog they
-//! describe. Expect more system tables to live here over time.
+//! (core cannot address itself through the `::ankurah` facade), and
+//! `system = "..."` pins each model's closed built-in identity: every
+//! registration path short-circuits on it, so these models never consult
+//! the catalog they describe. Expect more system tables to live here over
+//! time.
 
 use ankurah_derive::Model;
 use ankurah_proto::EntityId;
@@ -41,4 +42,24 @@ pub struct SysModelPropertyRow {
     pub model: EntityId,
     pub property: EntityId,
     pub optional: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Model;
+    use ankurah_core_types::SystemModel;
+
+    /// The derive builds each system collection label from the variant name
+    /// by convention; core declares the canonical labels as constants. The
+    /// two must agree, and each descriptor must pin its variant.
+    #[test]
+    fn row_models_match_the_canonical_system_labels() {
+        assert_eq!(SysModelRow::collection().as_str(), crate::schema::MODEL_COLLECTION_ID);
+        assert_eq!(SysPropertyRow::collection().as_str(), crate::schema::PROPERTY_COLLECTION_ID);
+        assert_eq!(SysModelPropertyRow::collection().as_str(), crate::schema::MODEL_PROPERTY_COLLECTION_ID);
+        assert_eq!(SysModelRow::descriptor().system, Some(SystemModel::Model));
+        assert_eq!(SysPropertyRow::descriptor().system, Some(SystemModel::Property));
+        assert_eq!(SysModelPropertyRow::descriptor().system, Some(SystemModel::ModelProperty));
+    }
 }

--- a/core/src/schema/catalog/rows.rs
+++ b/core/src/schema/catalog/rows.rs
@@ -1,7 +1,7 @@
 //! Typed row Models for the catalog's system collections, derived like any
 //! app model. `base = "crate"` repoints the generated code at core itself
 //! (core cannot address itself through the `::ankurah` facade), and
-//! `system = "..."` pins each model's closed built-in identity: every
+//! `system = "..."` pins each model's built-in System ID: every
 //! registration path short-circuits on it, so these models never consult
 //! the catalog they describe. Expect more system tables to live here over
 //! time.

--- a/core/src/schema/catalog/rows.rs
+++ b/core/src/schema/catalog/rows.rs
@@ -1,200 +1,44 @@
-//! Typed row Models for the three catalog collections: the catalog eating
-//! its own dogfood.
-//!
-//! These are ordinary [`crate::model::Model`] implementations whose identity
-//! is a built-in [`SystemModel`], pinned at compile time. Nothing here is
-//! registered: `descriptor().system` short-circuits first-use registration
-//! to the closed identity, so reading or writing these rows never consults
-//! the catalog they describe. That is what dissolves the old
-//! self-description worry: resolution for a system model is a compile-time
-//! constant, not a catalog lookup.
-//!
-//! The impls are written by hand rather than `#[derive(Model)]` because the
-//! derive emits `::ankurah::` facade paths that this crate cannot name (the
-//! facade depends on core). They implement the same traits the derive
-//! targets and stay field-for-field identical to what the registration
-//! executor writes (core/src/schema/registration.rs `creation`).
+//! Typed row Models for the catalog's system collections, derived like any
+//! app model. `base = "crate"` repoints the generated code at core itself
+//! (there is no facade below the facade), and `system = "..."` pins each
+//! model's closed built-in identity: every registration path
+//! short-circuits on it, so these models never consult the catalog they
+//! describe. Expect more system tables to live here over time.
 
-use ankurah_core_types::{EntityId, SystemModel};
-use ankurah_proto::CollectionId;
+use ankurah_derive::Model;
+use ankurah_proto::EntityId;
 
-use crate::entity::Entity;
-use crate::model::{Model, Mutable, View};
-use crate::property::backend::LWWBackend;
-use crate::property::{Property, PropertyError, PropertyName};
-use crate::schema::{ModelStructDescriptor, StructProperty};
-
-/// Read one typed property off an entity's LWW backend.
-fn get<T: Property>(entity: &Entity, name: &str) -> Result<T, PropertyError> {
-    let backend = entity.get_backend::<LWWBackend>().map_err(|e| PropertyError::RetrievalError(e))?;
-    T::from_value(backend.get(&PropertyName::from(name)))
+/// One `_ankurah_model` row: a registered model definition.
+#[derive(Model, Debug, Clone)]
+#[model(base = "crate", system = "Model")]
+pub struct SysModelRow {
+    #[active_type(LWW)]
+    pub label: String,
+    #[active_type(LWW)]
+    pub name: String,
 }
 
-/// Write one typed property into an entity's LWW backend.
-fn set<T: Property>(entity: &Entity, name: &str, value: &T) -> Result<(), PropertyError> {
-    let backend = entity.get_backend::<LWWBackend>().map_err(|e| PropertyError::RetrievalError(e))?;
-    backend.set(PropertyName::from(name), value.into_value()?);
-    Ok(())
+/// One `_ankurah_property` row: a registered property definition.
+/// `minted_for` and `target_model` are optional in the data (folds preserve
+/// absent provenance; only reference properties have targets).
+#[derive(Model, Debug, Clone)]
+#[model(base = "crate", system = "Property")]
+pub struct SysPropertyRow {
+    #[active_type(LWW)]
+    pub name: String,
+    #[active_type(LWW)]
+    pub backend: String,
+    #[active_type(LWW)]
+    pub value_type: String,
+    pub minted_for: Option<EntityId>,
+    pub target_model: Option<EntityId>,
 }
 
-/// Define one catalog row model: the struct, its `Model` impl bound to a
-/// [`SystemModel`], and its View/Mutable pair with typed accessors.
-macro_rules! catalog_row_model {
-    (
-        $(#[$meta:meta])*
-        $model:ident / $view:ident / $mutable:ident $(/ $refwrap:ident)?,
-        $system:ident, $collection:literal,
-        { $( $field:ident : $ty:ty = $value_type:literal ),+ $(,)? }
-    ) => {
-        $(#[$meta])*
-        #[derive(Debug, Clone, PartialEq)]
-        pub struct $model {
-            $( pub $field: $ty, )+
-        }
-
-        #[derive(Debug, Clone)]
-        pub struct $view(Entity);
-
-        #[derive(Debug)]
-        pub struct $mutable(Entity);
-
-        impl Model for $model {
-            type View = $view;
-            type Mutable = $mutable;
-            $( #[cfg(feature = "wasm")] type RefWrapper = $refwrap; )?
-
-            fn collection() -> CollectionId { CollectionId::fixed_name($collection) }
-
-            fn descriptor() -> &'static ModelStructDescriptor {
-                static DESCRIPTOR: ModelStructDescriptor = ModelStructDescriptor {
-                    label: $collection,
-                    name: stringify!($model),
-                    properties: &[
-                        $( StructProperty {
-                            field: stringify!($field),
-                            name: stringify!($field),
-                            renamed_from: None,
-                            backend: "lww",
-                            value_type: $value_type,
-                            target_label: None,
-                            optional: false,
-                            explicit_id: None,
-                        }, )+
-                    ],
-                    explicit_id: None,
-                    system: Some(SystemModel::$system),
-                };
-                &DESCRIPTOR
-            }
-
-            fn initialize_new_entity(&self, entity: &Entity, model_id: ankurah_proto::ModelId) {
-                entity.add_membership(model_id);
-                $( let _ = set(entity, stringify!($field), &self.$field); )+
-            }
-        }
-
-        impl View for $view {
-            type Model = $model;
-            type Mutable = $mutable;
-            fn entity(&self) -> &Entity { &self.0 }
-            fn from_entity(inner: Entity) -> Self { Self(inner) }
-            fn to_model(&self) -> anyhow::Result<$model, PropertyError> {
-                Ok($model { $( $field: get(&self.0, stringify!($field))?, )+ })
-            }
-        }
-
-        impl $view {
-            pub fn id(&self) -> EntityId { self.0.id() }
-            $( pub fn $field(&self) -> Result<$ty, PropertyError> { get(&self.0, stringify!($field)) } )+
-        }
-
-        impl Mutable for $mutable {
-            type Model = $model;
-            type View = $view;
-            fn entity(&self) -> &Entity { &self.0 }
-            fn new(entity: Entity) -> Self { Self(entity) }
-        }
-
-        impl $mutable {
-            $( pub fn $field(&self, value: &$ty) -> Result<(), PropertyError> { set(&self.0, stringify!($field), value) } )+
-        }
-
-        $(
-            /// WASM Ref wrapper satisfying the Model associated-type bound; a
-            /// plain newtype, no bindgen surface (catalog rows are internal).
-            #[cfg(feature = "wasm")]
-            pub struct $refwrap(crate::property::Ref<$model>);
-            #[cfg(feature = "wasm")]
-            impl From<crate::property::Ref<$model>> for $refwrap {
-                fn from(r: crate::property::Ref<$model>) -> Self { Self(r) }
-            }
-            #[cfg(feature = "wasm")]
-            impl From<$refwrap> for crate::property::Ref<$model> {
-                fn from(w: $refwrap) -> Self { w.0 }
-            }
-        )?
-    };
-}
-
-catalog_row_model!(
-    /// One `_ankurah_model` row: a registered model definition.
-    SysModelRow / SysModelRowView / SysModelRowMut / SysModelRowRef,
-    Model, "_ankurah_model",
-    { label: String = "string", name: String = "string" }
-);
-
-catalog_row_model!(
-    /// One `_ankurah_property` row: a registered property definition.
-    /// `minted_for` and `target_model` are optional in the data (folds
-    /// preserve absent provenance; only reference properties have targets).
-    SysPropertyRow / SysPropertyRowView / SysPropertyRowMut / SysPropertyRowRef,
-    Property, "_ankurah_property",
-    {
-        name: String = "string",
-        backend: String = "string",
-        value_type: String = "string",
-        minted_for: Option<EntityId> = "entityid",
-        target_model: Option<EntityId> = "entityid",
-    }
-);
-
-catalog_row_model!(
-    /// One `_ankurah_model_property` row: a property's membership in a model.
-    SysModelPropertyRow / SysModelPropertyRowView / SysModelPropertyRowMut / SysModelPropertyRowRef,
-    ModelProperty, "_ankurah_model_property",
-    {
-        model: EntityId = "entityid",
-        property: EntityId = "entityid",
-        optional: bool = "bool",
-    }
-);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::schema::system_collection_label;
-
-    /// Every row model's collection is the canonical system label and its
-    /// descriptor pins the matching SystemModel: the compile-time binding
-    /// the short-circuits rely on.
-    #[test]
-    fn row_models_pin_their_system_identity() {
-        assert_eq!(SysModelRow::collection().as_str(), system_collection_label(SystemModel::Model));
-        assert_eq!(SysModelRow::descriptor().system, Some(SystemModel::Model));
-        assert_eq!(SysPropertyRow::collection().as_str(), system_collection_label(SystemModel::Property));
-        assert_eq!(SysPropertyRow::descriptor().system, Some(SystemModel::Property));
-        assert_eq!(SysModelPropertyRow::collection().as_str(), system_collection_label(SystemModel::ModelProperty));
-        assert_eq!(SysModelPropertyRow::descriptor().system, Some(SystemModel::ModelProperty));
-    }
-
-    /// The row fields match the executor's writers field-for-field
-    /// (registration.rs `creation` calls), so a typed View reads exactly
-    /// what registration writes.
-    #[test]
-    fn row_fields_match_executor_writers() {
-        let fields: Vec<&str> = SysPropertyRow::descriptor().properties.iter().map(|p| p.name).collect();
-        assert_eq!(fields, ["name", "backend", "value_type", "minted_for", "target_model"]);
-        let fields: Vec<&str> = SysModelPropertyRow::descriptor().properties.iter().map(|p| p.name).collect();
-        assert_eq!(fields, ["model", "property", "optional"]);
-    }
+/// One `_ankurah_model_property` row: a property's membership in a model.
+#[derive(Model, Debug, Clone)]
+#[model(base = "crate", system = "ModelProperty")]
+pub struct SysModelPropertyRow {
+    pub model: EntityId,
+    pub property: EntityId,
+    pub optional: bool,
 }

--- a/core/src/schema/catalog/rows.rs
+++ b/core/src/schema/catalog/rows.rs
@@ -1,13 +1,13 @@
-//! Canonical typed read shapes for the catalog's three entity collections.
+//! Canonical typed model shapes for the catalog's three entity collections.
 //!
 //! Here, a **row** means the persisted fields of one model definition,
 //! property definition, or model-property membership. These structs make
-//! catalog data available through the same generated `View` API as
-//! application data and keep that typed schema beside the raw parser it must
-//! agree with. The durable registration executor still emits raw bootstrap
-//! events, and ordinary transactions may not mutate system collections; the
-//! generated `Mutable` surface grants a Rust representation, not write
-//! authority.
+//! catalog data available through the same generated Model, View, and
+//! Mutable APIs as application data. Durable registration writes them through
+//! a local SystemRoot context; ordinary application contexts are still
+//! forbidden from mutating system collections. The generated Mutable surface
+//! provides the common mechanism, while the Context authority decides who
+//! may use it.
 //!
 //! `base = "crate"` makes generated code address core directly rather than
 //! through the `::ankurah` facade. `system = "..."` pins a built-in

--- a/core/src/schema/compiled.rs
+++ b/core/src/schema/compiled.rs
@@ -48,6 +48,10 @@ pub struct ModelStructDescriptor {
     /// system models are pre-registered by definition and never consult
     /// the catalog they describe. `#[derive(Model)]` always emits `None`.
     pub system: Option<ankurah_core_types::SystemModel>,
+    /// The struct's deterministic source identity: a compile-time hash of
+    /// the declaring module path and struct name. Rides registration as a
+    /// migration hint; nothing resolves through it.
+    pub unique_id: ankurah_core_types::UniqueStructId,
 }
 
 /// The compiled schema for one active field of a model. `(backend,
@@ -92,6 +96,11 @@ pub struct StructProperty {
     /// default by-name registration. URL-safe base64 of a 16-byte EntityId,
     /// validated at derive time.
     pub explicit_id: Option<&'static str>,
+    /// The field's deterministic source identity: a compile-time hash of the
+    /// declaring module path, struct name, and field name. Names only, so it
+    /// survives a change of the field's type. Rides registration as a
+    /// migration hint; nothing resolves through it.
+    pub unique_id: ankurah_core_types::UniqueFieldId,
 }
 
 impl ModelStructDescriptor {
@@ -110,6 +119,7 @@ impl From<&ModelStructDescriptor> for RegisterModel {
             label: schema.label.to_string(),
             name: schema.name.to_string(),
             explicit_id: schema.explicit_id.map(parse_explicit_id),
+            unique_id: Some(schema.unique_id),
             properties: schema
                 .properties
                 .iter()
@@ -120,6 +130,7 @@ impl From<&ModelStructDescriptor> for RegisterModel {
                     value_type: field.value_type.to_string(),
                     target_label: field.target_label.map(str::to_string),
                     explicit_id: field.explicit_id.map(parse_explicit_id),
+                    unique_id: Some(field.unique_id),
                     optional: field.optional,
                 })
                 .collect(),

--- a/core/src/schema/compiled.rs
+++ b/core/src/schema/compiled.rs
@@ -1,21 +1,24 @@
-//! The local compiled schema: the derive macro's static description of a
-//! model and its properties.
+//! Static model declarations emitted into one compiled binary.
 //!
-//! Rust structs are ONE binding to the catalog, not the definitive schema
-//!: `#[derive(Model)]` emits a [`ModelStructDescriptor`] whose
-//! `(backend, value_type)` pairs come from the NORMATIVE mapping table
-//!. A property's minting model and name locate its identity;
-//! registration then checks the compiled pair against the immutable canonical
-//! pair (exact backend and a mutually castable value type), refusing an
-//! incompatible binding rather than minting another identity. The catalog
-//! entities themselves remain the definitive schema; ids exist only there and
-//! in registration responses. This type is how a compiled binary names its
-//! properties and how it builds a RegisterSchema request.
+//! Here, **compiled schema** means a program's source-level claim about one
+//! model, not the system's authoritative schema. `#[derive(Model)]` turns
+//! Rust names, field types, and model attributes into a static
+//! [`ModelStructDescriptor`]; this module turns that descriptor into a
+//! language-neutral `RegisterModel` request. It owns no catalog lookup,
+//! allocation, or per-system binding state.
 //!
-//! These types are entirely `&'static`: the derive macro emits a `static
-//! ModelStructDescriptor` and a `Model::descriptor()` returning `&'static` to it, so
-//! there is no per-call allocation and the schema is a `const`-shaped fact
-//! of the program.
+//! Ordinary property identity is located by current name inside the model's
+//! membership set; `minted_for` is provenance, not part of that key.
+//! Registration then checks the descriptor's `(backend, value_type)` against
+//! the durable property's canonical pair and refuses an incompatible
+//! declaration rather than minting a second identity. Explicit ids pin known
+//! catalog entities, while source-derived unique ids are migration hints only
+//! and never resolve a property today.
+//!
+//! Descriptor data is entirely `&'static`: the derive emits one static value
+//! and `Model::descriptor()` returns it by reference. Catalog entity ids enter
+//! only through explicit pins or a registration response, never through this
+//! module's ordinary derived declarations.
 
 use ankurah_proto::{RegisterModel, RegisterProperty};
 

--- a/core/src/schema/compiled.rs
+++ b/core/src/schema/compiled.rs
@@ -42,6 +42,12 @@ pub struct ModelStructDescriptor {
     /// the default label-based registration path. The value is
     /// URL-safe base64 of a 16-byte EntityId, validated at derive time.
     pub explicit_id: Option<&'static str>,
+    /// A built-in system model's closed identity, `Some` only for the
+    /// catalog's own row models (core/src/schema/catalog/rows.rs). It
+    /// short-circuits first-use registration to `ModelId::System(..)`:
+    /// system models are pre-registered by definition and never consult
+    /// the catalog they describe. `#[derive(Model)]` always emits `None`.
+    pub system: Option<ankurah_core_types::SystemModel>,
 }
 
 /// The compiled schema for one active field of a model. `(backend,

--- a/core/src/schema/compiled.rs
+++ b/core/src/schema/compiled.rs
@@ -46,7 +46,8 @@ pub struct ModelStructDescriptor {
     /// catalog's own row models (core/src/schema/catalog/rows.rs). It
     /// short-circuits first-use registration to `ModelId::System(..)`:
     /// system models are pre-registered by definition and never consult
-    /// the catalog they describe. `#[derive(Model)]` always emits `None`.
+    /// the catalog they describe. Only `#[model(system = "...")]` emits
+    /// `Some`; a plain derive emits `None`.
     pub system: Option<ankurah_core_types::SystemModel>,
     /// The struct's deterministic source identity: a compile-time hash of
     /// the declaring module path and struct name. Rides registration as a

--- a/core/src/schema/compiled.rs
+++ b/core/src/schema/compiled.rs
@@ -42,7 +42,7 @@ pub struct ModelStructDescriptor {
     /// the default label-based registration path. The value is
     /// URL-safe base64 of a 16-byte EntityId, validated at derive time.
     pub explicit_id: Option<&'static str>,
-    /// A built-in system model's closed identity, `Some` only for the
+    /// A built-in system model's System ID, `Some` only for the
     /// catalog's own row models (core/src/schema/catalog/rows.rs). It
     /// short-circuits first-use registration to `ModelId::System(..)`:
     /// system models are pre-registered by definition and never consult

--- a/core/src/schema/mod.rs
+++ b/core/src/schema/mod.rs
@@ -1,30 +1,27 @@
-//! The schema catalog: what the system knows about models and properties.
+//! The boundary between source-level model declarations and a system's
+//! durable model and property identities.
 //!
-//! Ankurah stores schema as DATA. Every model and every property is an
-//! ordinary entity in one of three reserved collections (`_ankurah_model`,
-//! `_ankurah_property`, `_ankurah_model_property` for the property-to-model
-//! memberships), with a durable id minted by the system's one durable
-//! allocator. Those entities replicate, persist, and survive renames like
-//! any other data, which is the point: a property's identity is its entity
-//! id, not its current display name, so renaming a field someday does not
-//! orphan the data written under it.
+//! Here, **schema** means the facts needed to translate model and property
+//! names and Rust field types into stable identities and value types. The
+//! durable facts are data: application model definitions, property
+//! definitions, and model-property memberships are entities in three
+//! reserved collections. Their entity ids survive renames, so stored data is
+//! addressed by identity rather than by its current source spelling.
 //!
-//! A Rust struct with `#[derive(Model)]` is not the schema; it is one
-//! binary's DECLARATION of a schema, compiled into a static
-//! ([`ModelStructDescriptor`], in [`compiled`]). The first time a binary uses a model --
-//! explicitly via `Context::register`, or implicitly on create/fetch -- that
-//! declaration is sent to the durable node, whose registration executor
-//! ([`registration`]) looks each piece up, allocates ids for anything new,
-//! checks that a re-declaration is compatible with what the catalog already
-//! holds, and returns the resolved ids. Two binaries with the same struct
-//! get the same ids; a binary whose declaration conflicts is refused.
+//! [`compiled`] is one binary's static declaration of those facts;
+//! [`registration`] is the durable allocator operation that reconciles a
+//! declaration with catalog data; [`catalog`] is each node's runtime service
+//! and materialized projection of the resulting definitions. The first use
+//! of a derived model, or an explicit `Context::register_model`, sends its
+//! [`ModelStructDescriptor`] through that path. Compatible declarations
+//! receive the same ids and incompatible declarations fail.
 //!
-//! Each node keeps an in-memory index of the catalog entities
-//! ([`catalog::CatalogManager`]) so lookups don't touch storage: parsed into
-//! `ModelDef`/`PropertyDef`/`ModelPropertyMembershipDef`, warmed from local storage on
-//! durable nodes and from registration responses on ephemeral ones. The
-//! wire request/response types live in ankurah-proto. The full design
-//! record lives with the design documents for this subsystem.
+//! This module root owns vocabulary shared by those three stages: the closed
+//! mapping between built-in [`SystemModel`]
+//! identities and their current collection labels, protection of the
+//! `_ankurah_` namespace, and [`CollectionSchema`], the minimal field-type
+//! interface used when query literals must be cast. Wire request and response
+//! types remain in `ankurah-proto`.
 
 pub mod catalog;
 pub mod compiled;
@@ -44,10 +41,10 @@ pub trait CollectionSchema {
     fn field_type(&self, path: &PathExpr) -> Result<ValueType, PropertyError>;
 }
 
-/// The metadata catalog collections. Catalog entities are SYSTEM MODELS: raw Entity/backend
-/// access only, like SysRoot; deriving a Model for one of these is the
-/// self-description ouroboros: the catalog must never need itself to
-/// describe itself.
+/// The metadata catalog collections. Their typed row models are SYSTEM
+/// MODELS: compile-time identities whose derives never consult the catalog
+/// they describe. Ordinary transactions may read them through typed Views,
+/// but only schema registration may mutate them.
 pub const MODEL_COLLECTION_ID: &str = "_ankurah_model";
 pub const PROPERTY_COLLECTION_ID: &str = "_ankurah_property";
 pub const MODEL_PROPERTY_COLLECTION_ID: &str = "_ankurah_model_property";

--- a/core/src/schema/mod.rs
+++ b/core/src/schema/mod.rs
@@ -66,7 +66,7 @@ pub fn is_catalog_collection(id: &ModelId) -> bool {
 
 /// Whether `id` names one of Ankurah's built-in collections. Built-ins are
 /// the only collections permitted under [`RESERVED_COLLECTION_PREFIX`] and
-/// cannot be mutated through ordinary user transactions.
+/// cannot be mutated through ordinary application transactions.
 pub fn is_protected_collection(id: &ModelId) -> bool { matches!(id, ModelId::System(_)) }
 
 /// The logical protocol model for today's built-in storage key. This mapping

--- a/core/src/schema/registration.rs
+++ b/core/src/schema/registration.rs
@@ -1,16 +1,22 @@
-//! The durable-side executor for the RegisterSchema protocol operation
-//!.
+//! The durable allocator and admission transaction for `RegisterSchema`.
 //!
-//! Registration is an UPSERT: the executor looks each definition up by its
-//! lookup key (model by source label; property by (model, name);
-//! model-property membership by (model, property)), ALLOCATES a fresh
-//! `EntityId::new()` -- a true ULID -- on miss, and emits ordinary events
-//! through the policy-checked commit pipeline. The whole execution
-//! serializes on a process-local mutex, and the executor upserts the
-//! resolved definitions into the catalog map synchronously after commit,
-//! BEFORE releasing that mutex, so consecutive registrations can never
-//! race the reactor-fed map into double-allocation. The resolved definitions are returned to the requester via
-//! `NodeResponseBody::SchemaRegistered`.
+//! Here, **registration** means the durable node's complete transition from
+//! a language-neutral declaration to resolved catalog identities. The input
+//! is a set of `RegisterModel` descriptors plus current catalog state; the
+//! output is a policy-visible [`RegistrationPlan`], ordinary catalog events,
+//! and a `SchemaRegistered` tree containing every resolved id. This module
+//! owns lookup-key semantics, compatibility checks, allocation, and event
+//! construction. The per-node feed, reset epoch, compiled-binding latch, and
+//! ephemeral forwarding path belong to [`super::catalog`].
+//!
+//! Registration is an upsert: models resolve by source label, properties by
+//! current name within a model's membership set, and memberships by
+//! `(model, property)`. A miss allocates a fresh `EntityId`; a hit keeps its
+//! identity. The whole lookup/allocate/commit/fold transaction serializes on
+//! the catalog manager's allocator mutex, and resolved definitions enter the
+//! materialized catalog projection before that mutex is released. A later
+//! reactor delivery is therefore redundant rather than necessary for the
+//! next registration's correctness.
 //!
 //! Policy gates the execution at two complementary boundaries:
 //! request authentication decides whether the principal may submit schema
@@ -29,6 +35,12 @@
 //! and reads through the cast); a different backend, or a non-castable type
 //! pair, refuses the registration loudly. Changing a canonical type is a
 //! deliberate migration (#303), never a model-struct edit.
+//!
+//! TODO(organization): this file still co-locates the public error/plan
+//! vocabulary, the allocation algorithm, bootstrap storage reads, and raw
+//! event encoding. Keep `register_schema` as the transaction boundary, but
+//! extract those supporting nouns into focused submodules once their inputs
+//! no longer require reaching through the whole `CatalogManager`.
 
 use std::collections::BTreeMap;
 

--- a/core/src/schema/registration.rs
+++ b/core/src/schema/registration.rs
@@ -1,32 +1,28 @@
-//! The durable allocator and admission transaction for `RegisterSchema`.
+//! The durable allocator for `RegisterSchema`.
 //!
 //! Here, **registration** means the durable node's complete transition from
 //! a language-neutral declaration to resolved catalog identities. The input
 //! is a set of `RegisterModel` descriptors plus current catalog state; the
-//! output is a policy-visible [`RegistrationPlan`], ordinary catalog events,
-//! and a `SchemaRegistered` tree containing every resolved id. This module
-//! owns lookup-key semantics, compatibility checks, allocation, and event
-//! construction. The per-node feed, reset epoch, compiled-binding latch, and
-//! ephemeral forwarding path belong to [`super::catalog`].
+//! output is a `SchemaRegistered` tree containing every resolved id. This
+//! module owns lookup-key semantics, compatibility checks, and allocation;
+//! it persists the resulting rows through the catalog's ordinary typed
+//! Models and Mutables under a local SystemRoot context. The per-node feed,
+//! reset epoch, compiled-binding latch, and ephemeral forwarding path belong
+//! to [`super::catalog`].
 //!
 //! Registration is an upsert: models resolve by source label, properties by
 //! current name within a model's membership set, and memberships by
 //! `(model, property)`. A miss allocates a fresh `EntityId`; a hit keeps its
 //! identity. The whole lookup/allocate/commit/fold transaction serializes on
-//! the catalog manager's allocator mutex, and resolved definitions enter the
-//! materialized catalog projection before that mutex is released. A later
-//! reactor delivery is therefore redundant rather than necessary for the
-//! next registration's correctness.
+//! the catalog manager's allocator mutex. The SystemRoot transaction notifies
+//! the typed catalog LiveQueries synchronously before commit returns, so the
+//! projection observes the new identities before the mutex is released.
 //!
-//! Policy gates the execution at two complementary boundaries:
-//! request authentication decides whether the principal may submit schema
-//! descriptors, the resolved plan -- what this request will actually create
-//! and update -- goes through `PolicyAgent::check_schema_registration` before
-//! anything is emitted, and every emitted event still passes `check_event` inside the ordinary
-//! commit pipeline. A durable node needs no model code to serve
-//! registration: the request carries language-agnostic descriptors.
-//! Idempotence is the upsert's: a repeat registration finds every key,
-//! emits zero events, and returns the same ids.
+//! Remote request authentication decides whether a principal may submit
+//! schema descriptors. Materializing an accepted request is trusted system
+//! work and therefore bypasses the application's PolicyAgent. Idempotence is
+//! the upsert's: a repeat registration finds every key, emits zero events,
+//! and returns the same ids.
 //!
 //! A property's (backend, value_type) is CANONICAL: fixed at allocation and
 //! never changed by registration. A hit
@@ -36,28 +32,21 @@
 //! pair, refuses the registration loudly. Changing a canonical type is a
 //! deliberate migration (#303), never a model-struct edit.
 //!
-//! TODO(organization): this file still co-locates the public error/plan
-//! vocabulary, the allocation algorithm, bootstrap storage reads, and raw
-//! event encoding. Keep `register_schema` as the transaction boundary, but
-//! extract those supporting nouns into focused submodules once their inputs
-//! no longer require reaching through the whole `CatalogManager`.
-
 use std::collections::BTreeMap;
 
-use ankurah_proto::{
-    self as proto, Attested, EntityId, Membership, Operation, OperationSet, RegisterModel, RegisterProperty, RegisteredModel,
-    RegisteredProperty, SystemProperty, TransactionId,
-};
+use ankurah_proto::{EntityId, RegisterModel, RegisterProperty, RegisteredModel, RegisteredProperty};
 
+use crate::context::Context;
 use crate::error::{MutationError, RetrievalError};
-use crate::policy::{AccessDenied, PolicyAgent};
-use crate::property::backend::{LWWBackend, PropertyBackend};
+use crate::model::View;
+use crate::policy::PolicyAgent;
+use crate::schema::catalog::rows::{
+    SysModelPropertyRow, SysModelPropertyRowView, SysModelRow, SysModelRowView, SysPropertyRow, SysPropertyRowView,
+};
 use crate::storage::StorageEngine;
-use crate::value::Value;
-use crate::ModelId;
 use ankurah_core_types::ValueType;
 
-use super::{model_collection, model_property_collection, property_collection};
+use ankql::ast::Selection;
 
 /// A durable schema-registration request could not be completed.
 #[derive(Debug, thiserror::Error)]
@@ -97,6 +86,10 @@ pub enum RegistrationError {
         /// The rejected source-level collection label.
         String,
     ),
+    /// SystemRoot operates only on built-in system models; it never
+    /// registers application models.
+    #[error("SystemRoot cannot register application model '{0}'")]
+    SystemRootApplicationModel(String),
     /// A membership's name reference was not declared in the same request.
     #[error("membership references property '{0}' which is not declared in this request for collection '{1}'")]
     UnresolvedPropertyRef(
@@ -151,13 +144,6 @@ pub enum RegistrationError {
         /// The value type declared by the requester.
         value_type: String,
     },
-    /// The policy agent denied the resolved registration plan.
-    #[error("registration refused by policy: {0}")]
-    PolicyDenied(
-        /// The policy agent's denial.
-        #[from]
-        AccessDenied,
-    ),
     /// Committing the catalog events failed.
     #[error(transparent)]
     Mutation(
@@ -191,87 +177,14 @@ impl From<RegistrationError> for crate::error::MutationError {
     fn from(error: RegistrationError) -> Self { crate::error::MutationError::General(Box::new(error)) }
 }
 
-/// What a RegisterSchema request will ACTUALLY do, resolved by the
-/// registration executor under the allocation mutex and handed to
-/// [`crate::policy::PolicyAgent::check_schema_registration`] before any
-/// event is emitted, so an agent can judge real creations and metadata
-/// changes without performing its own catalog lookups. Core-side only;
-/// never crosses the wire.
-#[derive(Debug, Default)]
-pub struct RegistrationPlan {
-    /// Model entities this request will CREATE, with their would-be
-    /// allocated ids (minted, not yet committed).
-    pub creates_models: Vec<(EntityId, RegisterModel)>,
-    /// Property entities this request will CREATE, with their would-be
-    /// allocated ids.
-    pub creates_properties: Vec<(EntityId, RegisterProperty)>,
-    /// Model-property memberships this request will CREATE, fully resolved.
-    pub creates_memberships: Vec<PlannedModelPropertyMembership>,
-    /// Metadata follow-ups this request will write on EXISTING entities
-    /// (display-name changes including rename-hint applications, target
-    /// retargets, membership `optional` flips).
-    pub updates: Vec<PlannedUpdate>,
-    /// Definitions that resolved to existing entities with no changes:
-    /// pure no-ops, listed for context.
-    pub existing: Vec<EntityId>,
-}
-
-impl RegistrationPlan {
-    /// Whether the plan writes anything at all (a re-registration of
-    /// unchanged definitions is a pure no-op and skips the policy verb).
-    pub fn is_noop(&self) -> bool {
-        self.creates_models.is_empty()
-            && self.creates_properties.is_empty()
-            && self.creates_memberships.is_empty()
-            && self.updates.is_empty()
-    }
-}
-
-/// A model-property membership creation in a [`RegistrationPlan`], resolved
-/// to ids.
-#[derive(Debug, Clone)]
-pub struct PlannedModelPropertyMembership {
-    /// The durable identity assigned to the membership entity.
-    pub id: EntityId,
-    /// The model receiving the property.
-    pub model: EntityId,
-    /// The property admitted to the model.
-    pub property: EntityId,
-    /// Whether entities of the model may omit the property.
-    pub optional: bool,
-}
-
-/// A metadata follow-up on an existing catalog entity, in a
-/// [`RegistrationPlan`].
-#[derive(Debug, Clone)]
-pub struct PlannedUpdate {
-    /// Which catalog collection the entity lives in.
-    pub collection: crate::ModelId,
-    /// The durable catalog entity to update.
-    pub entity: EntityId,
-    /// The system field whose metadata value changes.
-    pub field: String,
-    /// The current catalog value, when one exists.
-    pub from: Option<crate::value::Value>,
-    /// The requested catalog value. `None` means the field will be cleared.
-    pub to: Option<crate::value::Value>,
-}
-
 impl<SE, PA> super::catalog::CatalogManager<SE, PA>
 where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
-    /// Execute a RegisterSchema request as the system's allocator: upsert
-    /// every model by its label and every nested property within its
-    /// model's membership set, allocate fresh ids for misses, emit ordinary
-    /// creation events and difference-only follow-ups through the
-    /// policy-checked pipeline, and return the resolved tree.
-    pub async fn register_schema(
-        &self,
-        cdata: &PA::ContextData,
-        models: Vec<RegisterModel>,
-    ) -> Result<Vec<RegisteredModel>, RegistrationError> {
+    /// Resolve and persist a RegisterSchema request through the ordinary
+    /// typed Model/Mutable transaction path under local SystemRoot authority.
+    pub async fn register_schema(&self, models: Vec<RegisterModel>) -> Result<Vec<RegisteredModel>, RegistrationError> {
         let node = self.node().ok_or(RegistrationError::SystemNotReady)?;
         if !node.durable {
             return Err(RegistrationError::NotDurable);
@@ -280,12 +193,8 @@ where
             return Err(RegistrationError::SystemNotReady);
         }
         let registration_validity = self.registration_validity().ok_or(RegistrationError::SystemNotReady)?;
-        // Labels are schema lookup keys, not runtime model identities.
-        // Reserved collections are refused before policy is even asked: the
-        // catalog and system collections route by name and have no catalog
-        // model entities of their own, so a registration naming one -- as a
-        // model label or a property's target -- could only route ordinary
-        // traffic into a protected collection.
+        // Catalog and system collections route by built-in identity and can
+        // never be declared by an application descriptor.
         {
             let mut named: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
             for m in &models {
@@ -302,78 +211,39 @@ where
                 }
             }
         }
-        // The catalog map is the executor's primary lookup source; wait for
-        // the warm so the common case looks up against a full map. The map
-        // is NOT trusted alone on a miss: every miss double-checks durable
-        // storage before minting (the *_lookup_checked helpers), so a
-        // lagging or cold map can never fork identity.
         if !self.wait_catalog_ready_if_current(&registration_validity).await {
             return Err(RegistrationError::SystemNotReady);
         }
         let _registration_lease = registration_validity.try_acquire().ok_or(RegistrationError::SystemNotReady)?;
-
-        // Executor discipline: the whole upsert -- lookups, allocation,
-        // commit, and the synchronous map update -- serializes on the
-        // allocator mutex, so consecutive registrations observe each other.
         let _allocator = self.lock_allocator().await;
+        let context = Context::new_system_root(node)?;
+        let trx = context.begin();
+        let mut changed = false;
 
-        let mut plan = RegistrationPlan::default();
-        // Creation events carry the FULL definition state; follow-ups carry
-        // only fields that differ, parented at the entity's current head so
-        // LWW recency, rather than a concurrent tiebreak, decides.
-        let mut events: Vec<Attested<proto::Event>> = Vec::new();
-        let mut push = |event: proto::Event| events.push(Attested::opt(event, None));
-
-        // -- pass 1: model shells, so nested target references and
-        //    same-request cross-references resolve ---------------------------
+        // Pass 1 resolves model shells so target-model references in pass 2
+        // can point at models declared later in the same request.
         let mut model_ids: BTreeMap<String, (EntityId, usize)> = BTreeMap::new();
         let mut out_models: Vec<RegisteredModel> = Vec::new();
         for m in &models {
-            // A duplicate label in ONE request must not re-mint: the first
-            // occurrence resolves the model; later occurrences reuse it (their
-            // property entries still attach below).
             if model_ids.contains_key(&m.label) {
                 continue;
             }
             let (model_id, resolved_name) = match m.explicit_id {
                 Some(id) => {
-                    // Explicit binding: verify, never mint, never mutate the
-                    // bound entity's fields; the catalog's display name stands.
-                    let values = self.verify_explicit_model_binding(id, m).await?;
-                    let name = string_field(&values, "name").unwrap_or_else(|| m.label.clone());
-                    plan.existing.push(id);
-                    (id, name)
+                    let def = self.verify_explicit_model_binding(&context, id, m).await?;
+                    (id, def.name)
                 }
-                None => match self.model_lookup_checked(&m.label).await? {
+                None => match self.model_lookup_checked(&context, &m.label).await? {
                     Some(def) => {
-                        // Display names follow the most recent registration;
-                        // emit only on difference.
                         if def.name != m.name {
-                            let (_, head) = self
-                                .catalog_entity_snapshot(def.id, &model_collection())
-                                .await?
-                                .ok_or_else(|| RetrievalError::Other(format!("catalog map holds model {} absent from storage", def.id)))?;
-                            plan.updates.push(PlannedUpdate {
-                                collection: model_collection(),
-                                entity: def.id,
-                                field: "name".into(),
-                                from: Some(Value::String(def.name.clone())),
-                                to: Some(Value::String(m.name.clone())),
-                            });
-                            push(follow_up(model_collection(), def.id, head, vec![("name", Value::String(m.name.clone()))]));
-                        } else {
-                            plan.existing.push(def.id);
+                            trx.get::<SysModelRow>(&def.id).await?.name().set(&m.name).map_err(MutationError::from)?;
+                            changed = true;
                         }
                         (def.id, m.name.clone())
                     }
                     None => {
-                        let id = EntityId::new();
-                        plan.creates_models.push((id, m.clone()));
-                        push(creation(
-                            model_collection(),
-                            id,
-                            vec![("label", Value::String(m.label.clone())), ("name", Value::String(m.name.clone()))],
-                        ));
+                        let id = trx.create(&SysModelRow { label: m.label.clone(), name: m.name.clone() }).await?.id();
+                        changed = true;
                         (id, m.name.clone())
                     }
                 },
@@ -382,34 +252,22 @@ where
             out_models.push(RegisteredModel { id: model_id, label: m.label.clone(), name: resolved_name, properties: Vec::new() });
         }
 
-        // Resolve a label reference to a model id, allocating a stub model
-        // on full miss (target-model references resolve executor-side).
+        // Resolve a target label, creating its catalog model shell if the
+        // target was not separately declared.
         macro_rules! resolve_model {
             ($label:expr) => {{
                 let l: &str = $label;
                 match model_ids.get(l) {
                     Some((id, _)) => *id,
-                    None => match self.model_lookup_checked(l).await? {
+                    None => match self.model_lookup_checked(&context, l).await? {
                         Some(def) => {
                             model_ids.insert(l.to_string(), (def.id, out_models.len()));
                             out_models.push(RegisteredModel { id: def.id, label: def.label, name: def.name, properties: Vec::new() });
                             def.id
                         }
                         None => {
-                            let id = EntityId::new();
-                            let stub = RegisterModel {
-                                label: l.to_string(),
-                                name: l.to_string(),
-                                explicit_id: None,
-                                unique_id: None,
-                                properties: Vec::new(),
-                            };
-                            plan.creates_models.push((id, stub));
-                            push(creation(
-                                model_collection(),
-                                id,
-                                vec![("label", Value::String(l.to_string())), ("name", Value::String(l.to_string()))],
-                            ));
+                            let id = trx.create(&SysModelRow { label: l.to_string(), name: l.to_string() }).await?.id();
+                            changed = true;
                             model_ids.insert(l.to_string(), (id, out_models.len()));
                             out_models.push(RegisteredModel { id, label: l.to_string(), name: l.to_string(), properties: Vec::new() });
                             id
@@ -419,19 +277,11 @@ where
             }};
         }
 
-        // -- pass 2: each model entry's properties. Nesting IS the
-        //    membership assertion: every entry ensures a (model, property)
-        //    membership, whether the property is minted here, found in the
-        //    model's membership set by name, or explicitly shared by id. ----
         let mut property_ids: BTreeMap<(EntityId, String), (EntityId, String, String)> = BTreeMap::new();
-        let mut membership_seen: std::collections::BTreeSet<(EntityId, EntityId)> = std::collections::BTreeSet::new();
+        let mut membership_ids: BTreeMap<(EntityId, EntityId), EntityId> = BTreeMap::new();
         for m in &models {
             let (model_id, out_index) = *model_ids.get(&m.label).expect("pass 1 resolved every model label");
             for p in &m.properties {
-                // Duplicate (model, name) in one request: the first
-                // occurrence fixes the resolution; a later duplicate
-                // coalesces onto it under the same compatibility bar as a
-                // catalog hit.
                 if let Some((_, canon_backend, canon_vt)) = property_ids.get(&(model_id, p.name.clone())) {
                     if p.backend != *canon_backend || !value_types_compatible(canon_vt, &p.value_type) {
                         return Err(RegistrationError::NonCastable {
@@ -447,55 +297,35 @@ where
                 }
 
                 if let Some(id) = p.explicit_id {
-                    // Explicit binding: verify (backend, value_type), never
-                    // mint the property; the bound entity's name and metadata
-                    // are authoritative. The nested position still asserts
-                    // THIS model's membership, which is how a property minted
-                    // elsewhere is intentionally shared.
-                    let values = self.verify_explicit_binding(id, &m.label, p).await?;
-                    plan.existing.push(id);
-                    let backend = string_field(&values, "backend").unwrap_or_else(|| p.backend.clone());
-                    let value_type = string_field(&values, "value_type").unwrap_or_else(|| p.value_type.clone());
-                    let membership_id = self.ensure_membership(&mut plan, &mut push, model_id, id, p.optional).await?;
+                    let def = self.verify_explicit_binding(&context, id, &m.label, p).await?;
+                    let backend = def.backend.clone();
+                    let value_type = def.value_type.clone();
+                    let membership_id =
+                        self.ensure_membership(&context, &trx, &mut membership_ids, &mut changed, model_id, id, p.optional).await?;
                     property_ids.insert((model_id, p.name.clone()), (id, backend.clone(), value_type.clone()));
                     out_models[out_index].properties.push(RegisteredProperty {
                         id,
                         membership_id,
-                        name: string_field(&values, "name").unwrap_or_else(|| p.name.clone()),
+                        name: if def.name.is_empty() { p.name.clone() } else { def.name },
                         backend,
                         value_type,
-                        target_model: entity_id_field(&values, "target_model"),
-                        minted_for: entity_id_field(&values, "minted_for"),
+                        target_model: def.target_model,
+                        minted_for: def.minted_for,
                         optional: p.optional,
                     });
                     continue;
                 }
 
-                // Resolve the target-model reference first so both the
-                // create and the diff paths can use it.
                 let target = match &p.target_label {
                     Some(tl) => Some(resolve_model!(tl)),
                     None => None,
                 };
 
-                // Lookup scope is the model's MEMBERSHIP SET by current name
-                // (a shared property resolves here regardless of where it
-                // was minted; minted_for is provenance, never a key), with
-                // the rename hint consulted only when the current name
-                // misses.
-                let current = self.member_property_lookup_checked(&model_id, &p.name).await?;
+                let current = self.member_property_lookup_checked(&context, &model_id, &p.name).await?;
                 let renamed = match (&current, &p.renamed_from) {
-                    (None, Some(old)) => self.member_property_lookup_checked(&model_id, old).await?,
+                    (None, Some(old)) => self.member_property_lookup_checked(&context, &model_id, old).await?,
                     _ => None,
                 };
-
-                // The canonical-type compatibility gate: a hit never mutates
-                // (backend, value_type) and never forks a second identity.
-                // Refuses loudly on a different backend or a non-castable
-                // type pair; a castable drift is admitted (the binary writes
-                // and reads through the cast) and the response carries the
-                // CANONICAL types so the requester's map holds its cast
-                // target.
                 let canonical = current.as_ref().or(renamed.as_ref()).map(|(def, _)| (def.backend.clone(), def.value_type.clone()));
                 if let Some((def, _)) = current.as_ref().or(renamed.as_ref()) {
                     check_property_compat(def, &m.label, p)?;
@@ -503,82 +333,42 @@ where
 
                 let (property_id, membership_id) = match (&current, &renamed) {
                     (Some((def, membership)), _) => {
-                        // Plain hit: name matches by construction; only the
-                        // target reference can differ.
-                        let mut fields: Vec<(&str, Option<Value>)> = Vec::new();
                         if def.target_model != target {
-                            let target_value = target.map(Value::EntityId);
-                            plan.updates.push(PlannedUpdate {
-                                collection: property_collection(),
-                                entity: def.id,
-                                field: "target_model".into(),
-                                from: def.target_model.map(Value::EntityId),
-                                to: target_value.clone(),
-                            });
-                            fields.push(("target_model", target_value));
+                            trx.get::<SysPropertyRow>(&def.id).await?.target_model().set(&target).map_err(MutationError::from)?;
+                            changed = true;
                         }
-                        if fields.is_empty() {
-                            plan.existing.push(def.id);
-                        } else {
-                            let (_, head) = self.catalog_entity_snapshot(def.id, &property_collection()).await?.ok_or_else(|| {
-                                RetrievalError::Other(format!("catalog map holds property {} absent from storage", def.id))
-                            })?;
-                            push(follow_up_patch(property_collection(), def.id, head, fields));
-                        }
-                        let membership_id = self.ensure_membership_from(&mut plan, &mut push, membership.clone(), p.optional).await?;
+                        let membership_id = self.ensure_membership_from(&trx, &mut changed, membership.clone(), p.optional).await?;
+                        membership_ids.insert((model_id, def.id), membership_id);
                         (def.id, membership_id)
                     }
                     (None, Some((def, membership))) => {
-                        // The rename hint applies: update `name` on the
-                        // existing lineage, plus any target change, in one
-                        // follow-up.
-                        let mut fields: Vec<(&str, Option<Value>)> = vec![("name", Some(Value::String(p.name.clone())))];
-                        plan.updates.push(PlannedUpdate {
-                            collection: property_collection(),
-                            entity: def.id,
-                            field: "name".into(),
-                            from: Some(Value::String(def.name.clone())),
-                            to: Some(Value::String(p.name.clone())),
-                        });
+                        let property = trx.get::<SysPropertyRow>(&def.id).await?;
+                        property.name().set(&p.name).map_err(MutationError::from)?;
                         if def.target_model != target {
-                            let target_value = target.map(Value::EntityId);
-                            plan.updates.push(PlannedUpdate {
-                                collection: property_collection(),
-                                entity: def.id,
-                                field: "target_model".into(),
-                                from: def.target_model.map(Value::EntityId),
-                                to: target_value.clone(),
-                            });
-                            fields.push(("target_model", target_value));
+                            property.target_model().set(&target).map_err(MutationError::from)?;
                         }
-                        let (_, head) = self
-                            .catalog_entity_snapshot(def.id, &property_collection())
-                            .await?
-                            .ok_or_else(|| RetrievalError::Other(format!("catalog map holds property {} absent from storage", def.id)))?;
-                        push(follow_up_patch(property_collection(), def.id, head, fields));
-                        let membership_id = self.ensure_membership_from(&mut plan, &mut push, membership.clone(), p.optional).await?;
+                        changed = true;
+                        let membership_id = self.ensure_membership_from(&trx, &mut changed, membership.clone(), p.optional).await?;
+                        membership_ids.insert((model_id, def.id), membership_id);
                         (def.id, membership_id)
                     }
                     (None, None) => {
-                        // Miss: allocate the property AND its membership. The
-                        // creation events carry the full definition state.
-                        let id = EntityId::new();
-                        plan.creates_properties.push((id, p.clone()));
-                        let mut fields: Vec<(&str, Value)> = vec![
-                            ("minted_for", Value::EntityId(model_id)),
-                            ("name", Value::String(p.name.clone())),
-                            ("backend", Value::String(p.backend.clone())),
-                            ("value_type", Value::String(p.value_type.clone())),
-                        ];
-                        if let Some(t) = target {
-                            fields.push(("target_model", Value::EntityId(t)));
-                        }
-                        push(creation(property_collection(), id, fields));
-                        let membership_id = self.ensure_membership(&mut plan, &mut push, model_id, id, p.optional).await?;
+                        let id = trx
+                            .create(&SysPropertyRow {
+                                name: p.name.clone(),
+                                backend: p.backend.clone(),
+                                value_type: p.value_type.clone(),
+                                minted_for: Some(model_id),
+                                target_model: target,
+                            })
+                            .await?
+                            .id();
+                        changed = true;
+                        let membership_id =
+                            self.ensure_membership(&context, &trx, &mut membership_ids, &mut changed, model_id, id, p.optional).await?;
                         (id, membership_id)
                     }
                 };
-                membership_seen.insert((model_id, property_id));
 
                 let (backend, value_type) = canonical.unwrap_or_else(|| (p.backend.clone(), p.value_type.clone()));
                 let minted_for = match (&current, &renamed) {
@@ -598,124 +388,67 @@ where
                 });
             }
         }
-        let _ = membership_seen;
 
-        // A re-registration of unchanged definitions is a pure no-op:
-        // nothing to gate, nothing to commit, nothing to relay -- but the
-        // requester still gets the full resolved tree.
-        if plan.is_noop() {
-            return Ok(out_models);
+        if changed {
+            trx.commit().await?;
+        } else {
+            trx.rollback();
         }
-
-        // The exists-aware policy gate judges the resolved plan before
-        // anything is emitted; refusal fails the request before any write.
-        // Underneath, check_event still gates each event individually inside
-        // the commit pipeline, and the batch is NOT transactional: a
-        // mid-batch event denial leaves the earlier catalog events durable
-        // (maintainer ruling 2026-07-06: registration does not need to be
-        // atomic; #313 tracks the transactional upgrade). Identity survives
-        // such partials because every allocator lookup double-checks storage
-        // on a map miss, so a retry converges on the stored ids instead of
-        // re-minting.
-        node.policy_agent.check_schema_registration(&node, cdata, &plan)?;
-
-        // The ordinary remote-commit pipeline: policy check (check_event),
-        // attest, persist, apply, reactor notify.
-        node.commit_remote_transaction(cdata, TransactionId::new(), events).await?;
-
-        // Synchronous map upsert BEFORE the allocator mutex releases: the
-        // next registration in line must observe these allocations even if
-        // the reactor has not delivered them yet.
-        self.upsert_registered(&out_models);
 
         Ok(out_models)
     }
 
-    /// Ensure the (model, property) membership exists with `optional`: reuse
-    /// and difference-patch a stored one, or mint. Returns the membership id.
     async fn ensure_membership(
         &self,
-        plan: &mut RegistrationPlan,
-        push: &mut impl FnMut(proto::Event),
+        context: &Context,
+        trx: &crate::transaction::Transaction,
+        request_memberships: &mut BTreeMap<(EntityId, EntityId), EntityId>,
+        changed: &mut bool,
         model: EntityId,
         property: EntityId,
         optional: bool,
     ) -> Result<EntityId, RegistrationError> {
-        match self.membership_lookup_checked(&model, &property).await? {
-            Some(def) => self.ensure_membership_from(plan, push, def, optional).await,
-            None => {
-                let id = EntityId::new();
-                plan.creates_memberships.push(PlannedModelPropertyMembership { id, model, property, optional });
-                push(creation(
-                    model_property_collection(),
-                    id,
-                    vec![("model", Value::EntityId(model)), ("property", Value::EntityId(property)), ("optional", Value::Bool(optional))],
-                ));
-                Ok(id)
-            }
+        if let Some(id) = request_memberships.get(&(model, property)) {
+            return Ok(*id);
         }
+        let id = match self.membership_lookup_checked(context, &model, &property).await? {
+            Some(def) => self.ensure_membership_from(trx, changed, def, optional).await?,
+            None => {
+                *changed = true;
+                trx.create(&SysModelPropertyRow { model, property, optional }).await?.id()
+            }
+        };
+        request_memberships.insert((model, property), id);
+        Ok(id)
     }
 
-    /// Difference-patch an already-resolved membership's `optional` flag.
     async fn ensure_membership_from(
         &self,
-        plan: &mut RegistrationPlan,
-        push: &mut impl FnMut(proto::Event),
+        trx: &crate::transaction::Transaction,
+        changed: &mut bool,
         def: super::catalog::ModelPropertyMembershipDef,
         optional: bool,
     ) -> Result<EntityId, RegistrationError> {
         if def.optional != Some(optional) {
-            let (_, head) = self
-                .catalog_entity_snapshot(def.id, &model_property_collection())
-                .await?
-                .ok_or_else(|| RetrievalError::Other(format!("catalog map holds membership {} absent from storage", def.id)))?;
-            plan.updates.push(PlannedUpdate {
-                collection: model_property_collection(),
-                entity: def.id,
-                field: "optional".into(),
-                from: def.optional.map(Value::Bool),
-                to: Some(Value::Bool(optional)),
-            });
-            push(follow_up(model_property_collection(), def.id, head, vec![("optional", Value::Bool(optional))]));
-        } else {
-            plan.existing.push(def.id);
+            trx.get::<SysModelPropertyRow>(&def.id).await?.optional().set(&optional).map_err(MutationError::from)?;
+            *changed = true;
         }
         Ok(def.id)
     }
 
-    /// Allocator lookup for a model: the catalog map first, then durable
-    /// storage on a miss. The in-memory map can lag
-    /// durable truth -- a partial-commit abort skips the post-commit fold,
-    /// and non-sled engines warm lazily (#310) -- and minting from a cold
-    /// map would fork identity for a key that already exists. A storage hit
-    /// is folded into the map so the rest of the request (and the next one)
-    /// sees it; ordinary first sightings miss both and pay one bounded
-    /// fetch under the allocator mutex.
-    async fn model_lookup_checked(&self, label: &str) -> Result<Option<super::catalog::ModelDef>, RetrievalError> {
+    async fn model_lookup_checked(&self, context: &Context, label: &str) -> Result<Option<super::catalog::ModelDef>, RetrievalError> {
         if let Some(def) = self.model_by_label(label) {
             return Ok(Some(def));
         }
-        let Some((id, values)) = self.catalog_row_by_key(model_collection(), field_eq_str("label", label)).await? else {
-            return Ok(None);
-        };
-        let def = super::catalog::ModelDef {
-            id,
-            label: label.to_string(),
-            name: string_field(&values, "name").unwrap_or_else(|| label.to_string()),
-        };
-        self.upsert_registered(&[RegisteredModel { id: def.id, label: def.label.clone(), name: def.name.clone(), properties: Vec::new() }]);
-        Ok(Some(def))
+        let mut rows =
+            context.fetch::<SysModelRowView>(Selection { predicate: field_eq_str("label", label), order_by: None, limit: None }).await?;
+        rows.sort_by_key(|row| row.id());
+        rows.first().map(model_def).transpose()
     }
 
-    /// Allocator lookup for a property by name WITHIN a model's membership
-    /// set: map first, storage on a miss (see
-    /// [`Self::model_lookup_checked`]). Membership is the scope -- a shared
-    /// property resolves regardless of where it was minted -- so the storage
-    /// path walks the model's membership rows and matches each bound
-    /// property's current name. Returns the property with the membership
-    /// that binds it.
     async fn member_property_lookup_checked(
         &self,
+        context: &Context,
         model: &EntityId,
         name: &str,
     ) -> Result<Option<(super::catalog::PropertyDef, super::catalog::ModelPropertyMembershipDef)>, RetrievalError> {
@@ -724,45 +457,27 @@ where
                 return Ok(Some((def, membership)));
             }
         }
-        let node = self.node().ok_or_else(|| RetrievalError::Other("node dropped during catalog lookup".to_owned()))?;
-        let selection = ankql::ast::Selection { predicate: field_eq_id("model", *model), order_by: None, limit: None };
-        let mut rows: Vec<proto::Attested<proto::EntityState>> =
-            node.collections.get(&catalog_collection_id(model_property_collection())).await?.fetch_states(&selection).await?;
-        // Lowest membership id first, so repeated calls are deterministic
-        // even over historical duplicates.
-        rows.sort_by_key(|state| state.payload.entity_id);
+        let mut rows = context
+            .fetch::<SysModelPropertyRowView>(Selection { predicate: field_eq_id("model", *model), order_by: None, limit: None })
+            .await?;
+        rows.sort_by_key(|row| row.id());
         for row in rows {
-            let membership_id = row.payload.entity_id;
-            let Some(buffer) = row.payload.state.state_buffers.0.get("lww") else { continue };
-            let values = LWWBackend::from_state_buffer(buffer)?.property_values();
-            let Some(property_id) = entity_id_field(&values, "property") else { continue };
-            let Some(prop_values) = self.catalog_entity_values(property_id, &property_collection()).await? else { continue };
-            if string_field(&prop_values, "name").as_deref() != Some(name) {
+            let Ok(membership) = membership_def(&row) else { continue };
+            let property = match catalog_row_by_id::<SysPropertyRowView>(context, membership.property).await? {
+                Some(row) => property_def(&row)?,
+                None => continue,
+            };
+            if property.name != name {
                 continue;
             }
-            let def = super::catalog::PropertyDef {
-                id: property_id,
-                minted_for: entity_id_field(&prop_values, "minted_for"),
-                name: name.to_string(),
-                backend: string_field(&prop_values, "backend").unwrap_or_default(),
-                value_type: string_field(&prop_values, "value_type").unwrap_or_default(),
-                target_model: entity_id_field(&prop_values, "target_model"),
-            };
-            let membership = super::catalog::ModelPropertyMembershipDef {
-                id: membership_id,
-                model: *model,
-                property: property_id,
-                optional: bool_field(&values, "optional"),
-            };
-            return Ok(Some((def, membership)));
+            return Ok(Some((property, membership)));
         }
         Ok(None)
     }
 
-    /// Allocator lookup for a membership by (model, property): map first,
-    /// storage on a miss (see [`Self::model_lookup_checked`]).
     async fn membership_lookup_checked(
         &self,
+        context: &Context,
         model: &EntityId,
         property: &EntityId,
     ) -> Result<Option<super::catalog::ModelPropertyMembershipDef>, RetrievalError> {
@@ -770,138 +485,89 @@ where
             return Ok(Some(def));
         }
         let predicate = and(field_eq_id("model", *model), field_eq_id("property", *property));
-        let Some((id, values)) = self.catalog_row_by_key(model_property_collection(), predicate).await? else {
-            return Ok(None);
-        };
-        let optional = bool_field(&values, "optional");
-        // No map fold here: memberships fold with their full registered tree
-        // (a flag-less row is TREATED as optional, never defaulted; the
-        // executor's diff arm emits the repairing follow-up either way).
-        Ok(Some(super::catalog::ModelPropertyMembershipDef { id, model: *model, property: *property, optional }))
+        let mut rows = context.fetch::<SysModelPropertyRowView>(Selection { predicate, order_by: None, limit: None }).await?;
+        rows.sort_by_key(|row| row.id());
+        rows.first().map(membership_def).transpose()
     }
 
-    /// Fetch the catalog row matching `predicate` straight from durable
-    /// storage (no map, no policy: allocator-internal, under the mutex).
-    /// Returns the lowest entity id on multiple matches so repeated calls
-    /// are deterministic even over historical duplicates.
-    async fn catalog_row_by_key(
-        &self,
-        collection: ModelId,
-        predicate: ankql::ast::Predicate,
-    ) -> Result<Option<(EntityId, BTreeMap<String, Option<Value>>)>, RetrievalError> {
-        let selection = ankql::ast::Selection { predicate, order_by: None, limit: None };
-        let mut best: Option<(EntityId, BTreeMap<String, Option<Value>>)> = None;
-        let node = self.node().ok_or_else(|| RetrievalError::Other("node dropped during catalog lookup".to_owned()))?;
-        for state in node.collections.get(&catalog_collection_id(collection)).await?.fetch_states(&selection).await? {
-            let id = state.payload.entity_id;
-            if best.as_ref().is_some_and(|(b, _)| *b <= id) {
-                continue;
-            }
-            let Some(buffer) = state.payload.state.state_buffers.0.get("lww") else {
-                continue;
-            };
-            best = Some((id, LWWBackend::from_state_buffer(buffer)?.property_values()));
-        }
-        Ok(best)
-    }
-
-    /// An explicit binding references a definition authored
-    /// elsewhere. Absence is a hard failure (cold start), and a
-    /// (backend, value_type) mismatch means the definition was retyped:
-    /// breaking for binders BY DESIGN. Returns the bound entity's current
-    /// values for response building.
     async fn verify_explicit_binding(
         &self,
+        context: &Context,
         id: EntityId,
         model_label: &str,
         p: &RegisterProperty,
-    ) -> Result<BTreeMap<String, Option<Value>>, RegistrationError> {
-        let Some(values) = self.catalog_entity_values(id, &property_collection()).await? else {
+    ) -> Result<super::catalog::PropertyDef, RegistrationError> {
+        let Some(row) = catalog_row_by_id::<SysPropertyRowView>(context, id).await? else {
             return Err(RegistrationError::ExplicitIdNotFound { property: id });
         };
-        let get_string = |field: &str| match values.get(field) {
-            Some(Some(Value::String(s))) => s.clone(),
-            _ => String::new(),
-        };
-        let (found_backend, found_value_type) = (get_string("backend"), get_string("value_type"));
-        // Same compatibility bar as the name-keyed upsert: the backend must match, and a drifted
-        // value_type is admitted only when mutually castable with the
-        // canonical one. The binding never mutates the bound definition.
-        if found_backend != p.backend || !value_types_compatible(&found_value_type, &p.value_type) {
+        let def = property_def(&row)?;
+        if def.backend != p.backend || !value_types_compatible(&def.value_type, &p.value_type) {
             return Err(RegistrationError::NonCastable {
                 collection: model_label.to_string(),
                 name: p.name.clone(),
-                found_backend,
-                found_value_type,
+                found_backend: def.backend.clone(),
+                found_value_type: def.value_type.clone(),
                 backend: p.backend.clone(),
                 value_type: p.value_type.clone(),
             });
         }
-        Ok(values)
+        Ok(def)
     }
 
-    /// An explicit model binding references a model entity
-    /// authored elsewhere. Absence is a hard failure (never mints), and a
-    /// collection mismatch means the binder points at the wrong contract.
-    /// Returns the bound entity's current values for response building.
     async fn verify_explicit_model_binding(
         &self,
+        context: &Context,
         id: EntityId,
         m: &RegisterModel,
-    ) -> Result<BTreeMap<String, Option<Value>>, RegistrationError> {
-        let Some((values, _)) = self.catalog_entity_snapshot(id, &model_collection()).await? else {
+    ) -> Result<super::catalog::ModelDef, RegistrationError> {
+        let Some(row) = catalog_row_by_id::<SysModelRowView>(context, id).await? else {
             return Err(RegistrationError::ExplicitModelIdNotFound { model: id });
         };
-        let found_label = string_field(&values, "label").unwrap_or_default();
-        if found_label != m.label {
-            return Err(RegistrationError::ExplicitModelIdMismatch { model: id, found_label, label: m.label.clone() });
+        let def = model_def(&row)?;
+        if def.label != m.label {
+            return Err(RegistrationError::ExplicitModelIdMismatch { model: id, found_label: def.label, label: m.label.clone() });
         }
-        Ok(values)
-    }
-
-    /// Read a catalog entity's LWW values and head straight from storage
-    /// (catalog entities are system models: raw backend access, never a
-    /// View). `None` when the entity does not exist yet.
-    async fn catalog_entity_snapshot(
-        &self,
-        id: EntityId,
-        expected_model: &ModelId,
-    ) -> Result<Option<(BTreeMap<String, Option<Value>>, proto::Clock)>, RetrievalError> {
-        let node = self.node().ok_or_else(|| RetrievalError::Other("node dropped during catalog lookup".to_owned()))?;
-        let state = match node.collections.get(&catalog_collection_id(*expected_model)).await?.get_state(id).await {
-            Ok(state) => state,
-            Err(RetrievalError::EntityNotFound(_)) => return Ok(None),
-            Err(e) => return Err(e),
-        };
-        // Per-collection storage already scopes the read; keep the routing
-        // check anyway so a mis-filed id reads as absent rather than as a
-        // definition of the wrong kind.
-        if state.payload.collection != catalog_collection_id(*expected_model) {
-            return Ok(None);
-        }
-        let head = state.payload.state.head.clone();
-        let Some(buffer) = state.payload.state.state_buffers.0.get("lww") else {
-            return Ok(None);
-        };
-        let backend = LWWBackend::from_state_buffer(buffer)?;
-        Ok(Some((backend.property_values(), head)))
-    }
-
-    /// Values-only convenience over [`Self::catalog_entity_snapshot`].
-    async fn catalog_entity_values(
-        &self,
-        id: EntityId,
-        expected_model: &ModelId,
-    ) -> Result<Option<BTreeMap<String, Option<Value>>>, RetrievalError> {
-        Ok(self.catalog_entity_snapshot(id, expected_model).await?.map(|(values, _)| values))
+        Ok(def)
     }
 }
 
-fn string_field(values: &BTreeMap<String, Option<Value>>, field: &str) -> Option<String> {
-    match values.get(field) {
-        Some(Some(Value::String(s))) => Some(s.clone()),
-        _ => None,
-    }
+fn row_error(kind: &str, id: EntityId, error: crate::property::PropertyError) -> RetrievalError {
+    RetrievalError::Other(format!("malformed {kind} catalog row {id}: {error}"))
+}
+
+fn model_def(row: &SysModelRowView) -> Result<super::catalog::ModelDef, RetrievalError> {
+    let label = row.label().map_err(|error| row_error("model", row.id(), error))?;
+    let name = row.name().unwrap_or_else(|_| label.clone());
+    Ok(super::catalog::ModelDef { id: row.id(), label, name })
+}
+
+fn property_def(row: &SysPropertyRowView) -> Result<super::catalog::PropertyDef, RetrievalError> {
+    Ok(super::catalog::PropertyDef {
+        id: row.id(),
+        minted_for: row.minted_for().map_err(|error| row_error("property", row.id(), error))?,
+        name: row.name().map_err(|error| row_error("property", row.id(), error))?,
+        backend: row.backend().map_err(|error| row_error("property", row.id(), error))?,
+        value_type: row.value_type().map_err(|error| row_error("property", row.id(), error))?,
+        target_model: row.target_model().map_err(|error| row_error("property", row.id(), error))?,
+    })
+}
+
+fn membership_def(row: &SysModelPropertyRowView) -> Result<super::catalog::ModelPropertyMembershipDef, RetrievalError> {
+    Ok(super::catalog::ModelPropertyMembershipDef {
+        id: row.id(),
+        model: row.model().map_err(|error| row_error("membership", row.id(), error))?,
+        property: row.property().map_err(|error| row_error("membership", row.id(), error))?,
+        optional: row.optional().ok(),
+    })
+}
+
+/// Fetch one typed catalog row by id through the collection scan rather than
+/// accepting a state solely because a storage backend has that globally
+/// unique id in another collection. Explicit bindings must prove both the id
+/// and the catalog collection they claim.
+async fn catalog_row_by_id<R: View>(context: &Context, id: EntityId) -> Result<Option<R>, RetrievalError> {
+    let rows = context.fetch::<R>(Selection { predicate: field_eq_id("id", id), order_by: None, limit: Some(1) }).await?;
+    Ok(rows.into_iter().find(|row| row.id() == id))
 }
 
 /// Whether a declared value_type is admissible against a canonical one:
@@ -942,23 +608,11 @@ fn check_property_compat(def: &super::catalog::PropertyDef, model_label: &str, p
     Ok(())
 }
 
-fn bool_field(values: &BTreeMap<String, Option<Value>>, field: &str) -> Option<bool> {
-    match values.get(field) {
-        Some(Some(Value::Bool(b))) => Some(*b),
-        _ => None,
-    }
-}
-
-// -- allocator storage-lookup predicate builders ------------------------------
+// -- allocator lookup predicate builders -------------------------------------
 //
-// These build the RESOLVED form directly. The allocator reads catalog rows
-// straight from storage (`catalog_row_by_key`), bypassing catalog-backed name
-// resolution because these lookups bootstrap the catalog that resolution
-// would read. A storage engine can only address a property by
-// identity and rejects anything else (`ankql::ast::Selection::check`), so these
-// predicates must arrive resolved on their own. Catalog collections are frozen
-// and mint no property-definition ids, so their fields are `System` properties,
-// named through the same `system_property` decision the systemize pass uses.
+// Catalog collections use built-in System properties, so these predicates
+// are already identity-resolved before they enter the normal typed Context
+// fetch path.
 
 fn field_eq(field: &str, value: ankql::ast::Literal) -> ankql::ast::Predicate {
     ankql::ast::Predicate::Comparison {
@@ -973,63 +627,3 @@ fn field_eq_str(field: &str, value: &str) -> ankql::ast::Predicate { field_eq(fi
 fn field_eq_id(field: &str, id: EntityId) -> ankql::ast::Predicate { field_eq(field, ankql::ast::Literal::EntityId(id.to_ulid())) }
 
 fn and(a: ankql::ast::Predicate, b: ankql::ast::Predicate) -> ankql::ast::Predicate { ankql::ast::Predicate::And(Box::new(a), Box::new(b)) }
-
-fn entity_id_field(values: &BTreeMap<String, Option<Value>>, field: &str) -> Option<EntityId> {
-    match values.get(field) {
-        Some(Some(Value::EntityId(id))) => Some(*id),
-        _ => None,
-    }
-}
-
-/// The storage collection for a catalog model: the event's routing
-/// materialization in this write-only phase, always derived from the same
-/// model the membership operation asserts.
-fn catalog_collection_id(model: ModelId) -> proto::CollectionId {
-    match model {
-        ModelId::System(system) => proto::CollectionId::fixed_name(crate::schema::system_collection_label(system)),
-        ModelId::EntityId(_) => unreachable!("catalog collections are system models"),
-    }
-}
-
-/// A creation event: full definition state, empty parent clock. Ordinary
-/// in every respect.
-/// The membership operation is the authority for the entity's model; the
-/// event's collection field is the routing materialization of the same
-/// fact.
-fn creation(model: ModelId, entity_id: EntityId, fields: Vec<(&str, Value)>) -> proto::Event {
-    let mut event = follow_up(model, entity_id, proto::Clock::default(), fields);
-    event.operations.push(Operation::Membership(Membership::Add(model)));
-    event
-}
-
-/// A follow-up event carrying changed metadata, parented at the entity's
-/// current head. It must descend the metadata it supersedes so LWW recency
-/// decides, not the concurrent tiebreak.
-fn follow_up(model: ModelId, entity_id: EntityId, parent: proto::Clock, fields: Vec<(&str, Value)>) -> proto::Event {
-    follow_up_patch(model, entity_id, parent, fields.into_iter().map(|(name, value)| (name, Some(value))).collect())
-}
-
-/// A metadata follow-up that may clear fields as well as replace them.
-fn follow_up_patch(model: ModelId, entity_id: EntityId, parent: proto::Clock, fields: Vec<(&str, Option<Value>)>) -> proto::Event {
-    let backend = LWWBackend::new();
-    for (name, value) in fields {
-        let property = SystemProperty::from_name(name).expect("every catalog event field names a SystemProperty variant");
-        backend.set(property.to_string(), value);
-    }
-    let operations = backend.to_operations().expect("LWW encoding of scalar values is infallible").expect("fields are non-empty");
-    proto::Event {
-        collection: catalog_collection_id(model),
-        entity_id,
-        operations: OperationSet::from_backends(BTreeMap::from([("lww".to_string(), operations)])),
-        parent,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn selection(predicate: ankql::ast::Predicate) -> ankql::ast::Selection {
-        ankql::ast::Selection { predicate, order_by: None, limit: None }
-    }
-}

--- a/core/src/schema/registration.rs
+++ b/core/src/schema/registration.rs
@@ -1001,7 +1001,7 @@ fn follow_up(model: ModelId, entity_id: EntityId, parent: proto::Clock, fields: 
 fn follow_up_patch(model: ModelId, entity_id: EntityId, parent: proto::Clock, fields: Vec<(&str, Option<Value>)>) -> proto::Event {
     let backend = LWWBackend::new();
     for (name, value) in fields {
-        let property = SystemProperty::from_name(name).expect("catalog event fields are closed SystemProperty variants");
+        let property = SystemProperty::from_name(name).expect("every catalog event field names a SystemProperty variant");
         backend.set(property.to_string(), value);
     }
     let operations = backend.to_operations().expect("LWW encoding of scalar values is infallible").expect("fields are non-empty");

--- a/core/src/schema/registration.rs
+++ b/core/src/schema/registration.rs
@@ -385,8 +385,13 @@ where
                         }
                         None => {
                             let id = EntityId::new();
-                            let stub =
-                                RegisterModel { label: l.to_string(), name: l.to_string(), explicit_id: None, properties: Vec::new() };
+                            let stub = RegisterModel {
+                                label: l.to_string(),
+                                name: l.to_string(),
+                                explicit_id: None,
+                                unique_id: None,
+                                properties: Vec::new(),
+                            };
                             plan.creates_models.push((id, stub));
                             push(creation(
                                 model_collection(),

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -30,8 +30,8 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     }
 
     let hygiene_module = quote::format_ident!("__ankurah_derive_impl_{}", to_snake_case(&desc.name().to_string()));
-    let internal = desc.is_internal();
-    let wasm_imports = if cfg!(feature = "wasm") && !internal {
+    let no_ffi = desc.no_ffi();
+    let wasm_imports = if cfg!(feature = "wasm") && !no_ffi {
         quote! {
             use ::ankurah::derive_deps::wasm_bindgen::prelude::*;
             use ::ankurah::derive_deps::wasm_bindgen_futures;
@@ -45,7 +45,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     let view_impl = model::view::view_impl(&desc);
     let mutable_impl = model::mutable::mutable_impl(&desc);
     #[cfg(feature = "wasm")]
-    let wasm_impl = if internal {
+    let wasm_impl = if no_ffi {
         quote! {}
     } else {
         model::wasm::wasm_impl(&input, &desc)
@@ -53,7 +53,7 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     #[cfg(not(feature = "wasm"))]
     let wasm_impl = quote! {};
     #[cfg(all(feature = "uniffi", not(feature = "wasm")))]
-    let uniffi_impl = if internal {
+    let uniffi_impl = if no_ffi {
         quote! {}
     } else {
         model::uniffi::uniffi_impl(&desc)

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -30,7 +30,8 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     }
 
     let hygiene_module = quote::format_ident!("__ankurah_derive_impl_{}", to_snake_case(&desc.name().to_string()));
-    let wasm_imports = if cfg!(feature = "wasm") {
+    let internal = desc.is_internal();
+    let wasm_imports = if cfg!(feature = "wasm") && !internal {
         quote! {
             use ::ankurah::derive_deps::wasm_bindgen::prelude::*;
             use ::ankurah::derive_deps::wasm_bindgen_futures;
@@ -44,11 +45,19 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     let view_impl = model::view::view_impl(&desc);
     let mutable_impl = model::mutable::mutable_impl(&desc);
     #[cfg(feature = "wasm")]
-    let wasm_impl = model::wasm::wasm_impl(&input, &desc);
+    let wasm_impl = if internal {
+        quote! {}
+    } else {
+        model::wasm::wasm_impl(&input, &desc)
+    };
     #[cfg(not(feature = "wasm"))]
     let wasm_impl = quote! {};
     #[cfg(all(feature = "uniffi", not(feature = "wasm")))]
-    let uniffi_impl = model::uniffi::uniffi_impl(&desc);
+    let uniffi_impl = if internal {
+        quote! {}
+    } else {
+        model::uniffi::uniffi_impl(&desc)
+    };
     #[cfg(any(not(feature = "uniffi"), feature = "wasm"))]
     let uniffi_impl = quote! {};
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -61,7 +61,15 @@ pub fn derive_model(input: TokenStream) -> TokenStream {
     #[cfg(any(not(feature = "uniffi"), feature = "wasm"))]
     let uniffi_impl = quote! {};
 
+    // The declaring module's path, captured OUTSIDE the hygiene module so
+    // the unique-id hash input carries the user's own module path, not the
+    // hygiene module's.
+    let module_path_const = desc.module_path_const();
+
     let expanded = quote! {
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals)]
+        const #module_path_const: &'static str = ::core::module_path!();
         mod #hygiene_module {
             use super::*;
             #wasm_imports

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,3 +1,12 @@
+//! Procedural-macro entry points for Ankurah's typed application surface.
+//!
+//! This crate parses model/property declarations and query macro syntax, then
+//! coordinates generators for Model, View, Mutable, FFI, and selection code.
+//! The entry points own compile-time validation, expansion hygiene, and routing
+//! to those generators. They do not implement runtime behavior or wire
+//! semantics; generated code delegates those responsibilities to
+//! `ankurah-core` and `ankurah-proto`.
+
 mod model;
 mod property;
 mod selection;

--- a/derive/src/model/description.rs
+++ b/derive/src/model/description.rs
@@ -1,6 +1,18 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Data, DeriveInput, Fields, Ident, Type, Visibility};
+use syn::{meta::ParseNestedMeta, Data, DeriveInput, Fields, Ident, LitStr, Type, Visibility};
+
+/// The complete struct-level `#[model(...)]` vocabulary.
+///
+/// Parsing it once keeps unknown, duplicate, and malformed options from being
+/// silently ignored by independent lookups later in expansion.
+#[derive(Default)]
+struct ModelOptions {
+    base: Option<String>,
+    system: Option<String>,
+    explicit_id: Option<String>,
+    no_ffi: bool,
+}
 
 /// Encapsulates all the parsed information about a model and provides clean accessors
 pub struct ModelDescription {
@@ -14,25 +26,29 @@ pub struct ModelDescription {
     // Backend manager for configuration lookup
     pub(crate) backend_registry: crate::model::backend_registry::BackendRegistry,
 
-    // Struct-level attributes, retained for #[model(...)] parsing
-    struct_attrs: Vec<syn::Attribute>,
-
     /// `#[model(base = "...")]`: the path generated code addresses the core
     /// crate through. Default `::ankurah::core` (the facade's re-export);
     /// core-internal models pass `crate` so core can derive its own models.
     base: syn::Path,
-    /// True when `base` was overridden: an internal model, which skips the
-    /// wasm/uniffi binding layers (no JS or FFI surface).
-    internal: bool,
+    /// Whether active-type paths should use the backend registry's local
+    /// (`crate`) substitutions. This preserves the path behavior of an
+    /// explicit `base` without conflating it with FFI generation.
+    uses_local_paths: bool,
+    /// `#[model(no_ffi)]`: omit WASM and UniFFI bindings while retaining the
+    /// normal Rust model, view, and mutable APIs.
+    no_ffi: bool,
     /// `#[model(system = "...")]`: a built-in system model identity. Pins
     /// the collection to the system label and short-circuits registration.
     system: Option<Ident>,
+    /// `#[model(id = "...")]`: an explicit durable catalog model identity.
+    explicit_id: Option<String>,
 }
 
 impl ModelDescription {
     /// Parse a DeriveInput and create a ModelDescription
     pub fn parse(input: &DeriveInput) -> syn::Result<Self> {
         let name = input.ident.clone();
+        let options = parse_model_options(&input.attrs)?;
 
         let fields = match &input.data {
             Data::Struct(data) => match &data.fields {
@@ -46,7 +62,7 @@ impl ModelDescription {
         let mut active_fields = Vec::new();
         let mut ephemeral_fields = Vec::new();
         for field in fields.into_iter() {
-            if get_model_flag(&field.attrs, "ephemeral") {
+            if field_is_ephemeral(&field.attrs)? {
                 ephemeral_fields.push(field);
             } else {
                 active_fields.push(field);
@@ -56,14 +72,13 @@ impl ModelDescription {
         // Load backend configurations at compile time
         let backend_registry = crate::model::backend_registry::BackendRegistry::new()?;
 
-        let base_attr = model_str_attr_on(&input.attrs, "base")?;
-        let internal = base_attr.is_some();
-        let base: syn::Path = match &base_attr {
+        let uses_local_paths = options.base.is_some();
+        let base: syn::Path = match &options.base {
             Some(path) => syn::parse_str(path)
                 .map_err(|_| syn::Error::new_spanned(&name, format!("#[model(base = {path:?})] is not a valid path")))?,
             None => syn::parse_str("::ankurah::core").expect("default base path parses"),
         };
-        let system = match model_str_attr_on(&input.attrs, "system")? {
+        let system = match options.system {
             Some(variant) => match variant.as_str() {
                 "System" | "Model" | "Property" | "ModelProperty" => Some(format_ident!("{}", variant)),
                 other => {
@@ -78,13 +93,21 @@ impl ModelDescription {
             None => None,
         };
 
-        Ok(Self { name, active_fields, ephemeral_fields, backend_registry, struct_attrs: input.attrs.clone(), base, internal, system })
+        Ok(Self {
+            name,
+            active_fields,
+            ephemeral_fields,
+            backend_registry,
+            base,
+            uses_local_paths,
+            no_ffi: options.no_ffi,
+            system,
+            explicit_id: options.explicit_id,
+        })
     }
 
     // Basic identifier accessors
     pub fn name(&self) -> &Ident { &self.name }
-    /// Struct-level attributes, for `#[model(id = "...")]` parsing.
-    pub fn struct_attrs(&self) -> &[syn::Attribute] { &self.struct_attrs }
     pub fn collection_str(&self) -> String {
         match &self.system {
             // System models live at their fixed reserved label, not a name
@@ -103,10 +126,14 @@ impl ModelDescription {
     /// through `super::`. The struct name rides verbatim (not case-folded)
     /// so distinct structs always get distinct consts.
     pub fn module_path_const(&self) -> Ident { format_ident!("__ANKURAH_MODULE_PATH_{}", self.name) }
-    /// True for a core-internal model: skip the wasm/uniffi binding layers.
-    pub fn is_internal(&self) -> bool { self.internal }
+    /// Whether generated active-type paths use local backend substitutions.
+    pub fn uses_local_paths(&self) -> bool { self.uses_local_paths }
+    /// Whether this model deliberately omits WASM and UniFFI bindings.
+    pub fn no_ffi(&self) -> bool { self.no_ffi }
     /// The built-in system identity, when this is a system model.
     pub fn system(&self) -> Option<&Ident> { self.system.as_ref() }
+    /// The explicit durable catalog model identity, when supplied.
+    pub fn explicit_id(&self) -> Option<&str> { self.explicit_id.as_deref() }
     pub fn view_name(&self) -> Ident { format_ident!("{}View", self.name) }
     pub fn mutable_name(&self) -> Ident { format_ident!("{}Mut", self.name) }
 
@@ -166,7 +193,7 @@ impl ModelDescription {
         let mut results = Vec::new();
 
         for (i, desc) in descs.iter().enumerate() {
-            let context = if self.internal { "local" } else { "external" };
+            let context = if self.uses_local_paths { "local" } else { "external" };
             let rust_type = desc.rust_type_with_context(context).map_err(|e| {
                 let field = &self.active_fields[i];
                 syn::Error::new_spanned(&field.ty, format!("Failed to generate Rust type: {}", e))
@@ -443,47 +470,83 @@ impl ModelDescription {
     }
 }
 
-fn get_model_flag(attrs: &Vec<syn::Attribute>, flag_name: &str) -> bool {
-    attrs.iter().any(|attr| {
-        attr.path().segments.iter().any(|seg| seg.ident == "model")
-            && attr.meta.require_list().ok().and_then(|list| list.parse_args::<syn::Ident>().ok()).is_some_and(|ident| ident == flag_name)
-    })
-}
-
-/// Parse `#[model(key = "value")]` off raw struct attributes. Bare flags
-/// and unrelated keys are skipped; the requested key present with a
-/// non-string value is a hard error (silently dropping it would demote a
-/// system model to an ordinary one).
-pub(crate) fn model_str_attr_on(attrs: &[syn::Attribute], key: &str) -> syn::Result<Option<String>> {
-    let mut found = None;
-    let mut bad_value: Option<syn::Error> = None;
+/// Parse every struct-level `#[model(...)]` option using one closed
+/// vocabulary. A typo must not silently change the generated model's schema,
+/// identity, path base, or FFI surface.
+fn parse_model_options(attrs: &[syn::Attribute]) -> syn::Result<ModelOptions> {
+    let mut options = ModelOptions::default();
     for attr in attrs {
         if !attr.path().is_ident("model") {
             continue;
         }
-        // Ignore walk failures from the flag form (not a name-value list);
-        // `bad_value` still surfaces a non-string value for the requested key.
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident(key) {
-                if let Ok(value) = meta.value() {
-                    match value.parse::<syn::LitStr>() {
-                        Ok(lit) => found = Some(lit.value()),
-                        Err(_) => {
-                            bad_value = Some(syn::Error::new_spanned(&meta.path, format!("#[model({key} = ...)] expects a string literal")))
-                        }
-                    }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("base") {
+                let value = model_string_value(&meta, "base")?;
+                set_model_option(&mut options.base, value, &meta, "base")
+            } else if meta.path.is_ident("system") {
+                let value = model_string_value(&meta, "system")?;
+                set_model_option(&mut options.system, value, &meta, "system")
+            } else if meta.path.is_ident("id") {
+                let value = model_string_value(&meta, "id")?;
+                set_model_option(&mut options.explicit_id, value, &meta, "id")
+            } else if meta.path.is_ident("no_ffi") {
+                if options.no_ffi {
+                    return Err(meta.error("duplicate #[model(no_ffi)] option"));
                 }
-            } else if meta.input.peek(syn::Token![=]) {
-                let value = meta.value()?;
-                let _: syn::Expr = value.parse()?;
+                if !meta.input.is_empty() {
+                    return Err(meta.error("#[model(no_ffi)] is a bare flag and does not take a value"));
+                }
+                options.no_ffi = true;
+                Ok(())
+            } else {
+                Err(meta.error("unknown #[model(...)] option; expected `base`, `system`, `id`, or `no_ffi`"))
             }
+        })?;
+    }
+    Ok(options)
+}
+
+fn model_string_value(meta: &ParseNestedMeta<'_>, key: &str) -> syn::Result<String> {
+    if !meta.input.peek(syn::Token![=]) {
+        return Err(meta.error(format!("#[model({key} = ...)] expects a string literal")));
+    }
+    let value = meta.value()?;
+    let literal = value
+        .parse::<LitStr>()
+        .map_err(|_| syn::Error::new_spanned(&meta.path, format!("#[model({key} = ...)] expects a string literal")))?;
+    Ok(literal.value())
+}
+
+fn set_model_option(slot: &mut Option<String>, value: String, meta: &ParseNestedMeta<'_>, key: &str) -> syn::Result<()> {
+    if slot.replace(value).is_some() {
+        return Err(meta.error(format!("duplicate #[model({key} = ...)] option")));
+    }
+    Ok(())
+}
+
+/// Field-level `#[model(...)]` has its own closed vocabulary. At present the
+/// only field option is the bare `ephemeral` flag.
+fn field_is_ephemeral(attrs: &[syn::Attribute]) -> syn::Result<bool> {
+    let mut ephemeral = false;
+    for attr in attrs {
+        if !attr.path().is_ident("model") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if !meta.path.is_ident("ephemeral") {
+                return Err(meta.error("unknown field #[model(...)] option; expected `ephemeral`"));
+            }
+            if ephemeral {
+                return Err(meta.error("duplicate #[model(ephemeral)] option"));
+            }
+            if !meta.input.is_empty() {
+                return Err(meta.error("#[model(ephemeral)] is a bare flag and does not take a value"));
+            }
+            ephemeral = true;
             Ok(())
-        });
+        })?;
     }
-    match bad_value {
-        Some(err) => Err(err),
-        None => Ok(found),
-    }
+    Ok(ephemeral)
 }
 
 /// PascalCase to snake_case for system collection labels

--- a/derive/src/model/description.rs
+++ b/derive/src/model/description.rs
@@ -66,12 +66,14 @@ impl ModelDescription {
         let system = match model_str_attr_on(&input.attrs, "system")? {
             Some(variant) => match variant.as_str() {
                 "System" | "Model" | "Property" | "ModelProperty" => Some(format_ident!("{}", variant)),
-                other => return Err(syn::Error::new_spanned(
-                    &name,
-                    format!(
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        &name,
+                        format!(
                         "#[model(system = {other:?})] is not a built-in system model; expected System, Model, Property, or ModelProperty"
                     ),
-                )),
+                    ))
+                }
             },
             None => None,
         };

--- a/derive/src/model/description.rs
+++ b/derive/src/model/description.rs
@@ -16,6 +16,17 @@ pub struct ModelDescription {
 
     // Struct-level attributes, retained for #[model(...)] parsing
     struct_attrs: Vec<syn::Attribute>,
+
+    /// `#[model(base = "...")]`: the path generated code addresses the core
+    /// crate through. Default `::ankurah::core` (the facade's re-export);
+    /// core-internal models pass `crate` so core can derive its own models.
+    base: syn::Path,
+    /// True when `base` was overridden: an internal model, which skips the
+    /// wasm/uniffi binding layers (no JS or FFI surface).
+    internal: bool,
+    /// `#[model(system = "...")]`: a built-in system model identity. Pins
+    /// the collection to the system label and short-circuits registration.
+    system: Option<Ident>,
 }
 
 impl ModelDescription {
@@ -45,14 +56,47 @@ impl ModelDescription {
         // Load backend configurations at compile time
         let backend_registry = crate::model::backend_registry::BackendRegistry::new()?;
 
-        Ok(Self { name, active_fields, ephemeral_fields, backend_registry, struct_attrs: input.attrs.clone() })
+        let base_attr = model_str_attr_on(&input.attrs, "base")?;
+        let internal = base_attr.is_some();
+        let base: syn::Path = match &base_attr {
+            Some(path) => syn::parse_str(path)
+                .map_err(|_| syn::Error::new_spanned(&name, format!("#[model(base = {path:?})] is not a valid path")))?,
+            None => syn::parse_str("::ankurah::core").expect("default base path parses"),
+        };
+        let system = match model_str_attr_on(&input.attrs, "system")? {
+            Some(variant) => match variant.as_str() {
+                "System" | "Model" | "Property" | "ModelProperty" => Some(format_ident!("{}", variant)),
+                other => return Err(syn::Error::new_spanned(
+                    &name,
+                    format!(
+                        "#[model(system = {other:?})] is not a built-in system model; expected System, Model, Property, or ModelProperty"
+                    ),
+                )),
+            },
+            None => None,
+        };
+
+        Ok(Self { name, active_fields, ephemeral_fields, backend_registry, struct_attrs: input.attrs.clone(), base, internal, system })
     }
 
     // Basic identifier accessors
     pub fn name(&self) -> &Ident { &self.name }
     /// Struct-level attributes, for `#[model(id = "...")]` parsing.
     pub fn struct_attrs(&self) -> &[syn::Attribute] { &self.struct_attrs }
-    pub fn collection_str(&self) -> String { self.name.to_string().to_lowercase() }
+    pub fn collection_str(&self) -> String {
+        match &self.system {
+            // System models live at their fixed reserved label, not a name
+            // derived from the struct.
+            Some(variant) => format!("_ankurah_{}", to_snake(&variant.to_string())),
+            None => self.name.to_string().to_lowercase(),
+        }
+    }
+    /// The path generated code reaches the core crate through.
+    pub fn base(&self) -> &syn::Path { &self.base }
+    /// True for a core-internal model: skip the wasm/uniffi binding layers.
+    pub fn is_internal(&self) -> bool { self.internal }
+    /// The built-in system identity, when this is a system model.
+    pub fn system(&self) -> Option<&Ident> { self.system.as_ref() }
     pub fn view_name(&self) -> Ident { format_ident!("{}View", self.name) }
     pub fn mutable_name(&self) -> Ident { format_ident!("{}Mut", self.name) }
 
@@ -112,7 +156,8 @@ impl ModelDescription {
         let mut results = Vec::new();
 
         for (i, desc) in descs.iter().enumerate() {
-            let rust_type = desc.rust_type().map_err(|e| {
+            let context = if self.internal { "local" } else { "external" };
+            let rust_type = desc.rust_type_with_context(context).map_err(|e| {
                 let field = &self.active_fields[i];
                 syn::Error::new_spanned(&field.ty, format!("Failed to generate Rust type: {}", e))
             })?;
@@ -393,6 +438,45 @@ fn get_model_flag(attrs: &Vec<syn::Attribute>, flag_name: &str) -> bool {
         attr.path().segments.iter().any(|seg| seg.ident == "model")
             && attr.meta.require_list().ok().and_then(|list| list.parse_args::<syn::Ident>().ok()).is_some_and(|ident| ident == flag_name)
     })
+}
+
+/// Parse `#[model(key = "value")]` off raw struct attributes (same grammar
+/// as schema.rs's model_str_attr, available before a ModelDescription
+/// exists). Bare flags and unrelated keys are skipped.
+fn model_str_attr_on(attrs: &[syn::Attribute], key: &str) -> syn::Result<Option<String>> {
+    let mut found = None;
+    for attr in attrs {
+        if !attr.path().is_ident("model") {
+            continue;
+        }
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident(key) {
+                if let Ok(value) = meta.value() {
+                    if let Ok(lit) = value.parse::<syn::LitStr>() {
+                        found = Some(lit.value());
+                    }
+                }
+            } else if meta.input.peek(syn::Token![=]) {
+                let value = meta.value()?;
+                let _: syn::Expr = value.parse()?;
+            }
+            Ok(())
+        });
+    }
+    Ok(found)
+}
+
+/// PascalCase to snake_case for system collection labels
+/// (ModelProperty -> model_property).
+fn to_snake(ident: &str) -> String {
+    let mut out = String::new();
+    for (i, c) in ident.chars().enumerate() {
+        if c.is_uppercase() && i > 0 {
+            out.push('_');
+        }
+        out.push(c.to_ascii_lowercase());
+    }
+    out
 }
 
 fn as_turbofish(type_path: &syn::Type) -> proc_macro2::TokenStream {

--- a/derive/src/model/description.rs
+++ b/derive/src/model/description.rs
@@ -1,3 +1,13 @@
+//! Parses one `#[derive(Model)]` input into its model description.
+//!
+//! Here, a **model description** is the derive's validated vocabulary for a
+//! struct: its fields, generated-code base path, built-in or explicit
+//! identity, and FFI surface. [`ModelDescription`] gives the emission modules
+//! one shared interpretation of those facts; [`ModelOptions`] is the closed
+//! set of struct-level `#[model(...)]` options. This module parses and
+//! classifies input but does not emit model, view, mutable, or descriptor
+//! implementations.
+
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{meta::ParseNestedMeta, Data, DeriveInput, Fields, Ident, LitStr, Type, Visibility};
@@ -30,10 +40,10 @@ pub struct ModelDescription {
     /// crate through. Default `::ankurah::core` (the facade's re-export);
     /// core-internal models pass `crate` so core can derive its own models.
     base: syn::Path,
-    /// Whether active-type paths should use the backend registry's local
-    /// (`crate`) substitutions. This preserves the path behavior of an
-    /// explicit `base` without conflating it with FFI generation.
-    uses_local_paths: bool,
+    /// Whether active-type paths should use the backend registry's `crate`
+    /// substitutions. Only the literal crate-relative base selects them;
+    /// an explicit external base remains external.
+    uses_crate_paths: bool,
     /// `#[model(no_ffi)]`: omit WASM and UniFFI bindings while retaining the
     /// normal Rust model, view, and mutable APIs.
     no_ffi: bool,
@@ -72,12 +82,12 @@ impl ModelDescription {
         // Load backend configurations at compile time
         let backend_registry = crate::model::backend_registry::BackendRegistry::new()?;
 
-        let uses_local_paths = options.base.is_some();
         let base: syn::Path = match &options.base {
             Some(path) => syn::parse_str(path)
                 .map_err(|_| syn::Error::new_spanned(&name, format!("#[model(base = {path:?})] is not a valid path")))?,
             None => syn::parse_str("::ankurah::core").expect("default base path parses"),
         };
+        let uses_crate_paths = base.is_ident("crate");
         let system = match options.system {
             Some(variant) => match variant.as_str() {
                 "System" | "Model" | "Property" | "ModelProperty" => Some(format_ident!("{}", variant)),
@@ -99,7 +109,7 @@ impl ModelDescription {
             ephemeral_fields,
             backend_registry,
             base,
-            uses_local_paths,
+            uses_crate_paths,
             no_ffi: options.no_ffi,
             system,
             explicit_id: options.explicit_id,
@@ -127,7 +137,7 @@ impl ModelDescription {
     /// so distinct structs always get distinct consts.
     pub fn module_path_const(&self) -> Ident { format_ident!("__ANKURAH_MODULE_PATH_{}", self.name) }
     /// Whether generated active-type paths use local backend substitutions.
-    pub fn uses_local_paths(&self) -> bool { self.uses_local_paths }
+    pub fn uses_crate_paths(&self) -> bool { self.uses_crate_paths }
     /// Whether this model deliberately omits WASM and UniFFI bindings.
     pub fn no_ffi(&self) -> bool { self.no_ffi }
     /// The built-in system identity, when this is a system model.
@@ -193,7 +203,7 @@ impl ModelDescription {
         let mut results = Vec::new();
 
         for (i, desc) in descs.iter().enumerate() {
-            let context = if self.uses_local_paths { "local" } else { "external" };
+            let context = if self.uses_crate_paths { "local" } else { "external" };
             let rust_type = desc.rust_type_with_context(context).map_err(|e| {
                 let field = &self.active_fields[i];
                 syn::Error::new_spanned(&field.ty, format!("Failed to generate Rust type: {}", e))

--- a/derive/src/model/description.rs
+++ b/derive/src/model/description.rs
@@ -95,6 +95,14 @@ impl ModelDescription {
     }
     /// The path generated code reaches the core crate through.
     pub fn base(&self) -> &syn::Path { &self.base }
+    /// The per-struct hidden const holding `module_path!()` as expanded in
+    /// the USER's module. It must live outside the hygiene module (a
+    /// `module_path!()` inside it would pick up the hygiene segment, baking
+    /// a derive-internal name into the durable unique-id hash input), so
+    /// lib.rs emits it at the expansion's top level and schema.rs reads it
+    /// through `super::`. The struct name rides verbatim (not case-folded)
+    /// so distinct structs always get distinct consts.
+    pub fn module_path_const(&self) -> Ident { format_ident!("__ANKURAH_MODULE_PATH_{}", self.name) }
     /// True for a core-internal model: skip the wasm/uniffi binding layers.
     pub fn is_internal(&self) -> bool { self.internal }
     /// The built-in system identity, when this is a system model.

--- a/derive/src/model/description.rs
+++ b/derive/src/model/description.rs
@@ -450,20 +450,27 @@ fn get_model_flag(attrs: &Vec<syn::Attribute>, flag_name: &str) -> bool {
     })
 }
 
-/// Parse `#[model(key = "value")]` off raw struct attributes (same grammar
-/// as schema.rs's model_str_attr, available before a ModelDescription
-/// exists). Bare flags and unrelated keys are skipped.
-fn model_str_attr_on(attrs: &[syn::Attribute], key: &str) -> syn::Result<Option<String>> {
+/// Parse `#[model(key = "value")]` off raw struct attributes. Bare flags
+/// and unrelated keys are skipped; the requested key present with a
+/// non-string value is a hard error (silently dropping it would demote a
+/// system model to an ordinary one).
+pub(crate) fn model_str_attr_on(attrs: &[syn::Attribute], key: &str) -> syn::Result<Option<String>> {
     let mut found = None;
+    let mut bad_value: Option<syn::Error> = None;
     for attr in attrs {
         if !attr.path().is_ident("model") {
             continue;
         }
+        // Ignore walk failures from the flag form (not a name-value list);
+        // `bad_value` still surfaces a non-string value for the requested key.
         let _ = attr.parse_nested_meta(|meta| {
             if meta.path.is_ident(key) {
                 if let Ok(value) = meta.value() {
-                    if let Ok(lit) = value.parse::<syn::LitStr>() {
-                        found = Some(lit.value());
+                    match value.parse::<syn::LitStr>() {
+                        Ok(lit) => found = Some(lit.value()),
+                        Err(_) => {
+                            bad_value = Some(syn::Error::new_spanned(&meta.path, format!("#[model({key} = ...)] expects a string literal")))
+                        }
                     }
                 }
             } else if meta.input.peek(syn::Token![=]) {
@@ -473,7 +480,10 @@ fn model_str_attr_on(attrs: &[syn::Attribute], key: &str) -> syn::Result<Option<
             Ok(())
         });
     }
-    Ok(found)
+    match bad_value {
+        Some(err) => Err(err),
+        None => Ok(found),
+    }
 }
 
 /// PascalCase to snake_case for system collection labels

--- a/derive/src/model/model.rs
+++ b/derive/src/model/model.rs
@@ -21,8 +21,8 @@ pub fn model_impl(model: &crate::model::description::ModelDescription) -> TokenS
         Err(e) => return e.into_compile_error(),
     };
 
-    // RefWrapper associated type for WASM builds. Internal models skip the
-    // wasm binding layer, so they get a plain newtype satisfying the
+    // RefWrapper associated type for WASM builds. Models marked `no_ffi`
+    // skip the wasm binding layer, so they get a plain newtype satisfying the
     // associated-type bound with no bindgen surface.
     let ref_name = format_ident!("{}Ref", name);
     let ref_wrapper_type = if cfg!(feature = "wasm") {
@@ -32,7 +32,7 @@ pub fn model_impl(model: &crate::model::description::ModelDescription) -> TokenS
     } else {
         quote! {}
     };
-    let internal_ref_wrapper = if cfg!(feature = "wasm") && model.is_internal() {
+    let internal_ref_wrapper = if cfg!(feature = "wasm") && model.no_ffi() {
         quote! {
             pub struct #ref_name(#base::property::Ref<#name>);
             impl From<#base::property::Ref<#name>> for #ref_name {

--- a/derive/src/model/model.rs
+++ b/derive/src/model/model.rs
@@ -3,6 +3,7 @@ use quote::{format_ident, quote};
 
 /// Generate the Model trait implementation
 pub fn model_impl(model: &crate::model::description::ModelDescription) -> TokenStream {
+    let base = model.base();
     let name = model.name();
     let view_name = model.view_name();
     let mutable_name = model.mutable_name();
@@ -20,28 +21,44 @@ pub fn model_impl(model: &crate::model::description::ModelDescription) -> TokenS
         Err(e) => return e.into_compile_error(),
     };
 
-    // RefWrapper associated type for WASM builds
+    // RefWrapper associated type for WASM builds. Internal models skip the
+    // wasm binding layer, so they get a plain newtype satisfying the
+    // associated-type bound with no bindgen surface.
+    let ref_name = format_ident!("{}Ref", name);
     let ref_wrapper_type = if cfg!(feature = "wasm") {
-        let ref_name = format_ident!("{}Ref", name);
         quote! {
             type RefWrapper = #ref_name;
         }
     } else {
         quote! {}
     };
+    let internal_ref_wrapper = if cfg!(feature = "wasm") && model.is_internal() {
+        quote! {
+            pub struct #ref_name(#base::property::Ref<#name>);
+            impl From<#base::property::Ref<#name>> for #ref_name {
+                fn from(r: #base::property::Ref<#name>) -> Self { Self(r) }
+            }
+            impl From<#ref_name> for #base::property::Ref<#name> {
+                fn from(w: #ref_name) -> Self { w.0 }
+            }
+        }
+    } else {
+        quote! {}
+    };
 
     quote! {
-        impl ::ankurah::model::Model for #name {
+        #internal_ref_wrapper
+        impl #base::model::Model for #name {
             type View = #view_name;
             type Mutable = #mutable_name;
             #ref_wrapper_type
             #schema_method
-            fn collection() -> ankurah::proto::CollectionId {
+            fn collection() -> #base::proto::CollectionId {
                 #collection_str.into()
             }
-            fn initialize_new_entity(&self, entity: &::ankurah::entity::Entity, model_id: ::ankurah::proto::ModelId) {
+            fn initialize_new_entity(&self, entity: &#base::entity::Entity, model_id: #base::proto::ModelId) {
                 entity.add_membership(model_id);
-                use ::ankurah::property::InitializeWith;
+                use #base::property::InitializeWith;
                 #(
                     #active_field_types_turbofish::initialize_with(&entity, #active_field_name_strs.into(), &self.#active_field_names);
                 )*

--- a/derive/src/model/model.rs
+++ b/derive/src/model/model.rs
@@ -1,3 +1,12 @@
+//! Generation of the derived Model trait implementation.
+//!
+//! [`model_impl`] connects one parsed model description to its generated View
+//! and Mutable types, compiled schema descriptor, collection identity, and
+//! new-entity field initialization. It also emits the minimal internal Ref
+//! wrapper required by a WASM build when FFI generation is disabled. Attribute
+//! parsing and validation belong to neighboring description/schema modules;
+//! View, Mutable, and language-binding surfaces have their own generators.
+
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 

--- a/derive/src/model/mutable.rs
+++ b/derive/src/model/mutable.rs
@@ -3,6 +3,7 @@ use quote::quote;
 
 /// Generate the Mutable struct and all its implementations
 pub fn mutable_impl(model: &crate::model::description::ModelDescription) -> TokenStream {
+    let base = model.base();
     let mutable_name = model.mutable_name();
     let name = model.name();
     let view_name = model.view_name();
@@ -54,19 +55,19 @@ pub fn mutable_impl(model: &crate::model::description::ModelDescription) -> Toke
         #[derive(Debug)]
         pub struct #mutable_name {
             #field_attributes
-            pub entity: ::ankurah::entity::Entity,
+            pub entity: #base::entity::Entity,
         }
 
-        impl ::ankurah::model::Mutable for #mutable_name {
+        impl #base::model::Mutable for #mutable_name {
             type Model = #name;
             type View = #view_name;
 
-            fn entity(&self) -> &::ankurah::entity::Entity {
+            fn entity(&self) -> &#base::entity::Entity {
                 &self.entity
             }
 
-            fn new(entity: ::ankurah::entity::Entity) -> Self {
-                use ankurah::property::FromEntity;
+            fn new(entity: #base::entity::Entity) -> Self {
+                use #base::property::FromEntity;
                 assert_eq!(entity.collection(), &Self::collection());
                 Self {
                     // #( #active_field_names: #active_field_types_turbofish::from_entity(#active_field_name_strs.into(), &entity), )*
@@ -76,20 +77,20 @@ pub fn mutable_impl(model: &crate::model::description::ModelDescription) -> Toke
             }
 
         impl #mutable_name {
-            pub fn id(&self) -> ::ankurah::proto::EntityId {
+            pub fn id(&self) -> #base::proto::EntityId {
                 self.entity.id()
             }
 
             #(
                 pub fn #active_field_names(&self) -> #active_field_types {
-                    use ankurah::property::FromEntity;
+                    use #base::property::FromEntity;
                     #active_field_types_turbofish::from_entity(#active_field_name_strs.into(), &self.entity)
                 }
             )*
         }
 
-        impl<'a> Into<ankurah::proto::EntityId> for &'a #mutable_name {
-            fn into(self) -> ankurah::proto::EntityId {
+        impl<'a> Into<#base::proto::EntityId> for &'a #mutable_name {
+            fn into(self) -> #base::proto::EntityId {
                 self.entity.id()
             }
         }

--- a/derive/src/model/mutable.rs
+++ b/derive/src/model/mutable.rs
@@ -20,18 +20,22 @@ pub fn mutable_impl(model: &crate::model::description::ModelDescription) -> Toke
         Err(_) => return quote! { compile_error!("Failed to generate active field types turbofish"); },
     };
 
-    // FFI attributes for the struct and fields
+    // FFI attributes for the struct and fields. Internal models skip the
+    // wasm/uniffi binding layers entirely, matching lib.rs's gating of
+    // wasm_impl: their expansion has no bindgen imports in scope.
     #[cfg(feature = "wasm")]
-    let (struct_attributes, field_attributes) = super::wasm::mutable_attributes();
+    let (struct_attributes, field_attributes) =
+        if model.is_internal() { (quote! {}, quote! {}) } else { super::wasm::mutable_attributes() };
 
     #[cfg(all(feature = "uniffi", not(feature = "wasm")))]
-    let (struct_attributes, field_attributes) = super::uniffi::mutable_attributes();
+    let (struct_attributes, field_attributes) =
+        if model.is_internal() { (quote! {}, quote! {}) } else { super::uniffi::mutable_attributes() };
 
     #[cfg(not(any(feature = "wasm", feature = "uniffi")))]
     let (struct_attributes, field_attributes) = (quote! {}, quote! {});
 
     // Generate WASM getter methods and wrapper definitions for custom types
-    let (wasm_getter_impl, wasm_custom_wrappers) = if cfg!(feature = "wasm") {
+    let (wasm_getter_impl, wasm_custom_wrappers) = if cfg!(feature = "wasm") && !model.is_internal() {
         let getter_methods = model.mutable_wasm_getters();
         let custom_wrappers = model.custom_active_type_wrappers();
         (

--- a/derive/src/model/mutable.rs
+++ b/derive/src/model/mutable.rs
@@ -1,3 +1,11 @@
+//! Generation of a model's typed transactional Mutable projection.
+//!
+//! [`mutable_impl`] emits the Mutable wrapper around an Entity, its typed active
+//! property accessors, identity conversion, and optional WASM/UniFFI attributes
+//! and wrapper types. The generated object exposes staged transaction state; it
+//! does not own commit, authorization, or property-backend semantics. Model
+//! metadata and View generation remain in their neighboring generator modules.
+
 use proc_macro2::TokenStream;
 use quote::quote;
 

--- a/derive/src/model/mutable.rs
+++ b/derive/src/model/mutable.rs
@@ -20,22 +20,20 @@ pub fn mutable_impl(model: &crate::model::description::ModelDescription) -> Toke
         Err(_) => return quote! { compile_error!("Failed to generate active field types turbofish"); },
     };
 
-    // FFI attributes for the struct and fields. Internal models skip the
-    // wasm/uniffi binding layers entirely, matching lib.rs's gating of
+    // FFI attributes for the struct and fields. Models marked `no_ffi` skip
+    // the wasm/uniffi binding layers entirely, matching lib.rs's gating of
     // wasm_impl: their expansion has no bindgen imports in scope.
     #[cfg(feature = "wasm")]
-    let (struct_attributes, field_attributes) =
-        if model.is_internal() { (quote! {}, quote! {}) } else { super::wasm::mutable_attributes() };
+    let (struct_attributes, field_attributes) = if model.no_ffi() { (quote! {}, quote! {}) } else { super::wasm::mutable_attributes() };
 
     #[cfg(all(feature = "uniffi", not(feature = "wasm")))]
-    let (struct_attributes, field_attributes) =
-        if model.is_internal() { (quote! {}, quote! {}) } else { super::uniffi::mutable_attributes() };
+    let (struct_attributes, field_attributes) = if model.no_ffi() { (quote! {}, quote! {}) } else { super::uniffi::mutable_attributes() };
 
     #[cfg(not(any(feature = "wasm", feature = "uniffi")))]
     let (struct_attributes, field_attributes) = (quote! {}, quote! {});
 
     // Generate WASM getter methods and wrapper definitions for custom types
-    let (wasm_getter_impl, wasm_custom_wrappers) = if cfg!(feature = "wasm") && !model.is_internal() {
+    let (wasm_getter_impl, wasm_custom_wrappers) = if cfg!(feature = "wasm") && !model.no_ffi() {
         let getter_methods = model.mutable_wasm_getters();
         let custom_wrappers = model.custom_active_type_wrappers();
         (

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -2,7 +2,7 @@
 //!
 //! This module generates the `static` [`#base::schema::ModelStructDescriptor`]
 //! and the `Model::descriptor()` method. Two facts per field are NORMATIVE.
-//! A property's minting model and name locate its identity; registration
+//! A property's original model scope and name locate its identity; registration
 //! checks these compiled facts against the immutable canonical pair (exact
 //! backend and a mutually castable value type) and refuses an incompatible
 //! binding rather than registering another property identity.
@@ -18,9 +18,9 @@
 //! - `#[property(renamed_from = "...")]`: a property display name (the
 //!   transient rename hint).
 //! - `#[model(id = "...")]` / `#[property(id = "...")]`: the EntityId of an
-//!   EXISTING catalog entity to bind against, verified at registration and
-//!   never minting. Built-in system identities are not catalog entities and
-//!   cannot appear here.
+//!   EXISTING catalog entity to bind against, verified at registration; it
+//!   never registers a new definition. Built-in system identities are not
+//!   catalog entities and cannot appear here.
 //! - `#[model(system = "...")]`: a built-in SystemModel variant, parsed in
 //!   description.rs. A closed compile-time identity: never registered, and
 //!   the collection is pinned to its reserved system label.

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -1,6 +1,6 @@
 //! Compiled-schema emission for `#[derive(Model)]`.
 //!
-//! This module generates the `static` [`#base::schema::ModelStructDescriptor`]
+//! This module generates the static `ModelStructDescriptor`
 //! and the `Model::descriptor()` method. Two facts per field are NORMATIVE.
 //! A property's original model scope and name locate its identity; registration
 //! checks these compiled facts against the immutable canonical pair (exact
@@ -24,6 +24,10 @@
 //! - `#[model(system = "...")]`: a built-in SystemModel variant, parsed in
 //!   description.rs. A compile-time System ID: never registered, and
 //!   the collection is pinned to its reserved system label.
+//! - `#[model(base = "...")]`: the path through which generated Rust code
+//!   addresses core. This is independent of FFI generation.
+//! - `#[model(no_ffi)]`: omit WASM and UniFFI surfaces for this model while
+//!   retaining its normal Rust model, view, and mutable APIs.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -71,14 +75,14 @@ pub fn validate_schema_attrs(model: &ModelDescription) -> syn::Result<()> {
 
     // A system model's identity is built in; it cannot also bind a catalog
     // entity id.
-    if model.system().is_some() && model_str_attr(model, "id")?.is_some() {
+    if model.system().is_some() && model.explicit_id().is_some() {
         return Err(syn::Error::new(
             model.name().span(),
             "#[model(system = ...)] and #[model(id = ...)] are mutually exclusive: a built-in identity is not a catalog entity",
         ));
     }
 
-    if let Some(id) = model_str_attr(model, "id")? {
+    if let Some(id) = model.explicit_id() {
         validate_explicit_id(&id).map_err(|msg| {
             syn::Error::new(
                 model.name().span(),
@@ -138,7 +142,7 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
         // The active type declares which backend stores it (an associated
         // const, resolved inside the static initializer). Like value_type,
         // the derive tabulates nothing.
-        let active_type = desc.rust_type_with_context(if model.is_internal() { "local" } else { "external" })?;
+        let active_type = desc.rust_type_with_context(if model.uses_local_paths() { "local" } else { "external" })?;
         let backend = quote! { <#active_type as #base::property::ActiveType>::BACKEND };
 
         // #[property(renamed_from = "...")]: the transient rename hint. Applied by the registration executor before lookup-or-create,
@@ -171,11 +175,11 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
     }
 
     // #[model(id = "...")]: explicit binding to a known model entity.
-    let model_explicit_id = model_str_attr(model, "id")?;
-    if let Some(ref id) = model_explicit_id {
+    let model_explicit_id = model.explicit_id();
+    if let Some(id) = model_explicit_id {
         validate_explicit_id(id).map_err(|msg| syn::Error::new(name.span(), msg))?;
     }
-    let model_explicit_id_tokens = option_str_tokens(model_explicit_id.as_deref());
+    let model_explicit_id_tokens = option_str_tokens(model_explicit_id);
 
     // A system model pins its built-in System ID into the descriptor;
     // every registration path short-circuits on it.
@@ -286,13 +290,6 @@ fn property_str_attr(attrs: &[syn::Attribute], key: &str) -> syn::Result<Option<
         })?;
     }
     Ok(found)
-}
-
-/// Parse a `#[model(key = "value")]` string attribute off the struct.
-/// Coexists with the flag form `#[model(ephemeral)]`-style parsing
-/// (get_model_flag); a non-string value for `key` is a hard error.
-fn model_str_attr(model: &ModelDescription, key: &str) -> syn::Result<Option<String>> {
-    crate::model::description::model_str_attr_on(model.struct_attrs(), key)
 }
 
 /// Emit `Some("...")` or `None` for an `Option<&'static str>` field.

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -14,10 +14,16 @@
 //!   through its `Property` impl's `VALUE_TYPE` const; the derive carries
 //!   no value-type vocabulary of its own.
 //!
-//! Attributes parsed here: `#[property(renamed_from = "...")]` (the
-//! transient rename hint) and `#[property(id = "...")]` /
-//! `#[model(id = "...")]` (explicit binding). Explicit-id values
-//! are validated at compile time as URL-safe base64 of exactly 16 bytes.
+//! Attributes parsed here, by the kind of thing each value parses as:
+//! - `#[property(renamed_from = "...")]`: a property display name (the
+//!   transient rename hint).
+//! - `#[model(id = "...")]` / `#[property(id = "...")]`: the EntityId of an
+//!   EXISTING catalog entity to bind against, verified at registration and
+//!   never minting. Built-in system identities are not catalog entities and
+//!   cannot appear here.
+//! - `#[model(system = "...")]`: a built-in SystemModel variant, parsed in
+//!   description.rs. A closed compile-time identity: never registered, and
+//!   the collection is pinned to its reserved system label.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -64,7 +70,12 @@ pub fn validate_schema_attrs(model: &ModelDescription) -> syn::Result<()> {
     }
 
     if let Some(id) = model_str_attr(model, "id")? {
-        validate_explicit_id(&id).map_err(|msg| syn::Error::new(model.name().span(), msg))?;
+        validate_explicit_id(&id).map_err(|msg| {
+            syn::Error::new(
+                model.name().span(),
+                format!("{msg}; #[model(id = ...)] takes the EntityId of an existing model catalog entity -- for a built-in system model use #[model(system = \"...\")]"),
+            )
+        })?;
     }
 
     Ok(())

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -22,7 +22,7 @@
 //!   never registers a new definition. Built-in system identities are not
 //!   catalog entities and cannot appear here.
 //! - `#[model(system = "...")]`: a built-in SystemModel variant, parsed in
-//!   description.rs. A closed compile-time identity: never registered, and
+//!   description.rs. A compile-time System ID: never registered, and
 //!   the collection is pinned to its reserved system label.
 
 use proc_macro2::TokenStream;
@@ -177,7 +177,7 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
     }
     let model_explicit_id_tokens = option_str_tokens(model_explicit_id.as_deref());
 
-    // A system model pins its closed built-in identity into the descriptor;
+    // A system model pins its built-in System ID into the descriptor;
     // every registration path short-circuits on it.
     let system_tokens = match model.system() {
         Some(variant) => quote! { ::core::option::Option::Some(#base::proto::SystemModel::#variant) },

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -162,6 +162,7 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
                     #(#field_tokens),*
                 ],
                 explicit_id: #model_explicit_id_tokens,
+                system: ::core::option::Option::None,
             };
             &__ANKURAH_MODEL_SCHEMA
         }

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -92,6 +92,11 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
 
     let name = model.name();
     let name_str = name.to_string();
+    // The declaring module's path, captured by lib.rs in the user's module.
+    // The descriptor static lives inside the hygiene module, so it reads the
+    // const through `super::`. Unique ids hash NAMES ONLY (module path,
+    // struct, field), so they survive a change of a field's type.
+    let module_path_const = model.module_path_const();
 
     // Per-field descriptors, in declaration order (ephemeral fields already
     // excluded by ModelDescription's active/ephemeral split).
@@ -151,6 +156,7 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
                 target_label: #target_collection_tokens,
                 optional: #optional,
                 explicit_id: #explicit_id_tokens,
+                unique_id: #base::proto::UniqueFieldId::from_names(super::#module_path_const, #name_str, #field_name),
             }
         });
     }
@@ -182,6 +188,7 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
                 ],
                 explicit_id: #model_explicit_id_tokens,
                 system: #system_tokens,
+                unique_id: #base::proto::UniqueStructId::from_names(super::#module_path_const, #name_str),
             };
             &__ANKURAH_MODEL_SCHEMA
         }

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -69,6 +69,15 @@ pub fn validate_schema_attrs(model: &ModelDescription) -> syn::Result<()> {
         }
     }
 
+    // A system model's identity is built in; it cannot also bind a catalog
+    // entity id.
+    if model.system().is_some() && model_str_attr(model, "id")?.is_some() {
+        return Err(syn::Error::new(
+            model.name().span(),
+            "#[model(system = ...)] and #[model(id = ...)] are mutually exclusive: a built-in identity is not a catalog entity",
+        ));
+    }
+
     if let Some(id) = model_str_attr(model, "id")? {
         validate_explicit_id(&id).map_err(|msg| {
             syn::Error::new(
@@ -280,45 +289,10 @@ fn property_str_attr(attrs: &[syn::Attribute], key: &str) -> syn::Result<Option<
 }
 
 /// Parse a `#[model(key = "value")]` string attribute off the struct.
-/// Coexists with the existing flag form `#[model(ephemeral)]`-style parsing
-/// (get_model_flag): a bare-ident meta and unrelated keys are skipped, a
-/// `key = "lit"` is captured, and a `key = <non-string>` value is a hard
-/// error (previously it was silently ignored, so `#[model(id = 5)]` would
-/// fall back to derivation without a diagnostic).
+/// Coexists with the flag form `#[model(ephemeral)]`-style parsing
+/// (get_model_flag); a non-string value for `key` is a hard error.
 fn model_str_attr(model: &ModelDescription, key: &str) -> syn::Result<Option<String>> {
-    let mut found = None;
-    let mut bad_value: Option<syn::Error> = None;
-    for attr in model.struct_attrs() {
-        if !attr.path().is_ident("model") {
-            continue;
-        }
-        // Ignore parse failures from the flag form (e.g. #[model(ephemeral)]),
-        // which is not a name-value list; only capture name = "value".
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident(key) {
-                // Only ours if it is a name-value; a bare flag is skipped.
-                if let Ok(value) = meta.value() {
-                    match value.parse::<syn::LitStr>() {
-                        Ok(lit) => found = Some(lit.value()),
-                        Err(_) => {
-                            bad_value = Some(syn::Error::new(meta.path.span(), format!("#[model({key} = ...)] expects a string literal")));
-                        }
-                    }
-                }
-            }
-            // Consume any value token for unrelated keys so the walk
-            // continues past `key = value` we do not handle.
-            if meta.input.peek(syn::Token![=]) {
-                let value = meta.value()?;
-                let _: syn::Expr = value.parse()?;
-            }
-            Ok(())
-        });
-    }
-    if let Some(err) = bad_value {
-        return Err(err);
-    }
-    Ok(found)
+    crate::model::description::model_str_attr_on(model.struct_attrs(), key)
 }
 
 /// Emit `Some("...")` or `None` for an `Option<&'static str>` field.

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -142,7 +142,7 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
         // The active type declares which backend stores it (an associated
         // const, resolved inside the static initializer). Like value_type,
         // the derive tabulates nothing.
-        let active_type = desc.rust_type_with_context(if model.uses_local_paths() { "local" } else { "external" })?;
+        let active_type = desc.rust_type_with_context(if model.uses_crate_paths() { "local" } else { "external" })?;
         let backend = quote! { <#active_type as #base::property::ActiveType>::BACKEND };
 
         // #[property(renamed_from = "...")]: the transient rename hint. Applied by the registration executor before lookup-or-create,

--- a/derive/src/model/schema.rs
+++ b/derive/src/model/schema.rs
@@ -1,6 +1,6 @@
 //! Compiled-schema emission for `#[derive(Model)]`.
 //!
-//! This module generates the `static` [`ankurah::core::schema::ModelStructDescriptor`]
+//! This module generates the `static` [`#base::schema::ModelStructDescriptor`]
 //! and the `Model::descriptor()` method. Two facts per field are NORMATIVE.
 //! A property's minting model and name locate its identity; registration
 //! checks these compiled facts against the immutable canonical pair (exact
@@ -48,7 +48,7 @@ pub fn validate_schema_attrs(model: &ModelDescription) -> syn::Result<()> {
     // model must never claim it, complementing the
     // receiver-side structural protection.
     let collection = model.collection_str();
-    if collection.starts_with("_ankurah_") {
+    if model.system().is_none() && collection.starts_with("_ankurah_") {
         return Err(syn::Error::new(
             model.name().span(),
             format!("collection '{collection}' uses the reserved `_ankurah_` prefix, which is reserved for system collections; rename the model"),
@@ -76,6 +76,7 @@ pub fn validate_schema_attrs(model: &ModelDescription) -> syn::Result<()> {
 /// [`validate_schema_attrs`] already ran (it re-derives the same facts, so
 /// it is safe to call independently).
 pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
+    let base = model.base();
     let collection = model.collection_str();
 
     let name = model.name();
@@ -100,7 +101,7 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
         // associated const, resolved inside the static initializer). The
         // derive carries no value-type vocabulary of its own.
         let inner = mapping.inner;
-        let value_type = quote! { <#inner as ::ankurah::Property>::VALUE_TYPE };
+        let value_type = quote! { <#inner as #base::property::Property>::VALUE_TYPE };
 
         // Ref<T> names its target model by source label in the registration
         // descriptor. Source model labels are the lowercased model type name
@@ -112,8 +113,8 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
         // The active type declares which backend stores it (an associated
         // const, resolved inside the static initializer). Like value_type,
         // the derive tabulates nothing.
-        let active_type = desc.rust_type()?;
-        let backend = quote! { <#active_type as ::ankurah::property::ActiveType>::BACKEND };
+        let active_type = desc.rust_type_with_context(if model.is_internal() { "local" } else { "external" })?;
+        let backend = quote! { <#active_type as #base::property::ActiveType>::BACKEND };
 
         // #[property(renamed_from = "...")]: the transient rename hint. Applied by the registration executor before lookup-or-create,
         // guarded; removable from source once every target system has seen
@@ -130,7 +131,7 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
         let explicit_id_tokens = option_str_tokens(explicit_id.as_deref());
 
         field_tokens.push(quote! {
-            ::ankurah::core::schema::StructProperty {
+            #base::schema::StructProperty {
                 field: #field_name,
                 name: #display_name,
                 renamed_from: #renamed_from_tokens,
@@ -150,19 +151,26 @@ pub fn schema_impl(model: &ModelDescription) -> syn::Result<TokenStream> {
     }
     let model_explicit_id_tokens = option_str_tokens(model_explicit_id.as_deref());
 
+    // A system model pins its closed built-in identity into the descriptor;
+    // every registration path short-circuits on it.
+    let system_tokens = match model.system() {
+        Some(variant) => quote! { ::core::option::Option::Some(#base::proto::SystemModel::#variant) },
+        None => quote! { ::core::option::Option::None },
+    };
+
     // A private static so the returned reference is `&'static` with zero
     // per-call cost. Named distinctly to avoid colliding with anything in
     // the hygiene module.
     Ok(quote! {
-        fn descriptor() -> &'static ::ankurah::core::schema::ModelStructDescriptor {
-            static __ANKURAH_MODEL_SCHEMA: ::ankurah::core::schema::ModelStructDescriptor = ::ankurah::core::schema::ModelStructDescriptor {
+        fn descriptor() -> &'static #base::schema::ModelStructDescriptor {
+            static __ANKURAH_MODEL_SCHEMA: #base::schema::ModelStructDescriptor = #base::schema::ModelStructDescriptor {
                 label: #collection,
                 name: #name_str,
                 properties: &[
                     #(#field_tokens),*
                 ],
                 explicit_id: #model_explicit_id_tokens,
-                system: ::core::option::Option::None,
+                system: #system_tokens,
             };
             &__ANKURAH_MODEL_SCHEMA
         }

--- a/derive/src/model/view.rs
+++ b/derive/src/model/view.rs
@@ -1,3 +1,11 @@
+//! Generation of a model's typed read-only View projection.
+//!
+//! [`view_impl`] emits the View wrapper around an Entity, typed field accessors,
+//! signal/subscription integration, edit and Ref conveniences, and optional
+//! WASM/UniFFI exposure. The generated View interprets live entity state; it
+//! does not own query execution, mutation commit, or property-backend behavior.
+//! Model metadata and Mutable generation remain in their neighboring modules.
+
 use proc_macro2::TokenStream;
 use quote::quote;
 

--- a/derive/src/model/view.rs
+++ b/derive/src/model/view.rs
@@ -19,9 +19,12 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
     };
     let active_field_name_strs = model.active_field_name_strs();
 
-    // WASM field getters (conditionally generated)
+    // WASM field getters (conditionally generated; internal models skip the
+    // wasm binding layer, matching lib.rs's gating of wasm_impl)
     #[cfg(feature = "wasm")]
-    let wasm_field_getters_impl = {
+    let wasm_field_getters_impl = if model.is_internal() {
+        quote! {}
+    } else {
         let wasm_getters = model.wasm_getters();
         quote! {
             #[wasm_bindgen]
@@ -35,7 +38,9 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
 
     // UniFFI field getters (conditionally generated - only when uniffi enabled WITHOUT wasm)
     #[cfg(all(feature = "uniffi", not(feature = "wasm")))]
-    let uniffi_field_getters_impl = {
+    let uniffi_field_getters_impl = if model.is_internal() {
+        quote! {}
+    } else {
         let uniffi_getters = model.uniffi_view_getters();
         quote! {
             #[::uniffi::export]
@@ -47,17 +52,22 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
     #[cfg(any(not(feature = "uniffi"), feature = "wasm"))]
     let uniffi_field_getters_impl = quote! {};
 
-    // Get FFI-specific attributes from the appropriate module
-    // wasm takes precedence when both features are enabled
+    let no_ffi_attrs =
+        || super::ViewAttributes { struct_attr: quote! {}, impl_attr: quote! {}, id_method_attr: quote! {}, extra_impl: quote! {} };
+
+    // Get FFI-specific attributes from the appropriate module.
+    // wasm takes precedence when both features are enabled; internal models
+    // get no FFI surface at all (their expansion has no bindgen imports and
+    // the emitted paths would name the facade crate, which internal builds
+    // cannot see).
     #[cfg(feature = "wasm")]
-    let ffi_attrs = super::wasm::view_attributes(&view_name, &mutable_name, &name);
+    let ffi_attrs = if model.is_internal() { no_ffi_attrs() } else { super::wasm::view_attributes(&view_name, &mutable_name, &name) };
 
     #[cfg(all(feature = "uniffi", not(feature = "wasm")))]
-    let ffi_attrs = super::uniffi::view_attributes();
+    let ffi_attrs = if model.is_internal() { no_ffi_attrs() } else { super::uniffi::view_attributes() };
 
     #[cfg(not(any(feature = "wasm", feature = "uniffi")))]
-    let ffi_attrs =
-        super::ViewAttributes { struct_attr: quote! {}, impl_attr: quote! {}, id_method_attr: quote! {}, extra_impl: quote! {} };
+    let ffi_attrs = no_ffi_attrs();
 
     let struct_attr = ffi_attrs.struct_attr;
     let impl_attr = ffi_attrs.impl_attr;

--- a/derive/src/model/view.rs
+++ b/derive/src/model/view.rs
@@ -19,10 +19,10 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
     };
     let active_field_name_strs = model.active_field_name_strs();
 
-    // WASM field getters (conditionally generated; internal models skip the
+    // WASM field getters (conditionally generated; `no_ffi` models skip the
     // wasm binding layer, matching lib.rs's gating of wasm_impl)
     #[cfg(feature = "wasm")]
-    let wasm_field_getters_impl = if model.is_internal() {
+    let wasm_field_getters_impl = if model.no_ffi() {
         quote! {}
     } else {
         let wasm_getters = model.wasm_getters();
@@ -38,7 +38,7 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
 
     // UniFFI field getters (conditionally generated - only when uniffi enabled WITHOUT wasm)
     #[cfg(all(feature = "uniffi", not(feature = "wasm")))]
-    let uniffi_field_getters_impl = if model.is_internal() {
+    let uniffi_field_getters_impl = if model.no_ffi() {
         quote! {}
     } else {
         let uniffi_getters = model.uniffi_view_getters();
@@ -56,15 +56,15 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
         || super::ViewAttributes { struct_attr: quote! {}, impl_attr: quote! {}, id_method_attr: quote! {}, extra_impl: quote! {} };
 
     // Get FFI-specific attributes from the appropriate module.
-    // wasm takes precedence when both features are enabled; internal models
+    // wasm takes precedence when both features are enabled; `no_ffi` models
     // get no FFI surface at all (their expansion has no bindgen imports and
     // the emitted paths would name the facade crate, which internal builds
     // cannot see).
     #[cfg(feature = "wasm")]
-    let ffi_attrs = if model.is_internal() { no_ffi_attrs() } else { super::wasm::view_attributes(&view_name, &mutable_name, &name) };
+    let ffi_attrs = if model.no_ffi() { no_ffi_attrs() } else { super::wasm::view_attributes(&view_name, &mutable_name, &name) };
 
     #[cfg(all(feature = "uniffi", not(feature = "wasm")))]
-    let ffi_attrs = if model.is_internal() { no_ffi_attrs() } else { super::uniffi::view_attributes() };
+    let ffi_attrs = if model.no_ffi() { no_ffi_attrs() } else { super::uniffi::view_attributes() };
 
     #[cfg(not(any(feature = "wasm", feature = "uniffi")))]
     let ffi_attrs = no_ffi_attrs();

--- a/derive/src/model/view.rs
+++ b/derive/src/model/view.rs
@@ -3,6 +3,7 @@ use quote::quote;
 
 /// Generate the View struct and all its implementations
 pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenStream {
+    let base = model.base();
     let view_name = model.view_name();
     let name = model.name();
     let mutable_name = model.mutable_name();
@@ -68,44 +69,44 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
             #struct_attr
             #[derive(Clone, Debug, PartialEq)]
             pub struct #view_name {
-                entity: ::ankurah::entity::Entity,
+                entity: #base::entity::Entity,
                 #(
                     #ephemeral_field_visibility #ephemeral_field_names: #ephemeral_field_types,
                 )*
             }
 
-            impl From<#view_name> for ::ankurah::ankql::ast::Expr {
-                fn from(view: #view_name) -> ::ankurah::ankql::ast::Expr {
+            impl From<#view_name> for #base::ankql::ast::Expr {
+                fn from(view: #view_name) -> #base::ankql::ast::Expr {
                     view.entity.id().into()
                 }
             }
 
-            impl From<&#view_name> for ::ankurah::ankql::ast::Expr {
-                fn from(view: &#view_name) -> ::ankurah::ankql::ast::Expr {
+            impl From<&#view_name> for #base::ankql::ast::Expr {
+                fn from(view: &#view_name) -> #base::ankql::ast::Expr {
                     view.entity.id().into()
                 }
             }
 
-            impl ::ankurah::model::View for #view_name {
+            impl #base::model::View for #view_name {
                 type Model = #name;
                 type Mutable = #mutable_name;
 
                 // THINK ABOUT: to_model is the only thing that forces a clone requirement
                 // Even though most Models will be clonable, maybe we shouldn't force it?
                 // Also: nothing seems to be using this. Maybe it could be opt in
-                fn to_model(&self) -> Result<Self::Model, ankurah::property::PropertyError> {
+                fn to_model(&self) -> Result<Self::Model, #base::property::PropertyError> {
                     Ok(#name {
                         #( #active_field_names: self.#active_field_names()?, )*
                         #( #ephemeral_field_names: self.#ephemeral_field_names.clone(), )*
                     })
                 }
 
-                fn entity(&self) -> &::ankurah::entity::Entity {
+                fn entity(&self) -> &#base::entity::Entity {
                     &self.entity
                 }
 
-                fn from_entity(entity: ::ankurah::entity::Entity) -> Self {
-                    use ::ankurah::model::View;
+                fn from_entity(entity: #base::entity::Entity) -> Self {
+                    use #base::model::View;
                     assert_eq!(&Self::collection(), entity.collection());
                     #view_name {
                         entity,
@@ -116,28 +117,28 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
                 }
             }
 
-            impl ::ankurah::signals::Signal for #view_name {
-                fn listen(&self, listener: ::ankurah::signals::signal::Listener) -> ::ankurah::signals::signal::ListenerGuard {
+            impl #base::signals::Signal for #view_name {
+                fn listen(&self, listener: #base::signals::signal::Listener) -> #base::signals::signal::ListenerGuard {
                     self.entity.broadcast().reference().listen(listener).into()
                 }
-                fn broadcast_id(&self) -> ::ankurah::signals::broadcast::BroadcastId {
+                fn broadcast_id(&self) -> #base::signals::broadcast::BroadcastId {
                     self.entity.broadcast().id()
                 }
             }
 
-            impl ::ankurah::signals::Subscribe<#view_name> for #view_name {
-                fn subscribe<F>(&self, listener: F) -> ::ankurah::signals::SubscriptionGuard
+            impl #base::signals::Subscribe<#view_name> for #view_name {
+                fn subscribe<F>(&self, listener: F) -> #base::signals::SubscriptionGuard
                 where
-                    F: ::ankurah::signals::subscribe::IntoSubscribeListener<#view_name>,
+                    F: #base::signals::subscribe::IntoSubscribeListener<#view_name>,
                 {
-                    ::ankurah::core::model::view_subscribe(self, listener)
+                    #base::model::view_subscribe(self, listener)
                 }
             }
 
             impl #view_name {
                 /// Edit this entity in a transaction (Rust version - returns MutableBorrow with lifetime)
-                pub fn edit<'rec, 'trx: 'rec>(&self, trx: &'trx ankurah::transaction::Transaction) -> Result<::ankurah::model::MutableBorrow<'rec, #mutable_name>, ankurah::policy::AccessDenied> {
-                    use ::ankurah::model::View;
+                pub fn edit<'rec, 'trx: 'rec>(&self, trx: &'trx #base::transaction::Transaction) -> Result<#base::model::MutableBorrow<'rec, #mutable_name>, #base::policy::AccessDenied> {
+                    use #base::model::View;
                     // TODO - get rid of this in favor of directly cloning the entity of the ModelView struct
                     trx.edit::<#name>(&self.entity)
                 }
@@ -149,13 +150,13 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
             #impl_attr
             impl #view_name {
                 #id_method_attr
-                pub fn id(&self) -> ankurah::proto::EntityId {
+                pub fn id(&self) -> #base::proto::EntityId {
                     self.entity.id().clone()
                 }
 
                 /// Manually track this View in the current observer
                 pub fn track(&self) {
-                    ::ankurah::signals::CurrentObserver::track(self);
+                    #base::signals::CurrentObserver::track(self);
                 }
             }
 
@@ -170,14 +171,14 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
                 ///     artist: artist_view.r(),
                 /// })
                 /// ```
-                pub fn r(&self) -> ::ankurah::property::Ref<#name> {
-                    ::ankurah::property::Ref::new(self.entity.id())
+                pub fn r(&self) -> #base::property::Ref<#name> {
+                    #base::property::Ref::new(self.entity.id())
                 }
 
                 #(
-                    pub fn #active_field_names(&self) -> Result<#projected_field_types, ankurah::property::PropertyError> {
-                        use ankurah::property::{FromActiveType, FromEntity};
-                        ::ankurah::signals::CurrentObserver::track(self);
+                    pub fn #active_field_names(&self) -> Result<#projected_field_types, #base::property::PropertyError> {
+                        use #base::property::{FromActiveType, FromEntity};
+                        #base::signals::CurrentObserver::track(self);
                         let active_result = #active_field_types_turbofish::from_entity(#active_field_name_strs.into(), &self.entity);
                         #projected_field_types_turbofish::from_active(active_result)
                     }
@@ -188,17 +189,17 @@ pub fn view_impl(model: &crate::model::description::ModelDescription) -> TokenSt
 
             #uniffi_field_getters_impl
 
-            impl<'a> Into<ankurah::proto::EntityId> for &'a #view_name {
-                fn into(self) -> ankurah::proto::EntityId {
+            impl<'a> Into<#base::proto::EntityId> for &'a #view_name {
+                fn into(self) -> #base::proto::EntityId {
                     self.entity.id()
                 }
             }
 
             // From<&View> for Ref<Model> is implemented via blanket impl in entity_ref.rs
 
-            impl From<#view_name> for ::ankurah::property::Ref<#name> {
+            impl From<#view_name> for #base::property::Ref<#name> {
                 fn from(view: #view_name) -> Self {
-                    ::ankurah::property::Ref::new(view.entity.id())
+                    #base::property::Ref::new(view.entity.id())
                 }
             }
     };

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,3 +1,12 @@
+//! Serialized vocabulary exchanged between Ankurah nodes and storage layers.
+//!
+//! This crate gathers identities, clocks, entities, events, requests,
+//! responses, subscription updates, schema registration declarations, and
+//! attestations into one protocol surface, re-exporting their canonical types
+//! from this module root. It owns data shape and encoding compatibility, not
+//! transport, authorization, catalog allocation, or runtime application of the
+//! messages; those responsibilities live in connectors and `ankurah-core`.
+
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -23,7 +23,7 @@ pub mod registration;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
-pub use ankurah_core_types::{ModelId, PropertyId, SystemModel, SystemProperty};
+pub use ankurah_core_types::{ModelId, PropertyId, SystemModel, SystemProperty, UniqueFieldId, UniqueStructId};
 
 pub use auth::*;
 pub use clock::*;

--- a/proto/src/registration.rs
+++ b/proto/src/registration.rs
@@ -115,3 +115,43 @@ pub struct RegisteredProperty {
     /// Whether this property is optional in the parent model.
     pub optional: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The optional unique-id hints survive the serialized encoding in both
+    /// states. The in-process connection the registration suite runs over
+    /// passes structs in memory, so the encoded form is exercised here.
+    #[test]
+    fn unique_id_hints_round_trip_the_encoding() {
+        for (model_hint, field_hint) in [
+            (
+                Some(UniqueStructId::from_names("some_app::records", "Album")),
+                Some(UniqueFieldId::from_names("some_app::records", "Album", "name")),
+            ),
+            (None, None),
+        ] {
+            let model = RegisterModel {
+                label: "album".into(),
+                name: "Album".into(),
+                explicit_id: None,
+                unique_id: model_hint,
+                properties: vec![RegisterProperty {
+                    name: "name".into(),
+                    renamed_from: None,
+                    backend: "yrs".into(),
+                    value_type: "string".into(),
+                    target_label: None,
+                    explicit_id: None,
+                    unique_id: field_hint,
+                    optional: false,
+                }],
+            };
+            let decoded: RegisterModel = bincode::deserialize(&bincode::serialize(&model).unwrap()).unwrap();
+            assert_eq!(decoded.unique_id, model_hint);
+            assert_eq!(decoded.properties[0].unique_id, field_hint);
+            assert_eq!((decoded.label, decoded.name), (model.label, model.name));
+        }
+    }
+}

--- a/proto/src/registration.rs
+++ b/proto/src/registration.rs
@@ -10,6 +10,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use ankurah_core_types::{UniqueFieldId, UniqueStructId};
+
 use crate::id::EntityId;
 
 /// One model declaration within a RegisterSchema request.
@@ -26,6 +28,12 @@ pub struct RegisterModel {
     /// looking one up by label. Never mints; hard-fails if absent or if the
     /// bound entity's label differs.
     pub explicit_id: Option<EntityId>,
+    /// The declaring struct's deterministic source identity, hashed from its
+    /// names at compile time. An identity hint for future migrations: the
+    /// executor accepts and ignores it today. `None` for registrations with
+    /// no compile-time source (dynamic or non-Rust declarations); the derive
+    /// always supplies it.
+    pub unique_id: Option<UniqueStructId>,
     /// The model's properties, in declaration order. Each entry asserts a
     /// model-property membership; an entry with an explicit id references an
     /// existing (possibly shared) property and never mints.
@@ -58,6 +66,11 @@ pub struct RegisterProperty {
     /// Explicit binding: reference an EXISTING property entity instead of
     /// looking one up by name. Never mints; hard-fails if absent.
     pub explicit_id: Option<EntityId>,
+    /// The declaring field's deterministic source identity, hashed from its
+    /// names at compile time. An identity hint for future migrations: the
+    /// executor accepts and ignores it today. `None` for registrations with
+    /// no compile-time source; the derive always supplies it.
+    pub unique_id: Option<UniqueFieldId>,
     /// Whether entities of this model may omit the property. Per membership:
     /// the same property may be required in one model and optional in
     /// another.

--- a/tests/tests/catalog_dogfood.rs
+++ b/tests/tests/catalog_dogfood.rs
@@ -1,0 +1,94 @@
+//! The catalog dogfood spike: the three catalog collections accessed through
+//! ordinary typed Models (core/src/schema/catalog/rows.rs) whose identity is
+//! a compile-time SystemModel. No registration, no catalog lookup, no raw
+//! state-buffer parsing.
+
+mod common;
+use ankurah::core::schema::catalog::rows::{SysModelPropertyRowView, SysModelRow, SysModelRowView, SysPropertyRowView};
+use ankurah::proto::SystemModel;
+use common::*;
+
+use ankurah::model::Mutable as _;
+
+/// A typed create into a catalog collection travels the NORMAL entity path:
+/// first-use ensure short-circuits to the closed system identity, the
+/// staged membership asserts ModelId::System(Model), and commit-funnel
+/// admissibility accepts it because the collection fact matches.
+#[tokio::test]
+async fn typed_create_into_catalog_collection() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    let ctx = node.context(DEFAULT_CONTEXT)?;
+
+    let trx = ctx.begin();
+    let row = trx.create(&SysModelRow { label: "spike_row".into(), name: "SpikeRow".into() }).await?;
+    let id = row.id();
+    trx.commit().await?;
+
+    let fetched = ctx.fetch::<SysModelRowView>("label = 'spike_row'").await?;
+    assert_eq!(fetched.len(), 1, "typed fetch finds the typed create");
+    assert_eq!(fetched[0].id(), id);
+    assert_eq!(fetched[0].name()?, "SpikeRow");
+    use ankurah::model::View;
+    assert!(
+        fetched[0].entity().has_membership(&ankurah::proto::ModelId::System(SystemModel::Model)),
+        "the row's membership is the closed system identity"
+    );
+    Ok(())
+}
+
+/// The dogfood moment: rows the registration EXECUTOR wrote (forged events,
+/// raw LWW) read back through the typed Views, field for field. One schema
+/// spelling serves both writer and reader.
+#[tokio::test]
+async fn executor_rows_read_through_typed_views() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    let ctx = node.context(DEFAULT_CONTEXT)?;
+
+    let album_model = ctx.register_model::<Album>().await?;
+    let album_entity = *album_model.as_entity_id().expect("registered app model has an entity id");
+
+    // The model row, through the typed view.
+    let models = ctx.fetch::<SysModelRowView>("label = 'album'").await?;
+    assert_eq!(models.len(), 1, "the executor's model row is visible through the typed view");
+    assert_eq!(models[0].id(), album_entity);
+    assert_eq!(models[0].name()?, "Album");
+
+    // The property rows, through the typed view: Album has name + year.
+    let properties = ctx.fetch::<SysPropertyRowView>(format!("minted_for = '{album_entity}'").as_str()).await?;
+    let mut names: Vec<String> = properties.iter().map(|p| p.name()).collect::<Result<_, _>>()?;
+    names.sort();
+    assert_eq!(names, ["name", "year"], "the executor's property rows read typed");
+    for property in &properties {
+        assert_eq!(property.backend()?, "yrs", "Album String fields resolve to the yrs backend");
+        assert_eq!(property.value_type()?, "string");
+        assert_eq!(property.minted_for()?, Some(album_entity));
+    }
+
+    // The membership rows, through the typed view.
+    let memberships = ctx.fetch::<SysModelPropertyRowView>(format!("model = '{album_entity}'").as_str()).await?;
+    assert_eq!(memberships.len(), 2, "one membership row per Album property");
+    for membership in &memberships {
+        assert!(!membership.optional()?, "Album's fields are required");
+    }
+    Ok(())
+}
+
+/// The map feed proof: a catalog row committed OUTSIDE the registration
+/// executor (a typed create; `upsert_registered` never sees it) appears in
+/// the in-memory catalog map, delivered by the policy-free reactor
+/// subscription. `commit` awaits `notify_change`, and the feed listener
+/// folds inline on the broadcast, so the map is current when commit returns.
+#[tokio::test]
+async fn map_learns_from_the_feed_not_the_executor() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    let ctx = node.context(DEFAULT_CONTEXT)?;
+    node.catalog.wait_catalog_ready().await;
+
+    let trx = ctx.begin();
+    trx.create(&SysModelRow { label: "feed_only".into(), name: "FeedOnly".into() }).await?;
+    trx.commit().await?;
+
+    let model = node.catalog.model_by_label("feed_only").expect("the reactor feed delivered the row into the map");
+    assert_eq!(model.name, "FeedOnly");
+    Ok(())
+}

--- a/tests/tests/catalog_dogfood.rs
+++ b/tests/tests/catalog_dogfood.rs
@@ -10,9 +10,11 @@ use ankurah::proto::SystemModel;
 use common::*;
 use std::collections::BTreeMap;
 
-fn model_row_creation(label: &str, name: &str) -> anyhow::Result<proto::Event> {
+fn model_row_creation(label: Option<&str>, name: &str) -> anyhow::Result<proto::Event> {
     let backend = LWWBackend::new();
-    backend.set("label".into(), Some(Value::String(label.into())));
+    if let Some(label) = label {
+        backend.set("label".into(), Some(Value::String(label.into())));
+    }
     backend.set("name".into(), Some(Value::String(name.into())));
     let backend_operations = backend.to_operations()?.expect("the row has fields");
     let model = proto::ModelId::System(SystemModel::Model);
@@ -26,9 +28,9 @@ fn model_row_creation(label: &str, name: &str) -> anyhow::Result<proto::Event> {
     })
 }
 
-/// Rows the registration executor wrote as raw LWW events read back through
-/// the typed Views, field for field: one schema spelling serves both the
-/// executor's writes and typed reads.
+/// Rows the registration executor wrote through generated Models and
+/// Mutables read back through the generated Views, field for field: one
+/// schema spelling serves both writes and reads.
 #[tokio::test]
 async fn executor_rows_read_through_typed_views() -> anyhow::Result<()> {
     let node = durable_sled_setup().await?;
@@ -63,20 +65,42 @@ async fn executor_rows_read_through_typed_views() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A catalog row committed through the allocator's trusted low-level funnel,
-/// but outside `register_schema` (`upsert_registered` never sees it), appears
-/// in the map through the reactor feed. Ordinary transactions cannot take
-/// this path. `commit_remote_transaction` awaits `notify_change`, so the map
-/// is current when it returns.
+/// A test-injected catalog event committed outside `register_schema` appears
+/// in the map through the typed LiveQuery feed. This pins the important
+/// ownership boundary: the durable projection learns from catalog data, not
+/// from an executor side-channel. `commit_remote_transaction` awaits
+/// `notify_change`, so the map is current when it returns.
 #[tokio::test]
 async fn map_learns_from_the_feed_not_the_executor() -> anyhow::Result<()> {
     let node = durable_sled_setup().await?;
     node.catalog.wait_catalog_ready().await;
 
-    let event = model_row_creation("feed_only", "FeedOnly")?;
+    let event = model_row_creation(Some("feed_only"), "FeedOnly")?;
     node.commit_remote_transaction(&DEFAULT_CONTEXT, proto::TransactionId::new(), vec![proto::Attested::opt(event, None)]).await?;
 
-    let model = node.catalog.model_by_label("feed_only").expect("the reactor feed delivered the row into the map");
+    let model = node.catalog.model_by_label("feed_only").expect("the typed catalog feed delivered the row into the map");
     assert_eq!(model.name, "FeedOnly");
+    Ok(())
+}
+
+/// A malformed row is noisy but local to that row: it contributes no map
+/// entry and does not poison the subscription that delivers later valid
+/// catalog changes.
+#[tokio::test]
+async fn malformed_feed_row_is_skipped_without_stopping_the_feed() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    node.catalog.wait_catalog_ready().await;
+    let before = node.catalog.counts();
+
+    let malformed = model_row_creation(None, "MissingLabel")?;
+    node.commit_remote_transaction(&DEFAULT_CONTEXT, proto::TransactionId::new(), vec![proto::Attested::opt(malformed, None)]).await?;
+    assert_eq!(node.catalog.counts(), before, "a row missing its required label must not enter the map");
+
+    let valid = model_row_creation(Some("after_malformed"), "AfterMalformed")?;
+    node.commit_remote_transaction(&DEFAULT_CONTEXT, proto::TransactionId::new(), vec![proto::Attested::opt(valid, None)]).await?;
+
+    let model = node.catalog.model_by_label("after_malformed").expect("the feed must continue after a malformed row");
+    assert_eq!(model.name, "AfterMalformed");
+    assert_eq!(node.catalog.counts(), (before.0 + 1, before.1, before.2));
     Ok(())
 }

--- a/tests/tests/catalog_dogfood.rs
+++ b/tests/tests/catalog_dogfood.rs
@@ -1,39 +1,29 @@
-//! The three catalog collections accessed through ordinary typed Models
+//! The three catalog collections read through ordinary typed Views
 //! (core/src/schema/catalog/rows.rs) whose identity is a compile-time
 //! SystemModel. No registration, no catalog lookup, no raw state-buffer
-//! parsing.
+//! parsing on the typed read side.
 
 mod common;
-use ankurah::core::schema::catalog::rows::{SysModelPropertyRowView, SysModelRow, SysModelRowView, SysPropertyRowView};
+use ankurah::core::schema::catalog::rows::{SysModelPropertyRowView, SysModelRowView, SysPropertyRowView};
+use ankurah::core::{property::backend::LWWBackend, property::backend::PropertyBackend, value::Value};
 use ankurah::proto::SystemModel;
 use common::*;
+use std::collections::BTreeMap;
 
-use ankurah::model::Mutable as _;
-
-/// A typed create into a catalog collection travels the NORMAL entity path:
-/// first-use ensure short-circuits to the System ID, the
-/// staged membership asserts ModelId::System(Model), and commit-funnel
-/// admissibility accepts it because the collection fact matches.
-#[tokio::test]
-async fn typed_create_into_catalog_collection() -> anyhow::Result<()> {
-    let node = durable_sled_setup().await?;
-    let ctx = node.context(DEFAULT_CONTEXT)?;
-
-    let trx = ctx.begin();
-    let row = trx.create(&SysModelRow { label: "typed_row".into(), name: "TypedRow".into() }).await?;
-    let id = row.id();
-    trx.commit().await?;
-
-    let fetched = ctx.fetch::<SysModelRowView>("label = 'typed_row'").await?;
-    assert_eq!(fetched.len(), 1, "typed fetch finds the typed create");
-    assert_eq!(fetched[0].id(), id);
-    assert_eq!(fetched[0].name()?, "TypedRow");
-    use ankurah::model::View;
-    assert!(
-        fetched[0].entity().has_membership(&ankurah::proto::ModelId::System(SystemModel::Model)),
-        "the row's membership is the System ID"
-    );
-    Ok(())
+fn model_row_creation(label: &str, name: &str) -> anyhow::Result<proto::Event> {
+    let backend = LWWBackend::new();
+    backend.set("label".into(), Some(Value::String(label.into())));
+    backend.set("name".into(), Some(Value::String(name.into())));
+    let backend_operations = backend.to_operations()?.expect("the row has fields");
+    let model = proto::ModelId::System(SystemModel::Model);
+    let mut operations = proto::OperationSet::from_backends(BTreeMap::from([("lww".into(), backend_operations)]));
+    operations.push(proto::Operation::Membership(proto::Membership::Add(model)));
+    Ok(proto::Event {
+        collection: proto::CollectionId::fixed_name(ankurah::core::schema::MODEL_COLLECTION_ID),
+        entity_id: EntityId::new(),
+        operations,
+        parent: proto::Clock::default(),
+    })
 }
 
 /// Rows the registration executor wrote as raw LWW events read back through
@@ -73,20 +63,18 @@ async fn executor_rows_read_through_typed_views() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A catalog row committed OUTSIDE the registration executor (a typed
-/// create; `upsert_registered` never sees it) appears in the in-memory
-/// catalog map, delivered by the policy-free reactor subscription.
-/// `commit` awaits `notify_change`, and the feed listener folds inline on
-/// the broadcast, so the map is current when commit returns.
+/// A catalog row committed through the allocator's trusted low-level funnel,
+/// but outside `register_schema` (`upsert_registered` never sees it), appears
+/// in the map through the reactor feed. Ordinary transactions cannot take
+/// this path. `commit_remote_transaction` awaits `notify_change`, so the map
+/// is current when it returns.
 #[tokio::test]
 async fn map_learns_from_the_feed_not_the_executor() -> anyhow::Result<()> {
     let node = durable_sled_setup().await?;
-    let ctx = node.context(DEFAULT_CONTEXT)?;
     node.catalog.wait_catalog_ready().await;
 
-    let trx = ctx.begin();
-    trx.create(&SysModelRow { label: "feed_only".into(), name: "FeedOnly".into() }).await?;
-    trx.commit().await?;
+    let event = model_row_creation("feed_only", "FeedOnly")?;
+    node.commit_remote_transaction(&DEFAULT_CONTEXT, proto::TransactionId::new(), vec![proto::Attested::opt(event, None)]).await?;
 
     let model = node.catalog.model_by_label("feed_only").expect("the reactor feed delivered the row into the map");
     assert_eq!(model.name, "FeedOnly");

--- a/tests/tests/catalog_dogfood.rs
+++ b/tests/tests/catalog_dogfood.rs
@@ -1,7 +1,7 @@
-//! The catalog dogfood spike: the three catalog collections accessed through
-//! ordinary typed Models (core/src/schema/catalog/rows.rs) whose identity is
-//! a compile-time SystemModel. No registration, no catalog lookup, no raw
-//! state-buffer parsing.
+//! The three catalog collections accessed through ordinary typed Models
+//! (core/src/schema/catalog/rows.rs) whose identity is a compile-time
+//! SystemModel. No registration, no catalog lookup, no raw state-buffer
+//! parsing.
 
 mod common;
 use ankurah::core::schema::catalog::rows::{SysModelPropertyRowView, SysModelRow, SysModelRowView, SysPropertyRowView};
@@ -20,14 +20,14 @@ async fn typed_create_into_catalog_collection() -> anyhow::Result<()> {
     let ctx = node.context(DEFAULT_CONTEXT)?;
 
     let trx = ctx.begin();
-    let row = trx.create(&SysModelRow { label: "spike_row".into(), name: "SpikeRow".into() }).await?;
+    let row = trx.create(&SysModelRow { label: "typed_row".into(), name: "TypedRow".into() }).await?;
     let id = row.id();
     trx.commit().await?;
 
-    let fetched = ctx.fetch::<SysModelRowView>("label = 'spike_row'").await?;
+    let fetched = ctx.fetch::<SysModelRowView>("label = 'typed_row'").await?;
     assert_eq!(fetched.len(), 1, "typed fetch finds the typed create");
     assert_eq!(fetched[0].id(), id);
-    assert_eq!(fetched[0].name()?, "SpikeRow");
+    assert_eq!(fetched[0].name()?, "TypedRow");
     use ankurah::model::View;
     assert!(
         fetched[0].entity().has_membership(&ankurah::proto::ModelId::System(SystemModel::Model)),
@@ -36,9 +36,9 @@ async fn typed_create_into_catalog_collection() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The dogfood moment: rows the registration EXECUTOR wrote (forged events,
-/// raw LWW) read back through the typed Views, field for field. One schema
-/// spelling serves both writer and reader.
+/// Rows the registration executor wrote as raw LWW events read back through
+/// the typed Views, field for field: one schema spelling serves both the
+/// executor's writes and typed reads.
 #[tokio::test]
 async fn executor_rows_read_through_typed_views() -> anyhow::Result<()> {
     let node = durable_sled_setup().await?;
@@ -73,11 +73,11 @@ async fn executor_rows_read_through_typed_views() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The map feed proof: a catalog row committed OUTSIDE the registration
-/// executor (a typed create; `upsert_registered` never sees it) appears in
-/// the in-memory catalog map, delivered by the policy-free reactor
-/// subscription. `commit` awaits `notify_change`, and the feed listener
-/// folds inline on the broadcast, so the map is current when commit returns.
+/// A catalog row committed OUTSIDE the registration executor (a typed
+/// create; `upsert_registered` never sees it) appears in the in-memory
+/// catalog map, delivered by the policy-free reactor subscription.
+/// `commit` awaits `notify_change`, and the feed listener folds inline on
+/// the broadcast, so the map is current when commit returns.
 #[tokio::test]
 async fn map_learns_from_the_feed_not_the_executor() -> anyhow::Result<()> {
     let node = durable_sled_setup().await?;

--- a/tests/tests/catalog_dogfood.rs
+++ b/tests/tests/catalog_dogfood.rs
@@ -11,7 +11,7 @@ use common::*;
 use ankurah::model::Mutable as _;
 
 /// A typed create into a catalog collection travels the NORMAL entity path:
-/// first-use ensure short-circuits to the closed system identity, the
+/// first-use ensure short-circuits to the System ID, the
 /// staged membership asserts ModelId::System(Model), and commit-funnel
 /// admissibility accepts it because the collection fact matches.
 #[tokio::test]
@@ -31,7 +31,7 @@ async fn typed_create_into_catalog_collection() -> anyhow::Result<()> {
     use ankurah::model::View;
     assert!(
         fetched[0].entity().has_membership(&ankurah::proto::ModelId::System(SystemModel::Model)),
-        "the row's membership is the closed system identity"
+        "the row's membership is the System ID"
     );
     Ok(())
 }

--- a/tests/tests/catalog_map.rs
+++ b/tests/tests/catalog_map.rs
@@ -39,6 +39,7 @@ fn album_entry(name: &str, backend: &str, value_type: &str, optional: bool) -> p
         label: "album".into(),
         name: "Album".into(),
         explicit_id: None,
+        unique_id: None,
         properties: vec![proto::RegisterProperty {
             name: name.into(),
             renamed_from: None,
@@ -46,6 +47,7 @@ fn album_entry(name: &str, backend: &str, value_type: &str, optional: bool) -> p
             value_type: value_type.into(),
             target_label: None,
             explicit_id: None,
+            unique_id: None,
             optional,
         }],
     }

--- a/tests/tests/catalog_map.rs
+++ b/tests/tests/catalog_map.rs
@@ -91,8 +91,8 @@ fn expect_registered(resp: proto::NodeResponseBody) -> Vec<proto::RegisteredMode
     }
 }
 
-/// The durable fold runs synchronously under the allocator mutex, but the
-/// forwarded-response fold lands in a separate task, so poll until the map
+/// Durable LiveQuery delivery completes synchronously inside commit, but an
+/// ephemeral response fold can land in a separate task, so poll until the map
 /// resolves the given (collection, name) or time out.
 async fn wait_resolve<SE>(node: &Node<SE, PermissiveAgent>, collection: &str, name: &str) -> Option<EntityId>
 where SE: StorageEngine + Send + Sync + 'static {
@@ -250,8 +250,8 @@ async fn durable_map_resolves_after_registration() -> anyhow::Result<()> {
     let models = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, album_request()).await?);
     let (model_id, property_id, membership_id) = (models[0].id, models[0].properties[0].id, models[0].properties[0].membership_id);
 
-    // The executor's synchronous fold resolves the display name to the
-    // allocated id.
+    // The typed feed's synchronous commit delivery resolves the display name
+    // to the allocated id.
     let resolved = wait_resolve(&server, "album", "name").await.expect("catalog should resolve album.name on the durable node");
     assert_eq!(resolved, property_id, "the map resolves to the allocated property id");
 

--- a/tests/tests/catalog_map.rs
+++ b/tests/tests/catalog_map.rs
@@ -1,32 +1,28 @@
-//! The catalog map in its write-only phase.
+//! Integration tests for the per-node schema-catalog service.
 //!
-//! A durable node warms its in-memory catalog map from the three catalog
-//! collections at startup and keeps it fresh by folding its own registrations
-//! synchronously under the allocator mutex; an ephemeral node fills its map
-//! only by folding SchemaRegistered responses. These tests drive
-//! RegisterSchema over the wire (the same schema-less-durable harness as
-//! schema_registration.rs), assert the map resolves to the ids the allocator
-//! handed back, and pin the reset barrier that keeps hard_reset from deleting
-//! storage under an in-flight warm.
-//!
-//! Excised with the read flip (write-only phase): the reactor-fed durable
-//! subscription, the ephemeral relay warm and its generation/deadline/
-//! cancellation semantics, wire-state ingestion with the stale-generation
-//! admission fence, live-query resolution against the map, and resolver
-//! behavior for unwarmed catalogs. Their tests return with that machinery
-//! (successor notes in core/src/schema/catalog.rs).
+//! Here, the **catalog map** is the node-local materialized projection owned
+//! by `CatalogManager`, and the **catalog lifecycle** is its warm, feed,
+//! registration fold, and reset epoch. These tests drive those boundaries
+//! through real durable and ephemeral nodes: they verify allocated ids enter
+//! the projection, reactor updates maintain it, and hard reset either rejects
+//! or drains every old-epoch effect before clearing storage and bindings.
+//! Pure parsing and secondary-index invariants remain unit tests beside the
+//! projection in `core/src/schema/catalog/map.rs`.
 
 mod common;
 use ankurah::core::error::{MutationError, RetrievalError};
+use ankurah::core::property::backend::{LWWBackend, PropertyBackend};
 use ankurah::core::schema::{MODEL_COLLECTION_ID, MODEL_PROPERTY_COLLECTION_ID, PROPERTY_COLLECTION_ID};
 use ankurah::core::storage::{StorageCollection, StorageEngine};
+use ankurah::core::value::Value;
 use ankurah::PropertyId;
 use async_trait::async_trait;
 use common::*;
 use std::{
+    collections::BTreeMap,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
-        Arc,
+        Arc, Barrier,
     },
     time::Duration,
 };
@@ -60,6 +56,22 @@ fn album_request() -> proto::NodeRequestBody {
 /// Register a second property `year` on the album model (incremental).
 fn album_year_request() -> proto::NodeRequestBody {
     proto::NodeRequestBody::RegisterSchema { models: vec![album_entry("year", "lww", "i64", true)] }
+}
+
+fn model_row_creation(label: &str, name: &str) -> anyhow::Result<proto::Event> {
+    let backend = LWWBackend::new();
+    backend.set("label".into(), Some(Value::String(label.into())));
+    backend.set("name".into(), Some(Value::String(name.into())));
+    let backend_operations = backend.to_operations()?.expect("the row has fields");
+    let model = proto::ModelId::System(proto::SystemModel::Model);
+    let mut operations = proto::OperationSet::from_backends(BTreeMap::from([("lww".into(), backend_operations)]));
+    operations.push(proto::Operation::Membership(proto::Membership::Add(model)));
+    Ok(proto::Event {
+        collection: proto::CollectionId::fixed_name(MODEL_COLLECTION_ID),
+        entity_id: EntityId::new(),
+        operations,
+        parent: proto::Clock::default(),
+    })
 }
 
 async fn connected_pair(
@@ -380,6 +392,63 @@ async fn hard_reset_drains_in_flight_durable_catalog_warm() -> anyhow::Result<()
     Ok(())
 }
 
+// An admitted feed callback is an old-epoch effect even after it has sampled
+// the current generation. Reset must drain the callback before clearing the
+// map so it cannot resume afterward and resurrect the delivered row.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hard_reset_drains_admitted_catalog_feed_update() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    node.catalog.wait_catalog_ready().await;
+
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    node.catalog.hook_next_feed_apply({
+        let entered = entered.clone();
+        let release = release.clone();
+        move || {
+            entered.wait();
+            release.wait();
+        }
+    });
+
+    let event = model_row_creation("old_feed", "OldFeed")?;
+    let commit_node = node.clone();
+    let commit = tokio::spawn(async move {
+        commit_node.commit_remote_transaction(&DEFAULT_CONTEXT, proto::TransactionId::new(), vec![proto::Attested::opt(event, None)]).await
+    });
+    let entered_wait = entered.clone();
+    tokio::time::timeout(Duration::from_secs(1), tokio::task::spawn_blocking(move || entered_wait.wait()))
+        .await
+        .expect("feed callback must reach the post-admission pause")
+        .expect("barrier waiter must not panic");
+
+    let reset_node = node.clone();
+    let reset = tokio::spawn(async move { reset_node.system.hard_reset().await });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while node.catalog.registration_epoch_is_current() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("reset must invalidate the epoch before waiting for the feed callback");
+    assert!(!reset.is_finished(), "reset must drain the admitted feed callback before clearing");
+
+    let release_wait = release.clone();
+    tokio::task::spawn_blocking(move || release_wait.wait()).await.expect("release barrier must not panic");
+    tokio::time::timeout(Duration::from_secs(1), commit)
+        .await
+        .expect("feed-producing commit must finish after release")
+        .expect("commit task must not panic")?;
+    tokio::time::timeout(Duration::from_secs(1), reset)
+        .await
+        .expect("reset must finish after the callback drains")
+        .expect("reset task must not panic")?;
+
+    assert_eq!(node.catalog.counts(), (0, 0, 0), "old feed delivery must not survive reset");
+    assert!(node.catalog.model_by_label("old_feed").is_none());
+    Ok(())
+}
+
 // Forwarded registration may remain pending while reset clears the system.
 // Its old response must be rejected at schema ingress, never folded or
 // latched into either the cleared epoch or a replacement epoch.
@@ -436,6 +505,53 @@ async fn hard_reset_rejects_stale_schema_registration_response() -> anyhow::Resu
     assert!(client.catalog.is_ensured("album"));
     assert!(wait_resolve(&client, "album", "name").await.is_some());
 
+    Ok(())
+}
+
+// A response admitted before reset may fold, but reset must wait until both
+// the map update and ensured latch are complete and then clear them together.
+// This pins the former check-then-fold TOCTOU directly.
+#[tokio::test]
+async fn hard_reset_drains_admitted_schema_registration_fold() -> anyhow::Result<()> {
+    let server = durable_sled_setup().await?;
+    let client = ephemeral_sled_setup().await?;
+    let _connection = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    client.catalog.pause_next_registration_fold(entered.clone(), release.clone());
+
+    let registration_client = client.clone();
+    let registration =
+        tokio::spawn(async move { registration_client.catalog.ensure_registered(&DEFAULT_CONTEXT, Album::descriptor()).await });
+    tokio::time::timeout(Duration::from_secs(1), entered.notified())
+        .await
+        .expect("registration response must pause after acquiring its fold lease");
+
+    let reset_client = client.clone();
+    let reset = tokio::spawn(async move { reset_client.system.hard_reset().await });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while client.catalog.registration_epoch_is_current() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("reset must invalidate the epoch before waiting for the fold");
+    assert!(!reset.is_finished(), "reset must drain the admitted response fold before clearing");
+
+    release.notify_one();
+    tokio::time::timeout(Duration::from_secs(1), registration)
+        .await
+        .expect("registration must finish after the fold is released")
+        .expect("registration task must not panic")?;
+    tokio::time::timeout(Duration::from_secs(1), reset)
+        .await
+        .expect("reset must finish after the fold lease drains")
+        .expect("reset task must not panic")?;
+
+    assert_eq!(client.catalog.counts(), (0, 0, 0), "admitted old-epoch fold must be cleared by reset");
+    assert!(!client.catalog.is_ensured("album"), "old-epoch ensured latch must be cleared by reset");
     Ok(())
 }
 

--- a/tests/tests/compile_fail/malformed_system_attr.rs
+++ b/tests/tests/compile_fail/malformed_system_attr.rs
@@ -1,0 +1,14 @@
+//! A `#[model(...)]` attribute value must be a string literal. An unquoted
+//! value is refused outright; silently dropping it would turn an intended
+//! system model into an ordinary one.
+
+use ankurah::Model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Model, Debug, Serialize, Deserialize)]
+#[model(system = Model)]
+pub struct BadSystemAttr {
+    pub name: String,
+}
+
+fn main() {}

--- a/tests/tests/compile_fail/malformed_system_attr.stderr
+++ b/tests/tests/compile_fail/malformed_system_attr.stderr
@@ -1,0 +1,5 @@
+error: #[model(system = ...)] expects a string literal
+ --> tests/compile_fail/malformed_system_attr.rs:9:9
+  |
+9 | #[model(system = Model)]
+  |         ^^^^^^

--- a/tests/tests/compile_fail/model_id_signposts_system.rs
+++ b/tests/tests/compile_fail/model_id_signposts_system.rs
@@ -1,0 +1,15 @@
+//! `#[model(id = "...")]` takes the EntityId of an existing catalog
+//! entity. A value that does not parse as one is refused, and the
+//! diagnostic points at the system attribute (built-in identities are not
+//! catalog entities).
+
+use ankurah::Model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Model, Debug, Serialize, Deserialize)]
+#[model(id = "not-an-entity-id")]
+pub struct WrongKindOfId {
+    pub name: String,
+}
+
+fn main() {}

--- a/tests/tests/compile_fail/model_id_signposts_system.stderr
+++ b/tests/tests/compile_fail/model_id_signposts_system.stderr
@@ -1,0 +1,5 @@
+error: explicit id "not-an-entity-id" is not a valid EntityId encoding: Invalid Length; #[model(id = ...)] takes the EntityId of an existing model catalog entity -- for a built-in system model use #[model(system = "...")]
+  --> tests/compile_fail/model_id_signposts_system.rs:11:12
+   |
+11 | pub struct WrongKindOfId {
+   |            ^^^^^^^^^^^^^

--- a/tests/tests/compile_fail/no_ffi_takes_no_value.rs
+++ b/tests/tests/compile_fail/no_ffi_takes_no_value.rs
@@ -1,0 +1,13 @@
+//! `no_ffi` is deliberately a bare flag, keeping its grammar distinct from
+//! the string-valued `base`, `system`, and `id` options.
+
+use ankurah::Model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Model, Debug, Serialize, Deserialize)]
+#[model(no_ffi = true)]
+pub struct ValuedNoFfi {
+    pub name: String,
+}
+
+fn main() {}

--- a/tests/tests/compile_fail/no_ffi_takes_no_value.stderr
+++ b/tests/tests/compile_fail/no_ffi_takes_no_value.stderr
@@ -1,0 +1,5 @@
+error: #[model(no_ffi)] is a bare flag and does not take a value
+ --> tests/compile_fail/no_ffi_takes_no_value.rs:8:9
+  |
+8 | #[model(no_ffi = true)]
+  |         ^^^^^^

--- a/tests/tests/compile_fail/system_and_id_are_exclusive.rs
+++ b/tests/tests/compile_fail/system_and_id_are_exclusive.rs
@@ -1,0 +1,13 @@
+//! A system model's identity is built in; it cannot also bind a catalog
+//! entity id.
+
+use ankurah::Model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Model, Debug, Serialize, Deserialize)]
+#[model(system = "Model", id = "AAAAAAAAAAAAAAAAAAAAAA")]
+pub struct SystemWithId {
+    pub name: String,
+}
+
+fn main() {}

--- a/tests/tests/compile_fail/system_and_id_are_exclusive.stderr
+++ b/tests/tests/compile_fail/system_and_id_are_exclusive.stderr
@@ -1,0 +1,5 @@
+error: #[model(system = ...)] and #[model(id = ...)] are mutually exclusive: a built-in identity is not a catalog entity
+ --> tests/compile_fail/system_and_id_are_exclusive.rs:9:12
+  |
+9 | pub struct SystemWithId {
+  |            ^^^^^^^^^^^^

--- a/tests/tests/compile_fail/unknown_field_model_option.rs
+++ b/tests/tests/compile_fail/unknown_field_model_option.rs
@@ -1,0 +1,13 @@
+//! Field-level `#[model(...)]` options form a closed vocabulary too. Only
+//! the bare `ephemeral` flag is currently valid on a field.
+
+use ankurah::Model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Model, Debug, Serialize, Deserialize)]
+pub struct UnknownFieldModelOption {
+    #[model(ephemral)]
+    pub scratch: String,
+}
+
+fn main() {}

--- a/tests/tests/compile_fail/unknown_field_model_option.stderr
+++ b/tests/tests/compile_fail/unknown_field_model_option.stderr
@@ -1,0 +1,5 @@
+error: unknown field #[model(...)] option; expected `ephemeral`
+ --> tests/compile_fail/unknown_field_model_option.rs:9:13
+  |
+9 |     #[model(ephemral)]
+  |             ^^^^^^^^

--- a/tests/tests/compile_fail/unknown_model_option.rs
+++ b/tests/tests/compile_fail/unknown_model_option.rs
@@ -1,0 +1,13 @@
+//! Struct-level `#[model(...)]` options form a closed vocabulary. A typo
+//! must not silently discard a schema- or identity-affecting declaration.
+
+use ankurah::Model;
+use serde::{Deserialize, Serialize};
+
+#[derive(Model, Debug, Serialize, Deserialize)]
+#[model(systm = "Model")]
+pub struct UnknownModelOption {
+    pub name: String,
+}
+
+fn main() {}

--- a/tests/tests/compile_fail/unknown_model_option.stderr
+++ b/tests/tests/compile_fail/unknown_model_option.stderr
@@ -1,0 +1,5 @@
+error: unknown #[model(...)] option; expected `base`, `system`, `id`, or `no_ffi`
+ --> tests/compile_fail/unknown_model_option.rs:8:9
+  |
+8 | #[model(systm = "Model")]
+  |         ^^^^^

--- a/tests/tests/derive_compile_fail.rs
+++ b/tests/tests/derive_compile_fail.rs
@@ -1,6 +1,6 @@
 //! Compile-fail coverage for the `#[derive(Model)]` schema attributes:
 //! the reserved collection prefix, the explicit-id shape, and the system
-//! attribute's grammar. trybuild compiles each fixture as its own crate
+//! attribute grammar, including rejection of unknown model options. trybuild compiles each fixture as its own crate
 //! and asserts it fails with the pinned diagnostic in the matching
 //! `.stderr`.
 //!
@@ -18,6 +18,9 @@ fn derive_model_rejections() {
     t.compile_fail("tests/compile_fail/invalid_explicit_id.rs");
     t.compile_fail("tests/compile_fail/noncanonical_explicit_id.rs");
     t.compile_fail("tests/compile_fail/malformed_system_attr.rs");
+    t.compile_fail("tests/compile_fail/unknown_model_option.rs");
+    t.compile_fail("tests/compile_fail/unknown_field_model_option.rs");
+    t.compile_fail("tests/compile_fail/no_ffi_takes_no_value.rs");
     t.compile_fail("tests/compile_fail/system_and_id_are_exclusive.rs");
     t.compile_fail("tests/compile_fail/model_id_signposts_system.rs");
 }

--- a/tests/tests/derive_compile_fail.rs
+++ b/tests/tests/derive_compile_fail.rs
@@ -1,7 +1,8 @@
 //! Compile-fail coverage for the `#[derive(Model)]` schema attributes:
-//! the reserved collection prefix and the explicit-id shape. trybuild
-//! compiles each fixture as its own crate and asserts it fails with the
-//! pinned diagnostic in the matching `.stderr`.
+//! the reserved collection prefix, the explicit-id shape, and the system
+//! attribute's grammar. trybuild compiles each fixture as its own crate
+//! and asserts it fails with the pinned diagnostic in the matching
+//! `.stderr`.
 //!
 //! Kept behind `cfg(not(miri))` and gated on a stable-ish message: the
 //! error strings are our own (the reserved-prefix message and the
@@ -16,4 +17,7 @@ fn derive_model_rejections() {
     t.compile_fail("tests/compile_fail/reserved_collection_prefix.rs");
     t.compile_fail("tests/compile_fail/invalid_explicit_id.rs");
     t.compile_fail("tests/compile_fail/noncanonical_explicit_id.rs");
+    t.compile_fail("tests/compile_fail/malformed_system_attr.rs");
+    t.compile_fail("tests/compile_fail/system_and_id_are_exclusive.rs");
+    t.compile_fail("tests/compile_fail/model_id_signposts_system.rs");
 }

--- a/tests/tests/protected_collections.rs
+++ b/tests/tests/protected_collections.rs
@@ -3,6 +3,7 @@
 //! prefix is reserved.
 
 mod common;
+use ankurah::core::schema::catalog::rows::SysModelRow;
 use common::*;
 
 const PROTECTED: [&str; 4] = ["_ankurah_system", "_ankurah_model", "_ankurah_property", "_ankurah_model_property"];
@@ -42,14 +43,21 @@ async fn server_refuses_commits_into_protected_collections() -> anyhow::Result<(
     Ok(())
 }
 
-// NOTE: the local-transaction path into a protected collection (the
-// `commit_local_trx` guard, core/src/context.rs) is no longer reachable
-// through the public API: a user model whose collection carries the
-// reserved `_ankurah_` prefix is now REFUSED at derive time, so a struct
-// like `_ankurah_model` cannot be defined at all. That compile-time
-// rejection is exercised by the trybuild fixture
-// `tests/tests/compile_fail/reserved_collection_prefix.rs`
-// (see `derive_compile_fail.rs`). The runtime `commit_local_trx` guard
-// remains in place as structural defense-in-depth; the receiver-side guard
-// for all four protected collections is exercised by
-// `server_refuses_commits_into_protected_collections` above.
+/// The built-in typed catalog rows are public for typed reads, but their
+/// system identity must not turn an ordinary local transaction into a second
+/// registration path.
+#[tokio::test]
+async fn local_transaction_refuses_typed_catalog_write() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    let context = node.context(DEFAULT_CONTEXT)?;
+
+    let transaction = context.begin();
+    transaction.create(&SysModelRow { label: "blocked".into(), name: "Blocked".into() }).await?;
+    let error = transaction.commit().await.expect_err("ordinary catalog mutation must be rejected");
+    let message = error.to_string();
+    assert!(message.contains("protected"), "unexpected refusal: {message}");
+    assert!(message.contains("_ankurah_model"), "refusal should identify the collection: {message}");
+    assert!(node.catalog.model_by_label("blocked").is_none(), "rejected row must not reach the catalog map");
+
+    Ok(())
+}

--- a/tests/tests/schema_descriptor.rs
+++ b/tests/tests/schema_descriptor.rs
@@ -1,17 +1,12 @@
-//! The compiled schema `#[derive(Model)]` emits: the normative mapping,
-//! rename hints, and explicit-id bindings. Asserts the
-//! NORMATIVE (backend, value_type) mapping row-by-row, the renamed_from and
-//! explicit-id attributes, ephemeral exclusion, and the RegisterSchema
-//! descriptor conversion. Ends with an end-to-end registration built from a
-//! Model::descriptor() and driven through the durable/ephemeral harness, sourcing
-//! the allocated ids from the SchemaRegistered response.
+//! The compiled schema emitted by `#[derive(Model)]`.
 //!
-//! Excised with the read flip (write-only catalog phase): the bound-property
-//! half -- explicit ids driving derived accessors, query aliases, ambiguity
-//! rejection, and the offline fully-bound reassertion. Those read app
-//! entities by property id and preseed DDL-authored definitions the map
-//! only learns through the excised reactor feed; they return with the
-//! propertyid-resolution PR (successor notes in core/src/schema/catalog.rs).
+//! Here, a **descriptor** is one binary's static model declaration: source
+//! label and name, normative backend/value-type facts, optionality, reference
+//! targets, explicit bindings, rename hints, and source-derived unique IDs.
+//! These tests verify that derive output and its `RegisterModel` conversion,
+//! including path hygiene across user modules. Durable allocation and catalog
+//! projection behavior belong to the registration and catalog suites; the
+//! end-to-end cases here only prove descriptors enter that public path intact.
 
 mod common;
 use ankurah::property::{Json, Ref};
@@ -30,6 +25,25 @@ const MEMBERSHIP: &str = "_ankurah_model_property";
 #[derive(Model, Debug, Serialize, Deserialize)]
 pub struct DescArtist {
     pub name: String,
+}
+
+/// Spelling the default generated-code base explicitly must not select the
+/// derive crate's internal `crate::...` active-type paths.
+#[derive(Model, Debug, Serialize, Deserialize)]
+#[model(base = "::ankurah::core")]
+pub struct DescExplicitDefaultBase {
+    pub name: String,
+}
+
+mod shared_user_module {
+    use super::*;
+
+    /// Exercises the derive's hidden module-path constant through its nested
+    /// hygiene module rather than deriving only at the integration-crate root.
+    #[derive(Model, Debug, Serialize, Deserialize)]
+    pub struct NestedDescriptor {
+        pub title: String,
+    }
 }
 
 /// A model exercising EVERY row of the normative mapping table, plus
@@ -220,6 +234,17 @@ fn unique_ids_are_derived_distinct_and_carried_on_the_wire() {
     for (entry, f) in model.properties.iter().zip(schema.properties) {
         assert_eq!(entry.unique_id, Some(f.unique_id), "wire field id for {}", f.field);
     }
+}
+
+#[test]
+fn explicit_default_base_and_nested_module_hygiene_compile_and_describe_the_source() {
+    let explicit_base = DescExplicitDefaultBase::descriptor();
+    assert_eq!(explicit_base.properties[0].backend, "yrs");
+
+    let nested = shared_user_module::NestedDescriptor::descriptor();
+    let declaring_module = concat!(module_path!(), "::shared_user_module");
+    assert_eq!(nested.unique_id, proto::UniqueStructId::from_names(declaring_module, "NestedDescriptor"));
+    assert_eq!(nested.properties[0].unique_id, proto::UniqueFieldId::from_names(declaring_module, "NestedDescriptor", "title"));
 }
 
 // -- end-to-end registration through the harness -----------------------------

--- a/tests/tests/schema_descriptor.rs
+++ b/tests/tests/schema_descriptor.rs
@@ -193,6 +193,35 @@ fn register_model_honors_explicit_ids() {
     assert_eq!(other.explicit_id, None, "unbound field looks up by name");
 }
 
+// -- unique ids ---------------------------------------------------------------
+
+/// The derive hashes a deterministic unique id for the struct and each
+/// active field from the DECLARING module's path and the declared names --
+/// recomputing from this module's own `module_path!()` must reproduce them
+/// exactly (which also proves no derive-internal module segment leaks into
+/// the hash input). All field ids are distinct, structs in the same module
+/// get distinct ids, and the wire conversion supplies every id as `Some`.
+#[test]
+fn unique_ids_are_derived_distinct_and_carried_on_the_wire() {
+    let schema = DescAllTypes::descriptor();
+    assert_eq!(schema.unique_id, proto::UniqueStructId::from_names(module_path!(), "DescAllTypes"));
+
+    let mut seen = std::collections::BTreeSet::new();
+    for f in schema.properties {
+        assert_eq!(f.unique_id, proto::UniqueFieldId::from_names(module_path!(), "DescAllTypes", f.field), "field id for {}", f.field);
+        assert!(seen.insert(f.unique_id), "field ids must be distinct; {} repeats one", f.field);
+    }
+
+    // Same module, different struct: distinct struct ids.
+    assert_ne!(schema.unique_id, DescArtist::descriptor().unique_id);
+
+    let model = proto::RegisterModel::from(schema);
+    assert_eq!(model.unique_id, Some(schema.unique_id), "wire model id supplied");
+    for (entry, f) in model.properties.iter().zip(schema.properties) {
+        assert_eq!(entry.unique_id, Some(f.unique_id), "wire field id for {}", f.field);
+    }
+}
+
 // -- end-to-end registration through the harness -----------------------------
 
 async fn catalog_values(

--- a/tests/tests/schema_registration.rs
+++ b/tests/tests/schema_registration.rs
@@ -33,6 +33,7 @@ fn property(name: &str, renamed_from: Option<&str>, backend: &str, value_type: &
         value_type: value_type.into(),
         target_label: None,
         explicit_id: None,
+        unique_id: None,
         optional: false,
     }
 }
@@ -40,7 +41,7 @@ fn property(name: &str, renamed_from: Option<&str>, backend: &str, value_type: &
 /// One album model whose entries are the given properties (the nesting is
 /// the membership assertion).
 fn album_model(properties: Vec<proto::RegisterProperty>) -> proto::RegisterModel {
-    proto::RegisterModel { label: "album".into(), name: "Album".into(), explicit_id: None, properties }
+    proto::RegisterModel { label: "album".into(), name: "Album".into(), explicit_id: None, unique_id: None, properties }
 }
 
 fn album_request() -> proto::NodeRequestBody {
@@ -150,6 +151,44 @@ async fn registration_is_idempotent() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The wire's optional compile-time unique ids are hints the executor
+/// accepts and ignores: a request carrying them registers, and the same
+/// declaration without them resolves to the same catalog identities, so the
+/// hint participates in nothing. (Every other test in this suite sends
+/// `None`, which is the other half of the tolerance.)
+#[tokio::test]
+async fn unique_id_hints_are_accepted_and_ignored() -> anyhow::Result<()> {
+    let (server, client, _conn) = connected_pair().await?;
+
+    let hinted = proto::NodeRequestBody::RegisterSchema {
+        models: vec![proto::RegisterModel {
+            label: "album".into(),
+            name: "Album".into(),
+            explicit_id: None,
+            unique_id: Some(proto::UniqueStructId::from_names("some_app::records", "Album")),
+            properties: vec![proto::RegisterProperty {
+                name: "name".into(),
+                renamed_from: None,
+                backend: "yrs".into(),
+                value_type: "string".into(),
+                target_label: None,
+                explicit_id: None,
+                unique_id: Some(proto::UniqueFieldId::from_names("some_app::records", "Album", "name")),
+                optional: false,
+            }],
+        }],
+    };
+    let first = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, hinted).await?);
+    let (model_id, property_id) = (first[0].id, first[0].properties[0].id);
+
+    // The identical declaration WITHOUT hints lands on the same identities.
+    let second = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, album_request()).await?);
+    assert_eq!(second[0].id, model_id, "unique-id hints must not participate in model identity");
+    assert_eq!(second[0].properties[0].id, property_id, "unique-id hints must not participate in property identity");
+
+    Ok(())
+}
+
 /// The renamed_from hint moves the lineage to the new name
 /// WITHOUT re-keying (same property id), and no-ops once applied.
 #[tokio::test]
@@ -190,6 +229,7 @@ async fn target_model_can_be_cleared_retargeted_and_cleared_on_rename() -> anyho
             value_type: "entityid".into(),
             target_label: Some("artist".into()),
             explicit_id: None,
+            unique_id: None,
             optional: false,
         }])],
     };
@@ -205,6 +245,7 @@ async fn target_model_can_be_cleared_retargeted_and_cleared_on_rename() -> anyho
             value_type: "entityid".into(),
             target_label: None,
             explicit_id: None,
+            unique_id: None,
             optional: false,
         }])],
     };
@@ -221,6 +262,7 @@ async fn target_model_can_be_cleared_retargeted_and_cleared_on_rename() -> anyho
             value_type: "entityid".into(),
             target_label: Some("artist".into()),
             explicit_id: None,
+            unique_id: None,
             optional: false,
         }])],
     };
@@ -235,6 +277,7 @@ async fn target_model_can_be_cleared_retargeted_and_cleared_on_rename() -> anyho
             value_type: "entityid".into(),
             target_label: None,
             explicit_id: None,
+            unique_id: None,
             optional: false,
         }])],
     };
@@ -434,7 +477,13 @@ async fn model_display_name_renames_and_reverts() -> anyhow::Result<()> {
     assert_eq!(model.get("name"), Some(&Some(Value::String("Album".into()))));
 
     let rename = |name: &str| proto::NodeRequestBody::RegisterSchema {
-        models: vec![proto::RegisterModel { label: "album".into(), name: name.into(), explicit_id: None, properties: vec![] }],
+        models: vec![proto::RegisterModel {
+            label: "album".into(),
+            name: name.into(),
+            explicit_id: None,
+            unique_id: None,
+            properties: vec![],
+        }],
     };
 
     let resolved = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, rename("Discography")).await?);
@@ -465,6 +514,7 @@ async fn target_collection_resolves_and_allocates_on_miss() -> anyhow::Result<()
             value_type: "entityid".into(),
             target_label: Some("artist".into()),
             explicit_id: None,
+            unique_id: None,
             optional: false,
         }])],
     };
@@ -499,6 +549,7 @@ async fn explicit_id_binding_and_sharing() -> anyhow::Result<()> {
             label: "playlist".into(),
             name: "Playlist".into(),
             explicit_id: None,
+            unique_id: None,
             properties: vec![proto::RegisterProperty {
                 name: "name".into(),
                 renamed_from: None,
@@ -506,6 +557,7 @@ async fn explicit_id_binding_and_sharing() -> anyhow::Result<()> {
                 value_type: "string".into(),
                 target_label: None,
                 explicit_id: Some(property_id),
+                unique_id: None,
                 optional: true,
             }],
         }],
@@ -527,6 +579,7 @@ async fn explicit_id_binding_and_sharing() -> anyhow::Result<()> {
             value_type: "string".into(),
             target_label: None,
             explicit_id: Some(EntityId::new()),
+            unique_id: None,
             optional: false,
         }])],
     };
@@ -541,6 +594,7 @@ async fn explicit_id_binding_and_sharing() -> anyhow::Result<()> {
             value_type: "i64".into(),
             target_label: None,
             explicit_id: Some(property_id),
+            unique_id: None,
             optional: false,
         }])],
     };
@@ -571,6 +625,7 @@ async fn explicit_id_binding_rejects_non_catalog_entities() -> anyhow::Result<()
             value_type: "string".into(),
             target_label: None,
             explicit_id: Some(ordinary_id),
+            unique_id: None,
             optional: false,
         }])],
     };
@@ -581,6 +636,7 @@ async fn explicit_id_binding_rejects_non_catalog_entities() -> anyhow::Result<()
             label: "ordinary".into(),
             name: "Ordinary".into(),
             explicit_id: Some(ordinary_id),
+            unique_id: None,
             properties: vec![],
         }],
     };
@@ -604,6 +660,7 @@ async fn explicit_id_binding_accepts_castable_type_drift() -> anyhow::Result<()>
             label: "playlist".into(),
             name: "Playlist".into(),
             explicit_id: None,
+            unique_id: None,
             properties: vec![proto::RegisterProperty {
                 name: "year".into(),
                 renamed_from: None,
@@ -611,6 +668,7 @@ async fn explicit_id_binding_accepts_castable_type_drift() -> anyhow::Result<()>
                 value_type: "i64".into(),
                 target_label: None,
                 explicit_id: Some(property_id),
+                unique_id: None,
                 optional: false,
             }],
         }],
@@ -637,6 +695,7 @@ async fn dangling_explicit_property_refuses_before_writes() -> anyhow::Result<()
             label: "dangling".into(),
             name: "Dangling".into(),
             explicit_id: None,
+            unique_id: None,
             properties: vec![proto::RegisterProperty {
                 name: "ghost".into(),
                 renamed_from: None,
@@ -644,6 +703,7 @@ async fn dangling_explicit_property_refuses_before_writes() -> anyhow::Result<()
                 value_type: "string".into(),
                 target_label: None,
                 explicit_id: Some(missing),
+                unique_id: None,
                 optional: false,
             }],
         }],
@@ -664,7 +724,7 @@ async fn explicit_model_id_binding() -> anyhow::Result<()> {
     let album_model = first[0].id;
 
     let bind = |label: &str, explicit_id, properties| proto::NodeRequestBody::RegisterSchema {
-        models: vec![proto::RegisterModel { label: label.into(), name: label.into(), explicit_id, properties }],
+        models: vec![proto::RegisterModel { label: label.into(), name: label.into(), explicit_id, unique_id: None, properties }],
     };
 
     // Binding an id that does not exist never mints.
@@ -682,6 +742,7 @@ async fn explicit_model_id_binding() -> anyhow::Result<()> {
         value_type: "string".into(),
         target_label: None,
         explicit_id: None,
+        unique_id: None,
         optional: false,
     };
     let bound = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, bind("album", Some(album_model), vec![genre])).await?);
@@ -882,7 +943,13 @@ async fn check_schema_registration_gates_creates() -> anyhow::Result<()> {
     client.system.wait_system_ready().await;
 
     let forbidden = proto::NodeRequestBody::RegisterSchema {
-        models: vec![proto::RegisterModel { label: "forbidden".into(), name: "Forbidden".into(), explicit_id: None, properties: vec![] }],
+        models: vec![proto::RegisterModel {
+            label: "forbidden".into(),
+            name: "Forbidden".into(),
+            explicit_id: None,
+            unique_id: None,
+            properties: vec![],
+        }],
     };
     expect_error(client.request(server.id, &DEFAULT_CONTEXT, forbidden).await?, "policy");
     assert!(server.catalog.model_by_label("forbidden").is_none(), "a refused plan emits nothing");
@@ -1029,7 +1096,13 @@ async fn reserved_collection_prefix_refuses_registration() -> anyhow::Result<()>
     // under the prefix: the rule is the prefix, not an allowlist).
     for collection in ["_ankurah_model", "_ankurah_custom"] {
         let as_model = proto::NodeRequestBody::RegisterSchema {
-            models: vec![proto::RegisterModel { label: collection.into(), name: "Model".into(), explicit_id: None, properties: vec![] }],
+            models: vec![proto::RegisterModel {
+                label: collection.into(),
+                name: "Model".into(),
+                explicit_id: None,
+                unique_id: None,
+                properties: vec![],
+            }],
         };
         expect_error(client.request(server.id, &DEFAULT_CONTEXT, as_model).await?, "reserved prefix");
     }
@@ -1048,6 +1121,7 @@ async fn reserved_collection_prefix_refuses_registration() -> anyhow::Result<()>
             value_type: "entity_ref".into(),
             target_label: Some("_ankurah_model".into()),
             explicit_id: None,
+            unique_id: None,
             optional: false,
         }])],
     };

--- a/tests/tests/schema_registration.rs
+++ b/tests/tests/schema_registration.rs
@@ -6,8 +6,9 @@
 //! repeats are pure no-ops, rename hints move lineages without re-keying,
 //! retypes never fork (a castable declaration reuses the identity against
 //! the CANONICAL value_type, a non-castable one refuses; as
-//! amended 2026-07-10), and the exists-aware policy verb gates actual
-//! creations.
+//! amended 2026-07-10). Request authentication admits registration RPCs;
+//! accepted catalog materialization runs as local SystemRoot work rather
+//! than application-policy work.
 
 mod common;
 use ankurah::core::property::backend::{LWWBackend, PropertyBackend};
@@ -20,10 +21,6 @@ const PROPERTY: &str = "_ankurah_property";
 const MEMBERSHIP: &str = "_ankurah_model_property";
 
 type TestNode = Node<SledStorageEngine, PermissiveAgent>;
-
-fn catalog_model(collection: &str) -> ankurah::ModelId {
-    ankurah::core::schema::system_model_id(collection).expect("catalog helper only accepts built-in collection labels")
-}
 
 fn property(name: &str, renamed_from: Option<&str>, backend: &str, value_type: &str) -> proto::RegisterProperty {
     proto::RegisterProperty {
@@ -685,7 +682,7 @@ async fn explicit_id_binding_accepts_castable_type_drift() -> anyhow::Result<()>
 /// A dangling membership is unrepresentable under nesting (there is no
 /// membership item to point at nothing), so the surviving refusal is the
 /// explicit property binding: an unknown id rejects the whole request
-/// before any of its planned creations commit.
+/// before any staged creation commits.
 #[tokio::test]
 async fn dangling_explicit_property_refuses_before_writes() -> anyhow::Result<()> {
     let (server, client, _conn) = connected_pair().await?;
@@ -710,7 +707,7 @@ async fn dangling_explicit_property_refuses_before_writes() -> anyhow::Result<()
     };
 
     expect_error(client.request(server.id, &DEFAULT_CONTEXT, request).await?, "does not exist");
-    assert_eq!(server.catalog.model_id_for("dangling"), None, "planned model creation must not commit on refusal");
+    assert_eq!(server.catalog.model_id_for("dangling"), None, "staged model creation must not commit on refusal");
 
     Ok(())
 }
@@ -764,21 +761,27 @@ async fn ephemeral_node_refuses_execution() -> anyhow::Result<()> {
     Ok(())
 }
 
-// -- the exists-aware policy verb ---------------
+// -- the SystemRoot policy boundary ---------------
 
-/// One configurable PermissiveAgent clone driving every policy-verb test in
-/// this file. It is permissive everywhere except the customization points the
-/// tests exercise: a schema plan gate, a per-event gate, a collection-access
-/// gate, and an optional name-keyed catalog filter. A `Default` instance is
-/// fully permissive -- the inert client side.
+/// A PolicyAgent that can turn every application-policy touch of a catalog
+/// collection into a counted denial. SystemRoot catalog work must never call
+/// any of these hooks; a `Default` instance remains fully permissive for the
+/// inert client side.
 #[derive(Clone, Default)]
 struct ProbeAgent {
-    on_schema_registration:
-        Option<std::sync::Arc<dyn Fn(&ankurah::policy::RegistrationPlan) -> Result<(), ankurah::policy::AccessDenied> + Send + Sync>>,
-    on_event:
-        Option<std::sync::Arc<dyn Fn(&proto::CollectionId, &proto::Event) -> Result<(), ankurah::policy::AccessDenied> + Send + Sync>>,
-    on_collection_access: Option<std::sync::Arc<dyn Fn(&proto::CollectionId) -> Result<(), ankurah::policy::AccessDenied> + Send + Sync>>,
-    filter_catalog_properties: bool,
+    catalog_policy_calls: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+}
+
+impl ProbeAgent {
+    fn reject_catalog_policy_call(&self, collection: &proto::CollectionId) -> Result<(), ankurah::policy::AccessDenied> {
+        if collection.as_str().starts_with(ankurah::core::schema::RESERVED_COLLECTION_PREFIX) {
+            if let Some(calls) = &self.catalog_policy_calls {
+                calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                return Err(ankurah::policy::AccessDenied::ByPolicy("catalog infrastructure must bypass application policy"));
+            }
+        }
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -817,22 +820,8 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
         _entity_after: &ankurah::core::entity::Entity,
         event: &proto::Event,
     ) -> Result<Option<proto::Attestation>, ankurah::policy::AccessDenied> {
-        if let Some(hook) = &self.on_event {
-            hook(&event.collection, event)?;
-        }
+        self.reject_catalog_policy_call(&event.collection)?;
         Ok(None)
-    }
-
-    fn check_schema_registration<SE: ankurah::core::storage::StorageEngine>(
-        &self,
-        _node: &Node<SE, Self>,
-        _cdata: &Self::ContextData,
-        plan: &ankurah::policy::RegistrationPlan,
-    ) -> Result<(), ankurah::policy::AccessDenied> {
-        if let Some(hook) = &self.on_schema_registration {
-            hook(plan)?;
-        }
-        Ok(())
     }
 
     fn validate_received_event<SE: ankurah::core::storage::StorageEngine>(
@@ -847,8 +836,13 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
     fn attest_state<SE: ankurah::core::storage::StorageEngine>(
         &self,
         _node: &Node<SE, Self>,
-        _state: &proto::EntityState,
+        state: &proto::EntityState,
     ) -> Option<proto::Attestation> {
+        if state.collection.as_str().starts_with(ankurah::core::schema::RESERVED_COLLECTION_PREFIX) {
+            if let Some(calls) = &self.catalog_policy_calls {
+                calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
         None
     }
 
@@ -863,10 +857,7 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
 
     fn can_access_collection<C>(&self, _data: &C, collection: &proto::CollectionId) -> Result<(), ankurah::policy::AccessDenied>
     where C: ankurah::core::util::Iterable<Self::ContextData> {
-        if let Some(hook) = &self.on_collection_access {
-            hook(collection)?;
-        }
-        Ok(())
+        self.reject_catalog_policy_call(collection)
     }
 
     fn filter_predicate<C>(
@@ -878,10 +869,7 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
     where
         C: ankurah::core::util::Iterable<Self::ContextData>,
     {
-        if self.filter_catalog_properties && collection.as_str() == ankurah::core::schema::PROPERTY_COLLECTION_ID {
-            let name_filter = ankql::parser::parse_selection("name != '__never__'").expect("static catalog policy filter parses").predicate;
-            return Ok(ankql::ast::Predicate::And(Box::new(predicate), Box::new(name_filter)));
-        }
+        self.reject_catalog_policy_call(collection)?;
         Ok(predicate)
     }
 
@@ -889,13 +877,13 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
         &self,
         _data: &C,
         _id: &proto::EntityId,
-        _collection: &proto::CollectionId,
+        collection: &proto::CollectionId,
         _state: &proto::State,
     ) -> Result<(), ankurah::policy::AccessDenied>
     where
         C: ankurah::core::util::Iterable<Self::ContextData>,
     {
-        Ok(())
+        self.reject_catalog_policy_call(collection)
     }
 
     fn check_read_event<C>(&self, _data: &C, _event: &proto::Attested<proto::Event>) -> Result<(), ankurah::policy::AccessDenied>
@@ -906,10 +894,10 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
     fn check_write(
         &self,
         _context: &Self::ContextData,
-        _entity: &ankurah::core::entity::Entity,
+        entity: &ankurah::core::entity::Entity,
         _event: Option<&proto::Event>,
     ) -> Result<(), ankurah::policy::AccessDenied> {
-        Ok(())
+        self.reject_catalog_policy_call(entity.collection())
     }
 
     fn validate_causal_assertion<SE: ankurah::core::storage::StorageEngine>(
@@ -922,77 +910,31 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
     }
 }
 
-/// The exists-aware gate: a plan that would CREATE a forbidden definition
-/// is refused BEFORE anything is emitted (no catalog entities appear), and
-/// an unrelated registration on the same node passes.
+/// Catalog warming, typed lookups, `Mutable` writes, commit validation, and
+/// state publication all run under SystemRoot. The application PolicyAgent
+/// is still the request-authentication boundary, but is never consulted for
+/// those local catalog operations.
 #[tokio::test]
-async fn check_schema_registration_gates_creates() -> anyhow::Result<()> {
-    let deny_forbidden = ProbeAgent {
-        on_schema_registration: Some(std::sync::Arc::new(|plan: &ankurah::policy::RegistrationPlan| {
-            if plan.creates_models.iter().any(|(_, m)| m.label == "forbidden") {
-                return Err(ankurah::policy::AccessDenied::ByPolicy("schema definition for 'forbidden' is not writable"));
-            }
-            Ok(())
-        })),
-        ..Default::default()
-    };
-    let server = Node::new_durable(std::sync::Arc::new(SledStorageEngine::new_test().unwrap()), deny_forbidden.clone());
-    server.system.create().await?;
-    let client = Node::new(std::sync::Arc::new(SledStorageEngine::new_test().unwrap()), deny_forbidden);
-    let _conn = LocalProcessConnection::new(&server, &client).await?;
-    client.system.wait_system_ready().await;
-
-    let forbidden = proto::NodeRequestBody::RegisterSchema {
-        models: vec![proto::RegisterModel {
-            label: "forbidden".into(),
-            name: "Forbidden".into(),
-            explicit_id: None,
-            unique_id: None,
-            properties: vec![],
-        }],
-    };
-    expect_error(client.request(server.id, &DEFAULT_CONTEXT, forbidden).await?, "policy");
-    assert!(server.catalog.model_by_label("forbidden").is_none(), "a refused plan emits nothing");
-
-    // An unrelated collection passes the same gate.
-    expect_registered(client.request(server.id, &DEFAULT_CONTEXT, album_request()).await?);
-    assert!(server.catalog.model_by_label("album").is_some());
-
-    Ok(())
-}
-
-/// The policy verb fires once for a plan with effects and is SKIPPED for a
-/// pure no-op re-registration (REN 2 second ruling: predicate-resolution
-/// paths lean on the upsert's idempotence, so a no-op registration must not consult the
-/// agent -- zero events, zero policy calls, full definitions returned).
-#[tokio::test]
-async fn policy_verb_skipped_on_noop_reregistration() -> anyhow::Result<()> {
+async fn system_root_catalog_work_bypasses_application_policy() -> anyhow::Result<()> {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let count = std::sync::Arc::new(AtomicUsize::new(0));
-    let counting = {
-        let count = count.clone();
-        ProbeAgent {
-            on_schema_registration: Some(std::sync::Arc::new(move |_plan: &ankurah::policy::RegistrationPlan| {
-                count.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            })),
-            ..Default::default()
-        }
-    };
-    let server = Node::new_durable(std::sync::Arc::new(SledStorageEngine::new_test().unwrap()), counting.clone());
+    let calls = std::sync::Arc::new(AtomicUsize::new(0));
+    let server = Node::new_durable(
+        std::sync::Arc::new(SledStorageEngine::new_test().unwrap()),
+        ProbeAgent { catalog_policy_calls: Some(calls.clone()) },
+    );
     server.system.create().await?;
-    let client = Node::new(std::sync::Arc::new(SledStorageEngine::new_test().unwrap()), counting);
+    let client = Node::new(std::sync::Arc::new(SledStorageEngine::new_test().unwrap()), ProbeAgent::default());
     let _conn = LocalProcessConnection::new(&server, &client).await?;
     client.system.wait_system_ready().await;
 
-    let models1 = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, album_request()).await?);
-    assert_eq!(count.load(Ordering::SeqCst), 1, "a plan with creates consults the agent exactly once");
-
-    let models2 = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, album_request()).await?);
-    assert_eq!(count.load(Ordering::SeqCst), 1, "a pure no-op re-registration skips the policy verb");
-    assert_eq!(models1[0].id, models2[0].id, "the skipped no-op still returns the same ids");
-    assert_eq!(models1[0].properties[0].id, models2[0].properties[0].id, "the skipped no-op still returns the same ids");
+    let models = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, album_request()).await?);
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].properties.len(), 1);
+    assert_eq!(count_rows(&server, MODEL).await?, 1);
+    assert_eq!(count_rows(&server, PROPERTY).await?, 1);
+    assert_eq!(count_rows(&server, MEMBERSHIP).await?, 1);
+    assert_eq!(calls.load(Ordering::SeqCst), 0, "SystemRoot catalog work must not touch application policy");
 
     Ok(())
 }
@@ -1005,8 +947,8 @@ where PA: ankurah::policy::PolicyAgent + Send + Sync + 'static {
 }
 
 /// Duplicate descriptors inside ONE request must coalesce onto a single
-/// allocation (the in-flight tables are consulted before the catalog map,
-/// which only learns this request's ids at the post-commit fold).
+/// allocation (the request-local tables are consulted before the catalog
+/// LiveQueries learn this request's ids from the commit).
 #[tokio::test]
 async fn duplicate_descriptors_in_one_request_do_not_double_allocate() -> anyhow::Result<()> {
     let (server, client, _conn) = connected_pair().await?;
@@ -1028,65 +970,13 @@ async fn duplicate_descriptors_in_one_request_do_not_double_allocate() -> anyhow
     Ok(())
 }
 
-/// The interim commit contract (accepted by maintainer ruling 2026-07-06;
-/// #313 tracks the transactional upgrade): the commit batch is not
-/// transactional, so a mid-batch policy denial aborts the REMAINDER while
-/// earlier catalog events stay durable. The allocator's storage-checked
-/// lookups keep identity convergent across such partials: the retry finds
-/// the existing model row instead of double-allocating, and completes the
-/// property and membership. Batch atomicity returns with the StorageEngine
-/// PR, and this test's first phase tightens with it.
-#[tokio::test]
-async fn registration_policy_denial_aborts_the_remainder_and_heals_on_retry() -> anyhow::Result<()> {
-    let armed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-    let deny_property_once = {
-        let armed = armed.clone();
-        ProbeAgent {
-            on_event: Some(std::sync::Arc::new(move |collection: &proto::CollectionId, _event: &proto::Event| {
-                // The built-in property catalog routes by its system name.
-                if collection.as_str() == ankurah::core::schema::PROPERTY_COLLECTION_ID
-                    && armed.swap(false, std::sync::atomic::Ordering::SeqCst)
-                {
-                    return Err(ankurah::policy::AccessDenied::ByPolicy("property event denied once"));
-                }
-                Ok(())
-            })),
-            ..Default::default()
-        }
-    };
-    let server = Node::new_durable(std::sync::Arc::new(SledStorageEngine::new_test().unwrap()), deny_property_once);
-    server.system.create().await?;
-    let client = Node::new(std::sync::Arc::new(SledStorageEngine::new_test().unwrap()), ProbeAgent::default());
-    let _conn = LocalProcessConnection::new(&server, &client).await?;
-    client.system.wait_system_ready().await;
-
-    // First attempt: the model event commits, then the property event is
-    // denied mid-batch, aborting the remainder. The model row stays durable
-    // (the interim non-transactional contract).
-    expect_error(client.request(server.id, &DEFAULT_CONTEXT, album_request()).await?, "denied");
-    assert_eq!(count_rows(&server, MODEL).await?, 1, "the already-committed model row stays durable");
-    assert_eq!(count_rows(&server, PROPERTY).await?, 0, "the denied property event must not be durable");
-    assert_eq!(count_rows(&server, MEMBERSHIP).await?, 0, "the aborted remainder leaves no membership row");
-
-    // Retry (agent now allows): the existing model is found, not re-minted,
-    // and the property and membership complete.
-    let models = expect_registered(client.request(server.id, &DEFAULT_CONTEXT, album_request()).await?);
-    assert_eq!(count_rows(&server, MODEL).await?, 1, "the retry reuses the existing model row, no double allocation");
-    assert_eq!(count_rows(&server, PROPERTY).await?, 1, "the retry completes the property");
-    assert_eq!(count_rows(&server, MEMBERSHIP).await?, 1, "and the membership");
-    assert_eq!(models.len(), 1);
-    assert_eq!(models[0].properties.len(), 1);
-
-    Ok(())
-}
-
 /// No legitimate registration names a reserved collection: the system and
 /// catalog collections route by name and have no catalog model entities of
 /// their own, so a descriptor naming one could only route ordinary traffic into a
 /// protected collection. The executor refuses the reserved prefix in every
 /// position a request can name a collection -- the model itself, a
 /// property's minting or target collection, and a membership -- up front,
-/// before policy, lookups, or writes (the executor-side twin of the
+/// before lookups or writes (the executor-side twin of the
 /// descriptor-ingest guard in catalog.rs).
 #[tokio::test]
 async fn reserved_collection_prefix_refuses_registration() -> anyhow::Result<()> {
@@ -1131,7 +1021,7 @@ async fn reserved_collection_prefix_refuses_registration() -> anyhow::Result<()>
     // nesting is the membership, so there is no separate collection field to
     // abuse.
 
-    // The refusals happened before the plan committed anything: the catalog
+    // The refusals happened before the transaction committed anything: the catalog
     // holds no model or property rows (not even the "album" rider).
     assert_eq!(count_rows(&server, MODEL).await?, 0, "no model row survives a refused request");
     assert_eq!(count_rows(&server, PROPERTY).await?, 0, "no property row survives a refused request");


### PR DESCRIPTION
The catalog now uses Ankurah's ordinary typed model machinery for its own durable data. Catalog rows are generated Models, durable registration writes them through a normal Transaction and Mutable values, and the node's catalog projection is maintained by typed LiveQueries and Views.

This follows #422 and targets `main`.

## Why

The earlier implementation still treated catalog maintenance as a privileged parallel data path: registration planned and encoded raw events, and the durable projection consumed raw entity state. That undercut the point of dogfooding the model stack and duplicated behavior that Context, Transaction, Model/Mutable/View, LiveQuery, storage admission, and Reactor notification already own.

The only special concept this needs is authority. A durable node must be able to maintain its own reserved system models without pretending that infrastructure work belongs to an application principal.

## What changed

### Typed catalog models

`SysModelRow`, `SysPropertyRow`, and `SysModelPropertyRow` are ordinary `#[derive(Model)]` types. Their built-in identities come from `#[model(system = "...")]`, so they never consult the catalog they describe.

The derive now has two independent controls needed by these internal models:

- `base = "crate"` changes the generated Rust path.
- `no_ffi` suppresses generated WASM and UniFFI surfaces.

Model attributes are parsed strictly: unknown keys and invalid forms are compile errors.

### Local SystemRoot authority

`Context` now distinguishes `Session(ContextData)` from `SystemRoot`.

SystemRoot:

- is not a session and carries no application credentials;
- is constructible only inside core and only for durable nodes;
- may operate only on built-in system models;
- bypasses the application `PolicyAgent` for local system reads, queries, and commits; and
- otherwise uses the same transaction validation, event application, storage, and Reactor notification path as an application context.

Ordinary application contexts still cannot commit to `_ankurah_` collections, and remotely submitted protected-collection commits remain rejected.

### Registration uses Models and Mutables

Durable `RegisterSchema` materialization now opens a SystemRoot Context and uses the normal typed Transaction/Model/Mutable APIs to create or update catalog rows. `RegistrationPlan`, raw LWW event construction, and the parallel catalog write path are gone.

The remote request is still authenticated before it is accepted. Once accepted, materialization is local infrastructure work rather than work performed under the caller's policy context.

Ephemeral nodes deliberately continue to use the `RegisterSchema` RPC and fold its response for now.

### The durable catalog projection uses typed LiveQueries

A durable node opens three SystemRoot LiveQueries—one for each catalog collection—and applies their typed Views to `CatalogMap`. Initial results warm the projection; later ordinary commits update it through the same subscriptions.

Malformed rows are logged at error level, omitted from the projection, and do not stop later valid rows from being applied. Reset/readiness fences still prevent stale work from surviving a system-epoch change.

### Stable identity hints

`UniqueStructId` and `UniqueFieldId` are deterministic source-derived identifiers carried in descriptors and over `RegisterSchema`. They intentionally reach the server but are not used for matching yet.

A follow-up TODO records the observability needed before using them operationally: asynchronous successful-binding telemetry with declared and resolved identities, labels, match basis, declaring crate package/version, and application/source revision when the runtime can provide it.

### Purpose-first source organization

Every Rust source file touched by this PR now begins with module documentation that states the file's purpose, domain nouns, and boundary with neighboring modules. The repository's coding standards require that intention-setting step for touched source files.

## Deliberately out of scope

- Session aggregation/challenge-response work in #426.
- Ephemeral catalog LiveQuery reads; after #426 they can use Session-based subscriptions while keeping the RPC for writes, races, and migration fallbacks.
- Server-side matching on the source-derived unique IDs.
- The per-system descriptor/property lookup once-cell optimization.

## Verification

- `cargo test -p ankurah-core` — 213 passed, 1 ignored; doc tests completed.
- `cargo test -p ankurah-tests` — full package passed, including compile-fail, websocket, reset, protection, registration, and catalog dogfooding coverage.
- `cargo check -p ankurah-core --all-features` — passed.
- `cargo check -p ankurah-core --features wasm --target wasm32-unknown-unknown` — passed; CI now runs this target-specific check.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

Derive coverage also pins explicit-default base-path behavior and nested user-module unique-ID hygiene.

The focused catalog coverage includes typed executor rows, feed-only updates, malformed-row isolation/continuation, application-policy isolation, protected local and remote writes, restart/reset fencing, concurrent registration, explicit ID verification, and idempotence.

A full `cargo test --workspace` remains blocked by an existing JWT extension derive failure under workspace feature unification; clippy likewise stops on an existing denied lint in `core-types`. Neither failure is introduced by this PR.