### PR TITLE
Live credential sessions: updatable ContextData, the credential union, and query status

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -298,18 +298,6 @@ impl Context {
         Self(Arc::new(NodeAndContext { node, sessions: session.into() }))
     }
 
-    /// A context reading under the union of the node's live credentials,
-    /// reactively (the credential source is the node's whole SessionSet).
-    /// For system queries such as the catalog manager's; not a user
-    /// surface. Write operations, registration, and update_cdata refuse
-    /// through it, because they act as one principal.
-    pub(crate) fn new_system<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 'static>(
-        node: Node<SE, PA>,
-    ) -> Self {
-        let sessions = crate::session::Sessions::Set(node.sessions.clone());
-        Self(Arc::new(NodeAndContext { node, sessions }))
-    }
-
     /// Replace this context's credential in place: a token refresh or a
     /// re-login. Livequeries and pending operations keep running; each
     /// holder reads the new value on its next operation, and the relay
@@ -407,9 +395,9 @@ where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
-    /// The single credential write paths require. The system context
-    /// refuses: commits, registration, and event attestation act as one
-    /// principal, and the union has no single principal to act as.
+    /// The single credential write paths require. Set- and holder-backed
+    /// contexts refuse: commits, registration, and event attestation act
+    /// as one principal, and a union has no single principal to act as.
     fn write_credential(&self) -> Result<PA::ContextData, AccessDenied> {
         match &self.sessions {
             crate::session::Sessions::One(session) => Ok(session.snapshot()),
@@ -444,7 +432,7 @@ where
             debug!("Node({}).get_entity found local entity - returning", self.node.id);
             let state = local.to_state()?;
             let entity_id = local.id();
-            self.node.policy_agent.check_read(&cdata, &entity_id, collection_id, &state)?;
+            self.node.policy_agent.check_read(&self.sessions.snapshot(), &entity_id, collection_id, &state)?;
             return Ok(local);
         }
         debug!("{}.get_entity fetching from storage", self.node);
@@ -452,7 +440,12 @@ where
         let collection = self.node.collections.get(collection_id).await?;
         match collection.get_state(id).await {
             Ok(entity_state) => {
-                self.node.policy_agent.check_read(&cdata, &entity_state.payload.entity_id, collection_id, &entity_state.payload.state)?;
+                self.node.policy_agent.check_read(
+                    &self.sessions.snapshot(),
+                    &entity_state.payload.entity_id,
+                    collection_id,
+                    &entity_state.payload.state,
+                )?;
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection.clone());
                 let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection, &self.node, &cdata);
                 let (_changed, entity) = self
@@ -467,11 +460,13 @@ where
     }
     /// Fetch a list of entities based on a selection
     pub async fn fetch_entities(&self, collection_id: &CollectionId, mut args: MatchArgs) -> Result<Vec<Entity>, RetrievalError> {
-        let cdata = self.sessions.snapshot();
-        self.node.policy_agent.can_access_collection(&cdata, collection_id)?;
+        self.node.policy_agent.can_access_collection(&self.sessions.snapshot(), collection_id)?;
         // Fetch raw states from storage
 
-        args.selection.predicate = self.node.policy_agent.filter_predicate(&cdata, collection_id, args.selection.predicate)?;
+        args.selection.predicate =
+            self.node.policy_agent.filter_predicate(&self.sessions.snapshot(), collection_id, args.selection.predicate)?;
+
+        let cdata = self.sessions.snapshot();
 
         // Resolve types in the AST (converts literals for JSON path comparisons)
         args.selection = self.node.type_resolver.resolve_selection_types(args.selection);

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -33,7 +33,24 @@ where
     PA: PolicyAgent + Send + Sync + 'static,
 {
     pub node: Node<SE, PA>,
-    pub cdata: PA::ContextData,
+    /// The live credential source. An ordinary context holds exactly one
+    /// session (registered in the node's SessionSet); the system context
+    /// holds the whole set and reads under the union. Every operation
+    /// snapshots it once at entry, so an update lands between operations,
+    /// never inside one.
+    pub sessions: crate::session::Sessions<PA::ContextData>,
+}
+
+/// [`Context::update_cdata`] failure.
+#[derive(Debug, thiserror::Error)]
+pub enum UpdateCdataError {
+    /// The supplied value is not this node's ContextData type.
+    #[error("ContextData type mismatch: this node's policy agent uses a different ContextData type")]
+    WrongContextDataType,
+    /// The system context has no single credential to replace; its
+    /// member sessions update through their own contexts.
+    #[error("the system context's credentials update through their member contexts, not update_cdata")]
+    SystemContext,
 }
 
 #[async_trait]
@@ -66,6 +83,12 @@ pub trait TContext {
     async fn commit_local_trx(&self, trx: &Transaction) -> Result<Vec<Event>, MutationError>;
     fn query(&self, collection_id: proto::CollectionId, args: MatchArgs) -> Result<EntityLiveQuery, RetrievalError>;
     async fn collection(&self, id: &proto::CollectionId) -> Result<StorageCollectionWrapper, RetrievalError>;
+    /// Replace this context's credential (type-erased across the trait
+    /// object; [`Context::update_cdata`] is the typed surface). Holders of
+    /// the session observe the new value on their next operation. STANDING
+    /// queries keep their creation-time derivation; the liveness PR wires
+    /// re-permission.
+    fn update_cdata(&self, new: Box<dyn std::any::Any + Send>) -> Result<(), UpdateCdataError>;
 }
 
 #[async_trait]
@@ -74,7 +97,11 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         &self,
         schema: &'static crate::schema::ModelStructDescriptor,
     ) -> Result<proto::ModelId, crate::schema::registration::RegistrationError> {
-        self.node.catalog.ensure_schema_for_use(&self.cdata, schema).await
+        // Registration acts as one principal, like every write path.
+        let cdata = self
+            .write_credential()
+            .map_err(|denied| crate::schema::registration::RegistrationError::Retrieval(RetrievalError::AccessDenied(denied)))?;
+        self.node.catalog.ensure_schema_for_use(&cdata, schema).await
     }
 
     fn node_id(&self) -> proto::EntityId { self.node.id }
@@ -82,7 +109,9 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         let primary_entity = self.node.entities.create(collection);
         primary_entity.snapshot(trx_alive)
     }
-    fn check_write(&self, entity: &Entity) -> Result<(), AccessDenied> { self.node.policy_agent.check_write(&self.cdata, entity, None) }
+    fn check_write(&self, entity: &Entity) -> Result<(), AccessDenied> {
+        self.node.policy_agent.check_write(&self.write_credential()?, entity, None)
+    }
     async fn get_entity(&self, id: proto::EntityId, collection: &proto::CollectionId, cached: bool) -> Result<Entity, RetrievalError> {
         self.get_entity(collection, id, cached).await
     }
@@ -98,6 +127,10 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         if trx.alive.compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire).is_err() {
             return Err(MutationError::General("Transaction already committed or rolled back".into()));
         }
+
+        // One credential snapshot for the whole commit: a session update
+        // mid-commit must not mix credentials across its phases.
+        let cdata = self.write_credential()?;
 
         // Generate events from the transaction entities
         let trx_id = trx.id.clone();
@@ -152,7 +185,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
             event_getter.stage_event(event.clone());
             forked.apply_event(&event_getter, &event).await?;
 
-            let attestation = self.node.policy_agent.check_event(&self.node, &self.cdata, &entity_before, &forked, &event)?;
+            let attestation = self.node.policy_agent.check_event(&self.node, &cdata, &entity_before, &forked, &event)?;
             let attested = Attested::opt(event.clone(), attestation);
 
             attested_events.push(attested.clone());
@@ -171,7 +204,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
             entity.commit_head(Clock::new([attested_event.payload.id()]));
         }
         // Relay to peers and wait for confirmation
-        self.node.relay_to_required_peers(&self.cdata, trx_id, &attested_events).await?;
+        self.node.relay_to_required_peers(&cdata, trx_id, &attested_events).await?;
 
         // All peers confirmed, persist state to storage
         let mut changes: Vec<EntityChange> = Vec::new();
@@ -206,10 +239,24 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         Ok(attested_events.into_iter().map(|a| a.payload).collect())
     }
     fn query(&self, collection_id: proto::CollectionId, args: MatchArgs) -> Result<EntityLiveQuery, RetrievalError> {
-        EntityLiveQuery::new(&self.node, collection_id, args, self.cdata.clone())
+        EntityLiveQuery::new(&self.node, collection_id, args, self.sessions.clone())
     }
     async fn collection(&self, id: &proto::CollectionId) -> Result<StorageCollectionWrapper, RetrievalError> {
         self.node.system.collection(id).await
+    }
+    fn update_cdata(&self, new: Box<dyn std::any::Any + Send>) -> Result<(), UpdateCdataError> {
+        let new = new.downcast::<PA::ContextData>().map_err(|_| UpdateCdataError::WrongContextDataType)?;
+        match &self.sessions {
+            crate::session::Sessions::One(session) => {
+                session.update(*new);
+                Ok(())
+            }
+            // Held is server-internal (gap-fill holders) and unreachable
+            // from any user surface; its members update via
+            // SessionHolder::replace. The SystemContext error text
+            // describes the Set arm.
+            crate::session::Sessions::Set(_) | crate::session::Sessions::Held(_) => Err(UpdateCdataError::SystemContext),
+        }
     }
 }
 
@@ -248,8 +295,19 @@ impl Context {
         node: Node<SE, PA>,
         data: PA::ContextData,
     ) -> Self {
-        Self(Arc::new(NodeAndContext { node, cdata: data }))
+        let session = node.sessions.register(data);
+        Self(Arc::new(NodeAndContext { node, sessions: session.into() }))
     }
+
+    /// Replace this context's credential in place: a token refresh or a
+    /// re-login. Livequeries and pending operations keep running; each
+    /// holder reads the new value on its next operation, so commits,
+    /// fetches, and NEW queries run under the refreshed credential.
+    /// STANDING queries keep their creation-time derivation until the
+    /// liveness PR wires re-permission. Errors when `new` is not this
+    /// node's ContextData type, or through the system context (whose
+    /// member sessions update via their own contexts).
+    pub fn update_cdata<CD: crate::node::ContextData>(&self, new: CD) -> Result<(), UpdateCdataError> { self.0.update_cdata(Box::new(new)) }
 
     pub fn node_id(&self) -> proto::EntityId { self.0.node_id() }
 
@@ -339,6 +397,18 @@ where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
+    /// The single credential write paths require. Set- and holder-backed
+    /// contexts refuse: commits, registration, and event attestation act
+    /// as one principal, and a union has no single principal to act as.
+    fn write_credential(&self) -> Result<PA::ContextData, AccessDenied> {
+        match &self.sessions {
+            crate::session::Sessions::One(session) => Ok(session.snapshot()),
+            crate::session::Sessions::Set(_) | crate::session::Sessions::Held(_) => {
+                Err(AccessDenied::ByPolicy("write operations require a single-credential context"))
+            }
+        }
+    }
+
     /// Retrieve a single entity, either by cloning the resident Entity from the Node's WeakEntitySet or fetching from storage
     pub(crate) async fn get_entity(
         &self,
@@ -347,10 +417,11 @@ where
         cached: bool,
     ) -> Result<Entity, RetrievalError> {
         debug!("Node({}).get_entity {:?}-{:?}", self.node.id, id, collection_id);
+        let cdata = self.sessions.snapshot();
 
         if !self.node.durable {
             // Fetch from peers and commit first response
-            match self.node.get_from_peer(collection_id, vec![id], &self.cdata).await {
+            match self.node.get_from_peer(collection_id, vec![id], &cdata).await {
                 Ok(_) => (),
                 Err(RetrievalError::NoDurablePeers) if cached => (),
                 Err(e) => {
@@ -363,7 +434,7 @@ where
             debug!("Node({}).get_entity found local entity - returning", self.node.id);
             let state = local.to_state()?;
             let entity_id = local.id();
-            self.node.policy_agent.check_read(&self.cdata, &entity_id, collection_id, &state)?;
+            self.node.policy_agent.check_read(&self.sessions.snapshot(), &entity_id, collection_id, &state)?;
             return Ok(local);
         }
         debug!("{}.get_entity fetching from storage", self.node);
@@ -372,13 +443,13 @@ where
         match collection.get_state(id).await {
             Ok(entity_state) => {
                 self.node.policy_agent.check_read(
-                    &self.cdata,
+                    &self.sessions.snapshot(),
                     &entity_state.payload.entity_id,
                     collection_id,
                     &entity_state.payload.state,
                 )?;
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection.clone());
-                let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection, &self.node, &self.cdata);
+                let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection, &self.node, &cdata);
                 let (_changed, entity) = self
                     .node
                     .entities
@@ -391,18 +462,22 @@ where
     }
     /// Fetch a list of entities based on a selection
     pub async fn fetch_entities(&self, collection_id: &CollectionId, mut args: MatchArgs) -> Result<Vec<Entity>, RetrievalError> {
-        self.node.policy_agent.can_access_collection(&self.cdata, collection_id)?;
+        self.node.policy_agent.can_access_collection(&self.sessions.snapshot(), collection_id)?;
         // Fetch raw states from storage
 
-        args.selection.predicate = self.node.policy_agent.filter_predicate(&self.cdata, collection_id, args.selection.predicate)?;
+        args.selection.predicate =
+            self.node.policy_agent.filter_predicate(&self.sessions.snapshot(), collection_id, args.selection.predicate)?;
+
+        let cdata = self.sessions.snapshot();
 
         // Resolve types in the AST (converts literals for JSON path comparisons)
         args.selection = self.node.type_resolver.resolve_selection_types(args.selection);
 
         // TODO implement cached: true
         if !self.node.durable {
-            // Fetch from peers and commit first response
-            Ok(self.fetch_from_peer(collection_id, args.selection).await?)
+            // Fetch from peers and commit first response, under this
+            // operation's one credential snapshot.
+            Ok(self.fetch_from_peer(collection_id, args.selection, &cdata).await?)
         } else {
             let storage_collection = self.node.collections.get(collection_id).await?;
             let states = storage_collection.fetch_states(&args.selection).await?;
@@ -410,7 +485,7 @@ where
             // Convert states to entities
             let mut entities = Vec::new();
             let state_getter = crate::retrieval::LocalStateGetter::new(storage_collection.clone());
-            let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), storage_collection, &self.node, &self.cdata);
+            let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), storage_collection, &self.node, &cdata);
             for state in states {
                 let (_, entity) = self
                     .node
@@ -428,6 +503,7 @@ where
         &self,
         collection_id: &proto::CollectionId,
         selection: ankql::ast::Selection,
+        cdata: &Vec<PA::ContextData>,
     ) -> Result<Vec<crate::entity::Entity>, RetrievalError> {
         let peer_id = self.node.get_durable_peer_random().ok_or(RetrievalError::NoDurablePeers)?;
 
@@ -443,13 +519,12 @@ where
         let selection_clone = selection.clone();
         match self
             .node
-            .request(peer_id, &self.cdata, proto::NodeRequestBody::Fetch { collection: collection_id.clone(), selection, known_matches })
+            .request(peer_id, cdata, proto::NodeRequestBody::Fetch { collection: collection_id.clone(), selection, known_matches })
             .await?
         {
             proto::NodeResponseBody::Fetch(deltas) => {
                 let collection = self.node.collections.get(collection_id).await?;
-                let event_getter =
-                    crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection.clone(), &self.node, &self.cdata);
+                let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection.clone(), &self.node, cdata);
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection);
 
                 // 3. Apply deltas to local storage using NodeApplier

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -85,9 +85,8 @@ pub trait TContext {
     async fn collection(&self, id: &proto::CollectionId) -> Result<StorageCollectionWrapper, RetrievalError>;
     /// Replace this context's credential (type-erased across the trait
     /// object; [`Context::update_cdata`] is the typed surface). Holders of
-    /// the session observe the new value on their next operation. STANDING
-    /// queries keep their creation-time derivation; the liveness PR wires
-    /// re-permission.
+    /// the session observe the new value on their next operation, and the
+    /// relay re-permissions this context's remote subscriptions.
     fn update_cdata(&self, new: Box<dyn std::any::Any + Send>) -> Result<(), UpdateCdataError>;
 }
 
@@ -299,14 +298,25 @@ impl Context {
         Self(Arc::new(NodeAndContext { node, sessions: session.into() }))
     }
 
+    /// A context reading under the union of the node's live credentials,
+    /// reactively (the credential source is the node's whole SessionSet).
+    /// For system queries such as the catalog manager's; not a user
+    /// surface. Write operations, registration, and update_cdata refuse
+    /// through it, because they act as one principal.
+    pub(crate) fn new_system<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 'static>(
+        node: Node<SE, PA>,
+    ) -> Self {
+        let sessions = crate::session::Sessions::Set(node.sessions.clone());
+        Self(Arc::new(NodeAndContext { node, sessions }))
+    }
+
     /// Replace this context's credential in place: a token refresh or a
     /// re-login. Livequeries and pending operations keep running; each
-    /// holder reads the new value on its next operation, so commits,
-    /// fetches, and NEW queries run under the refreshed credential.
-    /// STANDING queries keep their creation-time derivation until the
-    /// liveness PR wires re-permission. Errors when `new` is not this
-    /// node's ContextData type, or through the system context (whose
-    /// member sessions update via their own contexts).
+    /// holder reads the new value on its next operation, and the relay
+    /// re-permissions this context's remote subscriptions with it. Errors
+    /// when `new` is not this node's ContextData type, or through the
+    /// system context (whose member sessions update via their own
+    /// contexts).
     pub fn update_cdata<CD: crate::node::ContextData>(&self, new: CD) -> Result<(), UpdateCdataError> { self.0.update_cdata(Box::new(new)) }
 
     pub fn node_id(&self) -> proto::EntityId { self.0.node_id() }
@@ -397,9 +407,9 @@ where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
-    /// The single credential write paths require. Set- and holder-backed
-    /// contexts refuse: commits, registration, and event attestation act
-    /// as one principal, and a union has no single principal to act as.
+    /// The single credential write paths require. The system context
+    /// refuses: commits, registration, and event attestation act as one
+    /// principal, and the union has no single principal to act as.
     fn write_credential(&self) -> Result<PA::ContextData, AccessDenied> {
         match &self.sessions {
             crate::session::Sessions::One(session) => Ok(session.snapshot()),
@@ -434,7 +444,7 @@ where
             debug!("Node({}).get_entity found local entity - returning", self.node.id);
             let state = local.to_state()?;
             let entity_id = local.id();
-            self.node.policy_agent.check_read(&self.sessions.snapshot(), &entity_id, collection_id, &state)?;
+            self.node.policy_agent.check_read(&cdata, &entity_id, collection_id, &state)?;
             return Ok(local);
         }
         debug!("{}.get_entity fetching from storage", self.node);
@@ -442,12 +452,7 @@ where
         let collection = self.node.collections.get(collection_id).await?;
         match collection.get_state(id).await {
             Ok(entity_state) => {
-                self.node.policy_agent.check_read(
-                    &self.sessions.snapshot(),
-                    &entity_state.payload.entity_id,
-                    collection_id,
-                    &entity_state.payload.state,
-                )?;
+                self.node.policy_agent.check_read(&cdata, &entity_state.payload.entity_id, collection_id, &entity_state.payload.state)?;
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection.clone());
                 let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection, &self.node, &cdata);
                 let (_changed, entity) = self
@@ -462,13 +467,11 @@ where
     }
     /// Fetch a list of entities based on a selection
     pub async fn fetch_entities(&self, collection_id: &CollectionId, mut args: MatchArgs) -> Result<Vec<Entity>, RetrievalError> {
-        self.node.policy_agent.can_access_collection(&self.sessions.snapshot(), collection_id)?;
+        let cdata = self.sessions.snapshot();
+        self.node.policy_agent.can_access_collection(&cdata, collection_id)?;
         // Fetch raw states from storage
 
-        args.selection.predicate =
-            self.node.policy_agent.filter_predicate(&self.sessions.snapshot(), collection_id, args.selection.predicate)?;
-
-        let cdata = self.sessions.snapshot();
+        args.selection.predicate = self.node.policy_agent.filter_predicate(&cdata, collection_id, args.selection.predicate)?;
 
         // Resolve types in the AST (converts literals for JSON path comparisons)
         args.selection = self.node.type_resolver.resolve_selection_types(args.selection);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod reactor;
 pub mod resultset;
 pub mod retrieval;
 pub mod selection;
+pub mod session;
 pub mod storage;
 pub mod system;
 pub mod task;

--- a/core/src/livequery.rs
+++ b/core/src/livequery.rs
@@ -64,6 +64,114 @@ where
     fn upgrade(&self) -> Option<Box<dyn TNodeErased>> { self.0.upgrade().map(|inner| Box::new(Node(inner)) as Box<dyn TNodeErased>) }
 }
 
+/// Re-derive the policy-filtered, type-resolved selection from a user
+/// intent under the session's CURRENT credential. Type-erased so the
+/// credential-generic policy machinery is reachable from the erased Inner.
+type RefilterFn = Box<dyn Fn(ankql::ast::Selection) -> Result<ankql::ast::Selection, RetrievalError> + Send + Sync>;
+
+/// The two-leg condition of a livequery, one reactive value exposed by
+/// [`EntityLiveQuery::status`]. Each leg reports where the current
+/// selection stands. Nothing here latches: a query fails, un-fails, and
+/// re-fails as credentials change, peers come and go, and the server
+/// answers, and the status follows.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryStatus {
+    pub local: LocalStatus,
+    pub remote: RemoteStatus,
+}
+
+/// The local leg: what this node's reactor serves for the query.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LocalStatus {
+    /// No registration has landed yet: construction through first
+    /// activation, and the window between a heal from [`Self::Denied`]
+    /// and its activation completing. An activation FAILURE leaves the
+    /// last truthful state standing (Pending, or the prior Active
+    /// version, whichever held) with the error latched on `error()`;
+    /// Active is only ever reported by a registration that actually
+    /// landed.
+    Pending,
+    /// No current credential grants access. The reactor holds no
+    /// registration, the resultset is empty (clawed back from the live
+    /// view; locally persisted rows are untouched), and the user's intent
+    /// is retained; the next credential change re-derives. Single-
+    /// credential queries fail CONSTRUCTION loud instead of starting
+    /// here, but any standing query enters this state when a credential
+    /// change revokes its access.
+    Denied { reason: String },
+    /// The effective selection at `version` IS the reactor registration:
+    /// reported by the registration itself as it completes (the
+    /// resultset's loaded flag tracks content arrival).
+    Active { version: u32 },
+}
+
+/// The authoritative effective selection, guarded by [`Inner::update_lock`]:
+/// policy-filtered under the credential current at derivation and
+/// type-resolved — EXCEPT under denial, where it deliberately holds the
+/// RAW intent (there is no effective selection and no reactor
+/// registration; the server applies its own filtering to whatever
+/// arrives). The `selection` Mut is porcelain fed from this via the
+/// effects queue.
+struct CurrentSelection {
+    selection: ankql::ast::Selection,
+    version: u32,
+}
+
+/// A deferred signal dispatch. Mutations enqueue effects under their
+/// locks; [`Inner::drain_effects`] fires them AFTER release, in enqueue
+/// order, through a single dispatcher — so a subscriber that re-enters
+/// the query (update_selection, a credential refresh) finds every lock
+/// free, and its own enqueues are dispatched by the active drainer.
+enum Effect {
+    Status(QueryStatus),
+    Selection(ankql::ast::Selection, u32),
+    /// The error latch, versioned by WHERE it is enqueued: only an
+    /// activation whose version was still current at completion (checked
+    /// under the update lock) enqueues, so a superseded failure or
+    /// success can never overwrite the latch that belongs to the newer
+    /// version, and dispatch order through the queue settles the rest.
+    Error(Option<RetrievalError>),
+}
+
+struct EffectState {
+    /// The authoritative status fold (the `status` Mut lags during
+    /// dispatch; readers of record go through here).
+    current: QueryStatus,
+    /// Floor for remote-leg reports: the relay stamps each report under
+    /// its own lock, and delivery order is thread scheduling, so a
+    /// delayed older report must not overwrite a newer one.
+    remote_seq: u64,
+    queue: std::collections::VecDeque<Effect>,
+    draining: bool,
+}
+
+/// The remote leg: where the upstream subscription stands. The relay
+/// reports every transition; durable-node queries have no remote leg.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RemoteStatus {
+    /// No remote leg exists (this node answers the query itself).
+    None,
+    /// Waiting for a durable peer, or queued for retry.
+    Pending,
+    Requested {
+        version: u32,
+    },
+    Established {
+        version: u32,
+    },
+    /// This node's policy refused to sign the request with the current
+    /// credentials; a credential change re-attempts.
+    Denied {
+        reason: String,
+    },
+    /// A non-retryable failure. The server's refusals arrive here as its
+    /// error text (the wire has no structured denial yet); retryable
+    /// transport failures report as [`RemoteStatus::Pending`] instead.
+    Error {
+        message: String,
+    },
+}
+
 struct Inner {
     pub(crate) query_id: proto::QueryId,
     // subscription must be declared before node so it drops first —
@@ -77,14 +185,43 @@ struct Inner {
     pub(crate) initialized_version: std::sync::atomic::AtomicU32,
     // Version tracking for predicate updates
     pub(crate) current_version: std::sync::atomic::AtomicU32,
-    // Store selection with its version (starts with version 1, updated on selection changes)
-    // This represents user intent (client-side state), separate from reactor's QueryState.selection (reactor-side state)
-    // Using Mut for reactive updates that can be observed in WASM
+    // Porcelain mirror of the authoritative selection in `update_lock`
+    // (reactive, observable in WASM); fed through the effects queue, so
+    // it may briefly lag the authority mid-dispatch.
     pub(crate) selection: Mut<(ankql::ast::Selection, u32)>,
+    // The user's PRE-FILTER intent, retained so a credential change can
+    // re-derive the effective selection instead of re-sending a filter
+    // baked under the old credential.
+    pub(crate) intent_selection: std::sync::Mutex<ankql::ast::Selection>,
+    // See RefilterFn.
+    pub(crate) refilter: RefilterFn,
+    // THE serialization point, guarding the authoritative selection:
+    // reissue's read-refilter-mint-store, activation's snapshot and its
+    // post-registration re-validation, and the initialization report all
+    // bracket under it, so a selection update, a credential
+    // re-permission, and an in-flight activation can never interleave
+    // into a stale registration or a resurrected resultset. This code
+    // never FIRES a signal while holding it (see Effect) — though a
+    // concurrent drainer may dispatch effects enqueued here while the
+    // lock is still held; that drainer holds no locks, so a re-entrant
+    // subscriber blocks only for this critical section, never deadlocks.
+    pub(crate) update_lock: std::sync::Mutex<CurrentSelection>,
     // Store collection_id for selection updates
     pub(crate) collection_id: CollectionId,
     // Gap fetcher for reactor.add_query (type-erased)
     pub(crate) gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>>,
+    // Fires re-permission on credential change; installed once by
+    // new_with_node_ref after construction.
+    pub(crate) session_guard: std::sync::OnceLock<SubscriptionGuard>,
+    // The two-leg status, porcelain mirror of `effects.current`; fed
+    // through the effects queue so subscribers never run under a lock.
+    pub(crate) status: Mut<QueryStatus>,
+    // The status fold of record plus the deferred-dispatch queue.
+    pub(crate) effects: std::sync::Mutex<EffectState>,
+    // Governs CONSTRUCTION under denial: set-backed queries construct
+    // into the Denied state; single-credential queries fail loud. (Post-
+    // construction re-permission denial is a state for every kind.)
+    pub(crate) set_backed: bool,
 }
 
 /// Weak reference to EntityLiveQuery for breaking circular dependencies
@@ -92,6 +229,27 @@ pub struct WeakEntityLiveQuery(Weak<Inner>);
 
 impl WeakEntityLiveQuery {
     pub fn upgrade(&self) -> Option<EntityLiveQuery> { self.0.upgrade().map(EntityLiveQuery) }
+
+    /// Re-permission after a credential change: re-derive the effective
+    /// selection under the new credential and push it through the same
+    /// versioned flow. Runs for EVERY livequery (durable-local queries
+    /// re-filter their reactor registration; relayed queries additionally
+    /// re-send upstream, where the durable side re-validates and swaps).
+    fn credential_updated(&self) {
+        if let Some(lq) = self.upgrade() {
+            if let Err(e) = lq.reissue(None) {
+                // Log-only is honest TODAY: every policy failure arrives
+                // as AccessDenied and becomes the Denied state inside
+                // reissue, and type resolution is infallible, so the only
+                // error reaching here is node teardown. If the refilter
+                // ever grows a non-denial failure mode, this must latch
+                // observably (enqueue_error), not just log.
+                tracing::warn!("credential re-permission failed for query {}: {}", lq.0.query_id, e);
+                lq.0.enqueue_error(Some(e));
+                lq.0.drain_effects();
+            }
+        }
+    }
 }
 
 impl Clone for WeakEntityLiveQuery {
@@ -109,58 +267,183 @@ impl<R: View> std::ops::Deref for LiveQuery<R> {
 impl Inner {
     fn node(&self) -> Option<Box<dyn TNodeErased>> { self.node.upgrade() }
 
-    async fn wait_initialized(&self) {
-        // If already initialized, return immediately
-        if self.initialized_version.load(std::sync::atomic::Ordering::Relaxed)
-            >= self.current_version.load(std::sync::atomic::Ordering::Relaxed)
-        {
-            return;
-        }
+    /// The local leg of record (the `status` Mut may lag mid-dispatch).
+    fn local_status(&self) -> LocalStatus { self.effects.lock().unwrap_or_else(|e| e.into_inner()).current.local.clone() }
 
-        // FIXME - this should be waiting for the correct version, not any version
-        // Otherwise wait for the notification
-        self.initialized.notified().await;
+    /// Fold a local-leg transition and queue its dispatch. The caller
+    /// drains after releasing its locks.
+    fn enqueue_local_status(&self, local: LocalStatus) {
+        let mut st = self.effects.lock().unwrap_or_else(|e| e.into_inner());
+        st.current.local = local;
+        let report = st.current.clone();
+        st.queue.push_back(Effect::Status(report));
+    }
+
+    /// Queue a porcelain-selection dispatch (the authority is already
+    /// stored in `update_lock` by the caller).
+    fn enqueue_selection(&self, selection: ankql::ast::Selection, version: u32) {
+        let mut st = self.effects.lock().unwrap_or_else(|e| e.into_inner());
+        st.queue.push_back(Effect::Selection(selection, version));
+    }
+
+    /// Queue an error-latch update; see [`Effect::Error`] for the version
+    /// ownership rule.
+    fn enqueue_error(&self, error: Option<RetrievalError>) {
+        let mut st = self.effects.lock().unwrap_or_else(|e| e.into_inner());
+        st.queue.push_back(Effect::Error(error));
+    }
+
+    pub(crate) fn set_remote_status(&self, seq: u64, remote: RemoteStatus) {
+        {
+            let mut st = self.effects.lock().unwrap_or_else(|e| e.into_inner());
+            if seq <= st.remote_seq {
+                return;
+            }
+            st.remote_seq = seq;
+            st.current.remote = remote;
+            let report = st.current.clone();
+            st.queue.push_back(Effect::Status(report));
+        }
+        self.drain_effects();
+    }
+
+    /// Fire queued signal dispatches, none under any lock. One drainer at
+    /// a time: an enqueue that finds a drain in progress returns
+    /// immediately and the active drainer picks its effect up — including
+    /// enqueues made by re-entrant subscribers mid-dispatch, which is what
+    /// makes re-entry (a status subscriber calling update_selection) safe
+    /// instead of a deadlock.
+    fn drain_effects(&self) {
+        // Unwind-safe handoff: a panicking subscriber must not leave the
+        // draining flag set forever, or every later drainer would see a
+        // dispatch in progress and return, wedging the queue.
+        struct DrainingReset<'a>(&'a std::sync::Mutex<EffectState>);
+        impl Drop for DrainingReset<'_> {
+            fn drop(&mut self) { self.0.lock().unwrap_or_else(|e| e.into_inner()).draining = false; }
+        }
+        loop {
+            let effect = {
+                let mut st = self.effects.lock().unwrap_or_else(|e| e.into_inner());
+                if st.draining {
+                    return;
+                }
+                match st.queue.pop_front() {
+                    Some(effect) => {
+                        st.draining = true;
+                        effect
+                    }
+                    None => return,
+                }
+            };
+            let reset = DrainingReset(&self.effects);
+            match effect {
+                Effect::Status(status) => self.status.set(status),
+                Effect::Selection(selection, version) => self.selection.set((selection, version)),
+                Effect::Error(error) => self.error.set(error),
+            }
+            drop(reset);
+        }
+    }
+
+    /// Returns when the CURRENT selection has initialized, or when the
+    /// query is Denied (initialization cannot proceed until a credential
+    /// change re-grants; waiting through that would hang the caller
+    /// indefinitely). Callers that care which happened read `status()`.
+    async fn wait_initialized(&self) {
+        loop {
+            let notified = self.initialized.notified();
+            tokio::pin!(notified);
+            // Register interest BEFORE checking the condition: a wake
+            // landing between the check and the await stores no permit,
+            // so an unregistered waiter would sleep through its only
+            // notification and hang despite a satisfied condition.
+            notified.as_mut().enable();
+            if self.initialized_version.load(std::sync::atomic::Ordering::Relaxed)
+                >= self.current_version.load(std::sync::atomic::Ordering::Relaxed)
+                || matches!(self.local_status(), LocalStatus::Denied { .. })
+            {
+                // The wake's report was enqueued before notify (see
+                // mark_initialized and the denial arms); drain so a
+                // caller that peeks right after waiting observes it.
+                self.drain_effects();
+                return;
+            }
+            notified.await;
+        }
     }
 
     /// Activate the LiveQuery by fetching entities and calling reactor.add_query or reactor.update_query
     /// Called after deltas have been applied for both initial subscription and selection updates
     /// Gets all parameters from self (collection_id, query_id, selection)
-    /// Marks initialization as complete regardless of success/failure
     /// Rejects activation if the version is older than the current selection to prevent regression
     async fn activate(&self, version: u32) -> Result<(), RetrievalError> {
-        // Get the current selection and its version
-        let (selection, stored_version) = self.selection.value();
-
-        // Reject activation if this is an older version than what's currently stored
-        // This prevents out-of-order activations from regressing the state
-        if version < stored_version {
-            warn!("LiveQuery - Dropped stale activation request for version {} (current version is {})", version, stored_version);
-            return Ok(());
-        }
+        // Snapshot under the update lock: the authoritative selection and
+        // the denial state change together under it, so this cannot
+        // observe a half-applied re-permission. A denied query holds no
+        // reactor registration and its stored selection is the raw
+        // intent; nothing to activate until a credential change
+        // re-derives.
+        let (selection, first_activation) = {
+            let current = self.update_lock.lock().unwrap_or_else(|e| e.into_inner());
+            if let LocalStatus::Denied { .. } = self.local_status() {
+                debug!("LiveQuery - Skipping activation for denied query {}", self.query_id);
+                return Ok(());
+            }
+            if version < current.version {
+                warn!("LiveQuery - Dropped stale activation request for version {} (current version is {})", version, current.version);
+                return Ok(());
+            }
+            // The add-vs-update decision is part of the snapshot: read
+            // outside the lock it can go stale against a concurrent
+            // denial-and-heal and pick the wrong path.
+            (current.selection.clone(), self.initialized_version.load(std::sync::atomic::Ordering::Relaxed) == 0)
+        };
 
         debug!("LiveQuery.activate() for predicate {} (version {})", self.query_id, version);
 
         let node = self.node().ok_or_else(|| RetrievalError::Other("Node has been dropped".into()))?;
         let reactor = node.reactor();
-        let initialized_version = self.initialized_version.load(std::sync::atomic::Ordering::Relaxed);
 
         let hook = InnerPreNotifyHook(self);
-        // Determine if this is the first activation (query not yet in reactor)
-        if initialized_version == 0 {
-            // First activation ever: call reactor.add_query_and_notify which will populate the resultset
-            // Pass the hook as pre_notify_hook to mark initialized before notification
-            reactor
+        let result = if first_activation {
+            // First activation, or a heal from Denied. A registration may
+            // already exist (an activation that raced the denial installed
+            // one the denial's removal ran too early to see, or a twin of
+            // this activation got there first). It is NEVER removed here:
+            // a stale activation must not be able to uninstall a newer
+            // live registration. On conflict this falls back to the
+            // update path, whose version floor arbitrates: a zombie or a
+            // same-version twin is superseded or idempotently re-applied,
+            // and a stale attempt no-ops.
+            let add_result = reactor
                 .add_query_and_notify(
                     self.subscription.id(),
                     self.query_id,
                     self.collection_id.clone(),
-                    selection,
+                    selection.clone(),
                     &*node,
                     self.resultset.clone(),
                     self.gap_fetcher.clone(),
+                    version,
                     &hook,
                 )
-                .await?
+                .await;
+            match add_result {
+                Err(e) if e.downcast_ref::<crate::reactor::QueryAlreadyRegistered>().is_some() => {
+                    reactor
+                        .update_query_and_notify(
+                            self.subscription.id(),
+                            self.query_id,
+                            self.collection_id.clone(),
+                            selection,
+                            &*node,
+                            version,
+                            &hook,
+                        )
+                        .await
+                }
+                other => other,
+            }
         } else {
             // Subsequent activation (including cached re-initialization or selection update): use update_query_and_notify
             // This handles both: (1) cached queries re-activating after remote deltas, and (2) selection updates
@@ -174,17 +457,103 @@ impl Inner {
                     version,
                     &hook,
                 )
-                .await?;
+                .await
         };
 
-        Ok(())
+        // Re-validate under the lock: a denial that landed during the
+        // await found no registration to remove (ours had not installed
+        // yet), so re-assert its end state — deregistered, empty,
+        // uninitialized. The resultset empties under the lock (a heal
+        // cannot interleave with it) but the broadcast fires after
+        // release, via the write guard's deferred notification.
+        let (clawed_back, outcome) = {
+            let current = self.update_lock.lock().unwrap_or_else(|e| e.into_inner());
+            // The ACTIVATION error latch is versioned by enqueueing UNDER
+            // this lock, where currency is decided: a still-current
+            // completion clears it (the healthy terminal, so `error()`
+            // and `status()` agree after a failure-then-recovery), a
+            // still-current failure latches, and a SUPERSEDED outcome of
+            // either kind owns nothing — the latch belongs to the newer
+            // version's attempt, whose own enqueue is ordered after this
+            // one by the same lock. Dispatch rides the effects queue like
+            // every other signal. (Relay-leg failures and re-permission
+            // failures ride the same queue through their own call sites.)
+            let still_current = version >= current.version;
+            let outcome = match result {
+                Ok(()) => {
+                    if still_current {
+                        self.enqueue_error(None);
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    let error: RetrievalError = e.into();
+                    if still_current {
+                        // The caller's copy is a lossy summary; the TYPED
+                        // error goes to the latch, and callers only log.
+                        let summary = RetrievalError::Other(error.to_string());
+                        self.enqueue_error(Some(error));
+                        Err(summary)
+                    } else {
+                        Err(error)
+                    }
+                }
+            };
+            if let LocalStatus::Denied { .. } = self.local_status() {
+                // The deregistration runs before the write guard exists:
+                // remove_query reads the resultset keys for its watcher
+                // cleanup, and holding the guard across it would
+                // self-deadlock. The discard is safe: the error space
+                // is absence-only, and absence is legitimate (denial can
+                // precede the first activation's registration).
+                let _ = self.subscription.remove_predicate(self.query_id);
+                self.initialized_version.store(0, std::sync::atomic::Ordering::Relaxed);
+                self.initialized.notify_waiters();
+                let mut write = self.resultset.write();
+                write.replace_all(Vec::new());
+                (Some(write), outcome)
+            } else {
+                (None, outcome)
+            }
+        };
+        drop(clawed_back);
+        self.drain_effects();
+        outcome
     }
 
-    /// Mark initialization as complete for a given version
+    /// The registration's own completion report (the reactor's pre-notify
+    /// hook): marks initialization and reports `Active` — the ONLY writer
+    /// of `Active`, so the status never claims a registration that did
+    /// not land.
     fn mark_initialized(&self, version: u32) {
         // TASK: Serialize or coalesce concurrent activations to prevent version regression https://github.com/ankurah/ankurah/issues/146
-        self.initialized_version.store(version, std::sync::atomic::Ordering::Relaxed);
+        // Under the update lock: a denial owns initialization state (skip
+        // entirely), and a report for a superseded version is dropped —
+        // its registration content has been or is being replaced, so
+        // reporting it would regress the floor (a wait_initialized
+        // against the current version would hang) and the status.
+        let current = self.update_lock.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(self.local_status(), LocalStatus::Denied { .. }) {
+            return;
+        }
+        if version < current.version {
+            return;
+        }
+        self.initialized_version.fetch_max(version, std::sync::atomic::Ordering::Relaxed);
+        // Enqueue before waking: a woken waiter drains, so it observes
+        // this report immediately after wait_initialized returns.
+        self.enqueue_local_status(LocalStatus::Active { version });
         self.initialized.notify_waiters();
+        drop(current);
+        // Drain now, before the reactor sends its ReactorUpdate content
+        // notification (this hook runs just ahead of it, with no reactor
+        // locks held): a CHANGESET subscriber that receives the
+        // initialized content and then peeks the status finds Active.
+        // Scope honestly: the RESULTSET broadcast (the write guard inside
+        // update_query) fires before this hook, so a resultset subscriber
+        // can observe loaded content while the status still says Pending
+        // for one dispatch beat.
+        self.drain_effects();
     }
 }
 
@@ -210,21 +579,50 @@ where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
-    // Derivation runs under the sessions current at creation (policy
-    // checks and filtering, then type resolution). Re-derivation on
-    // change is the liveness PR.
-    node.policy_agent.can_access_collection(&sessions.snapshot(), &collection_id)?;
-    args.selection.predicate = node.policy_agent.filter_predicate(&sessions.snapshot(), &collection_id, args.selection.predicate)?;
-
-    // Resolve types in the AST (converts literals for JSON path comparisons)
-    args.selection = node.type_resolver.resolve_selection_types(args.selection);
+    // One derivation authority for the effective selection: policy checks
+    // and filtering run under the session's credential AT DERIVATION TIME
+    // (creation now, every re-permission later), then type resolution.
+    let refilter: RefilterFn = {
+        let weak = Arc::downgrade(&node.0);
+        let sessions = sessions.clone();
+        let collection_id = collection_id.clone();
+        Box::new(move |intent: ankql::ast::Selection| {
+            let node = Node(weak.upgrade().ok_or_else(|| RetrievalError::Other("Node has been dropped".into()))?);
+            let cdatas = sessions.snapshot();
+            node.policy_agent.can_access_collection(&cdatas, &collection_id)?;
+            let mut effective = intent;
+            effective.predicate = node.policy_agent.filter_predicate(&cdatas, &collection_id, effective.predicate)?;
+            // Resolve types in the AST (converts literals for JSON path
+            // comparisons), AFTER filtering so injected policy clauses get
+            // typed literals too.
+            Ok(node.type_resolver.resolve_selection_types(effective))
+        })
+    };
+    // Held is deliberately NOT set-backed: it is the server-side holder
+    // arm and never constructs livequeries; if one ever did, failing
+    // construction loud (the One rule) is the conservative default.
+    let set_backed = matches!(sessions, crate::session::Sessions::Set(_));
+    // A set-backed query survives credential denial as a reported status,
+    // its intent retained and shipped upstream for the server's own
+    // verdict; a single-credential query keeps failing construction.
+    let (effective, local_status) = match (refilter)(args.selection.clone()) {
+        Ok(effective) => (effective, LocalStatus::Pending),
+        Err(RetrievalError::AccessDenied(denied)) if set_backed => {
+            (args.selection.clone(), LocalStatus::Denied { reason: denied.to_string() })
+        }
+        Err(error) => return Err(error),
+    };
 
     let subscription = node.reactor.subscribe();
 
     let resultset = EntityResultSet::empty();
     let query_id = proto::QueryId::new();
-    let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(&node, sessions.clone()));
+    let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(&node, sessions));
 
+    // Check if this is a durable node (no relay) or ephemeral node (has relay)
+    let has_relay = node.subscription_relay.is_some();
+
+    let initial_status = QueryStatus { local: local_status, remote: if has_relay { RemoteStatus::Pending } else { RemoteStatus::None } };
     let inner = Arc::new(Inner {
         query_id,
         node: node_ref,
@@ -234,13 +632,22 @@ where
         initialized: tokio::sync::Notify::new(),
         initialized_version: std::sync::atomic::AtomicU32::new(0), // 0 means uninitialized
         current_version: std::sync::atomic::AtomicU32::new(1),     // Start at version 1
-        selection: Mut::new((args.selection.clone(), 1)),          // Start with version 1
+        selection: Mut::new((effective.clone(), 1)),               // porcelain; the authority is update_lock below
+        intent_selection: std::sync::Mutex::new(args.selection.clone()),
+        refilter,
+        update_lock: std::sync::Mutex::new(CurrentSelection { selection: effective, version: 1 }),
         collection_id: collection_id.clone(),
         gap_fetcher,
+        session_guard: std::sync::OnceLock::new(),
+        status: Mut::new(initial_status.clone()),
+        effects: std::sync::Mutex::new(EffectState {
+            current: initial_status,
+            remote_seq: 0,
+            queue: std::collections::VecDeque::new(),
+            draining: false,
+        }),
+        set_backed,
     });
-
-    // Check if this is a durable node (no relay) or ephemeral node (has relay)
-    let has_relay = node.subscription_relay.is_some();
 
     if args.cached || !has_relay {
         // Durable node: spawn initialization task directly (no remote subscription needed)
@@ -249,9 +656,10 @@ where
         debug!("LiveQuery::new() spawning initialization task for durable node predicate {}", query_id);
         crate::task::spawn(async move {
             debug!("LiveQuery initialization task starting for predicate {}", query_id);
+            // The error latch is owned by activate (versioned there);
+            // callers only log.
             if let Err(e) = inner2.activate(1).await {
                 debug!("LiveQuery initialization failed for predicate {}: {}", query_id, e);
-                inner2.error.set(Some(e));
             } else {
                 debug!("LiveQuery initialization completed for predicate {}", query_id);
             }
@@ -308,6 +716,7 @@ impl EntityLiveQuery {
         PA: PolicyAgent + Send + Sync + 'static,
     {
         let has_relay = node.subscription_relay.is_some();
+        let credential_generation = sessions.generation();
         let (inner, query_id) = create_inner(node, node_ref, collection_id.clone(), args, sessions.clone())?;
 
         let me = Self(inner.clone());
@@ -315,7 +724,27 @@ impl EntityLiveQuery {
         // Ephemeral node: register with relay for remote subscription
         // Remote will call activate() after applying deltas via subscription_established
         if has_relay {
-            node.subscribe_remote_query(query_id, collection_id, inner.selection.value().0, sessions, 1, me.weak());
+            node.subscribe_remote_query(query_id, collection_id, inner.selection.value().0, sessions.clone(), 1, me.weak());
+        }
+
+        // Every query re-permissions on credential change (see
+        // credential_updated). The guard installs after the relay
+        // registration (a listener firing before the query is registered
+        // would find no relay entry), which leaves a window between the
+        // creation-time derivation and this line. The session's generation
+        // closes it: an update the derivation missed either bumped before
+        // the re-check below, or stored after the listener was live.
+        let weak = me.weak();
+        let guard = sessions.subscribe_changes({
+            let weak = weak.clone();
+            move |_new: Vec<PA::ContextData>| weak.credential_updated()
+        });
+        // Single install site (OnceLock): if a second install path ever
+        // appears, the discarded NEW guard would silently unsubscribe
+        // re-permission for this query. Keep it impossible.
+        let _ = inner.session_guard.set(guard);
+        if sessions.generation() != credential_generation {
+            weak.credential_updated();
         }
 
         Ok(me)
@@ -330,32 +759,122 @@ impl EntityLiveQuery {
         new_selection: impl TryInto<ankql::ast::Selection, Error = impl Into<RetrievalError>>,
     ) -> Result<(), RetrievalError> {
         let new_selection = new_selection.try_into().map_err(|e| e.into())?;
+        self.reissue(Some(new_selection))
+    }
+
+    /// Re-derive the effective selection and push it through the versioned
+    /// update flow. `Some(intent)` replaces the stored user intent (a
+    /// selection update); `None` re-derives from the existing intent under
+    /// the session's CURRENT credential (re-permission after a credential
+    /// change). The lock makes read-refilter-mint-store one atomic step, so
+    /// a selection update, a re-permission, and an in-flight activation
+    /// can never interleave into a stale selection stored at a newer
+    /// version; out-of-order DISPATCH is harmless because the server
+    /// upsert, the relay's content store, and activation all enforce a
+    /// version floor. No signal fires under the lock: the resultset
+    /// broadcast rides the write guard past release, and selection/status
+    /// dispatch through the effects queue — so observers may re-enter
+    /// selection updates or re-permission freely.
+    fn reissue(&self, new_intent: Option<ankql::ast::Selection>) -> Result<(), RetrievalError> {
         let node = self.0.node().ok_or_else(|| RetrievalError::Other("Node has been dropped".into()))?;
 
-        // Increment current_version atomically and get the new version number
-        let new_version = self.0.current_version.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        let (effective, new_version, resultset_write) = {
+            let mut current = self.0.update_lock.lock().unwrap_or_else(|e| e.into_inner());
+            let mut intent = self.0.intent_selection.lock().unwrap_or_else(|e| e.into_inner());
+            let previous_intent = new_intent.as_ref().map(|_| intent.clone());
+            if let Some(new_intent) = new_intent {
+                *intent = new_intent;
+            }
+            // A rejected selection UPDATE restores the previous intent and
+            // errors loud: the caller is present to hear it, and a later
+            // re-permission must not silently apply what they were told
+            // failed. A denied RE-PERMISSION (new_intent = None) is a
+            // state, not a failure, for every query kind: the credential
+            // changed out from under a standing query, so the local leg
+            // empties (the resultset is clawed back; locally persisted
+            // rows are untouched), the intent ships upstream for the
+            // server's own verdict, and the next credential change
+            // re-derives.
+            let (effective, denial) = match (self.0.refilter)(intent.clone()) {
+                Ok(effective) => (effective, None),
+                Err(RetrievalError::AccessDenied(denied)) if previous_intent.is_none() => (intent.clone(), Some(denied.to_string())),
+                Err(error) => {
+                    if let Some(previous) = previous_intent {
+                        *intent = previous;
+                    }
+                    return Err(error);
+                }
+            };
+            drop(intent);
 
-        // Mark resultset as not loaded since we're changing the selection
-        self.0.resultset.set_loaded(false);
+            let new_version = self.0.current_version.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            current.selection = effective.clone();
+            current.version = new_version;
+            self.0.enqueue_selection(effective.clone(), new_version);
 
-        // Store new selection and version
-        self.0.selection.set((new_selection.clone(), new_version));
+            // The reactor deregistration runs BEFORE the resultset write
+            // guard exists: remove_query reads the resultset (its keys
+            // drive the watcher cleanup), so holding the guard across it
+            // self-deadlocks on the same thread.
+            if denial.is_some() {
+                // Absence-only error space; absence is legitimate (a
+                // denied query may never have registered).
+                let _ = self.0.subscription.remove_predicate(self.0.query_id);
+            }
+            // The resultset mutations happen here under the lock, but
+            // their broadcast rides the returned write guard, which drops
+            // after release.
+            let mut write = self.0.resultset.write();
+            // Not loaded: the selection is changing under the content.
+            write.set_loaded(false);
+            match denial {
+                None => {
+                    if matches!(self.0.local_status(), LocalStatus::Denied { .. }) {
+                        // Returning from denial re-enters the reactor via
+                        // the first-activation path (the registration was
+                        // removed at denial); Active is reported by the
+                        // registration when it lands.
+                        self.0.initialized_version.store(0, std::sync::atomic::Ordering::Relaxed);
+                        self.0.enqueue_local_status(LocalStatus::Pending);
+                    }
+                    // An already-active query keeps reporting its old
+                    // version until the new registration lands
+                    // (mark_initialized owns Active); a pending one stays
+                    // pending.
+                }
+                Some(reason) => {
+                    // Empty the local results (the registration is already
+                    // gone, above). Waiters are woken to observe the
+                    // denial rather than sleeping until an eventual heal.
+                    write.replace_all(Vec::new());
+                    self.0.initialized_version.store(0, std::sync::atomic::Ordering::Relaxed);
+                    self.0.enqueue_local_status(LocalStatus::Denied { reason });
+                    self.0.initialized.notify_waiters();
+                }
+            }
+            (effective, new_version, write)
+        };
+        // Broadcasts, none under the lock: the resultset first (a Denied
+        // observer must find it already empty), then the queued selection
+        // and status reports in order.
+        drop(resultset_write);
+        self.0.drain_effects();
 
         // Check if this node has a relay (ephemeral) or not (durable)
         let has_relay = node.has_subscription_relay();
 
         if has_relay {
             // Ephemeral node: delegate to relay, which will call update_selection_init after applying deltas
-            node.update_remote_query(self.0.query_id, new_selection.clone(), new_version)?;
+            node.update_remote_query(self.0.query_id, effective, new_version)?;
         } else {
             // Durable node: spawn task to call update_selection_init directly
             let inner = self.0.clone();
             let query_id = self.0.query_id;
 
             crate::task::spawn(async move {
+                // The error latch is owned by activate (versioned there).
                 if let Err(e) = inner.activate(new_version).await {
                     tracing::error!("LiveQuery update failed for predicate {}: {}", query_id, e);
-                    inner.error.set(Some(e));
                 }
             });
         }
@@ -373,6 +892,9 @@ impl EntityLiveQuery {
     }
 
     pub fn error(&self) -> Read<Option<RetrievalError>> { self.0.error.read() }
+    /// The two-leg status: what the local reactor serves, and where the
+    /// upstream subscription stands. Reactive; see [`QueryStatus`].
+    pub fn status(&self) -> Read<QueryStatus> { self.0.status.read() }
     pub fn query_id(&self) -> proto::QueryId { self.0.query_id }
     pub fn selection(&self) -> Read<(ankql::ast::Selection, u32)> { self.0.selection.read() }
     pub fn resultset(&self) -> EntityResultSet { self.0.resultset.clone() }
@@ -395,24 +917,46 @@ impl crate::peer_subscription::RemoteQuerySubscriber for WeakEntityLiveQuery {
     async fn subscription_established(&self, version: u32) {
         // Try to upgrade the weak reference
         if let Some(inner) = self.0.upgrade() {
-            // Activate the query (fetch entities, call reactor, and mark initialized)
-            // Handle errors internally by setting last_error
+            // Activate the query (fetch entities, call reactor, and mark
+            // initialized); the error latch is owned by activate.
             tracing::debug!("Subscription established for query {}: {}", inner.query_id, version);
             if let Err(e) = inner.activate(version).await {
                 tracing::error!("Failed to activate subscription for query {}: {}", inner.query_id, e);
-                inner.error.set(Some(e));
             }
         }
         // If upgrade fails, the LiveQuery was already dropped - nothing to do
     }
 
-    fn set_last_error(&self, error: RetrievalError) {
+    fn set_last_error(&self, seq: u64, error: RetrievalError) {
         // Try to upgrade the weak reference
         if let Some(inner) = self.0.upgrade() {
             tracing::info!("Setting last error for LiveQuery {}: {}", inner.query_id, error);
-            inner.error.set(Some(error));
+            // Floored on the report sequence, so a superseded failure
+            // that reaches here late cannot overwrite the error state a
+            // newer attempt already settled. Equality cannot occur here:
+            // per-entry seqs strictly increase and this latch runs before
+            // its own paired Failed status is recorded, so remote_seq is
+            // always below this seq unless a NEWER report already landed.
+            // A newer report landing between this latch and the paired
+            // status dispatch keeps the error while dropping the status;
+            // a bounded skew the next transition settles. Rides the
+            // ordered dispatch like every other latch write.
+            {
+                let mut st = inner.effects.lock().unwrap_or_else(|e| e.into_inner());
+                if seq < st.remote_seq {
+                    return;
+                }
+                st.queue.push_back(Effect::Error(Some(error)));
+            }
+            inner.drain_effects();
         }
         // If upgrade fails, the LiveQuery was already dropped - nothing to do
+    }
+
+    fn remote_status(&self, seq: u64, status: RemoteStatus) {
+        if let Some(inner) = self.0.upgrade() {
+            inner.set_remote_status(seq, status);
+        }
     }
 }
 
@@ -465,6 +1009,15 @@ where R: Clone + Send + Sync + 'static
         let me = self.clone();
         // Subscribe to the underlying ReactorUpdate stream and convert to ChangeSet<R>
         self.0 .0.subscription.subscribe(move |reactor_update: ReactorUpdate| {
+            // A batch decided before a revocation can be dispatched after
+            // it: the claw-back already emptied the resultset and reported
+            // Denied, so the dead registration's membership changes would
+            // contradict the changeset's own (now empty) resultset.
+            // Denial is checked at delivery, so the dispatch that CARRIES
+            // the revocation still reaches the subscriber performing it.
+            if matches!(me.0 .0.local_status(), LocalStatus::Denied { .. }) {
+                return;
+            }
             let changeset: ChangeSet<R> = livequery_change_set_from(me.0 .0.resultset.wrap::<R>(), reactor_update);
             listener(changeset);
         })

--- a/core/src/livequery.rs
+++ b/core/src/livequery.rs
@@ -588,10 +588,9 @@ where
         let collection_id = collection_id.clone();
         Box::new(move |intent: ankql::ast::Selection| {
             let node = Node(weak.upgrade().ok_or_else(|| RetrievalError::Other("Node has been dropped".into()))?);
-            let cdatas = sessions.snapshot();
-            node.policy_agent.can_access_collection(&cdatas, &collection_id)?;
+            node.policy_agent.can_access_collection(&sessions.snapshot(), &collection_id)?;
             let mut effective = intent;
-            effective.predicate = node.policy_agent.filter_predicate(&cdatas, &collection_id, effective.predicate)?;
+            effective.predicate = node.policy_agent.filter_predicate(&sessions.snapshot(), &collection_id, effective.predicate)?;
             // Resolve types in the AST (converts literals for JSON path
             // comparisons), AFTER filtering so injected policy clauses get
             // typed literals too.
@@ -716,7 +715,7 @@ impl EntityLiveQuery {
         PA: PolicyAgent + Send + Sync + 'static,
     {
         let has_relay = node.subscription_relay.is_some();
-        let credential_generation = sessions.generation();
+        let credential_before = sessions.snapshot();
         let (inner, query_id) = create_inner(node, node_ref, collection_id.clone(), args, sessions.clone())?;
 
         let me = Self(inner.clone());
@@ -731,9 +730,12 @@ impl EntityLiveQuery {
         // credential_updated). The guard installs after the relay
         // registration (a listener firing before the query is registered
         // would find no relay entry), which leaves a window between the
-        // creation-time derivation and this line. The session's generation
-        // closes it: an update the derivation missed either bumped before
-        // the re-check below, or stored after the listener was live.
+        // creation-time derivation and this line. Comparing snapshots
+        // closes it: an update the derivation missed either changed the
+        // value before the re-check below, or stored after the listener
+        // was live. (A change-and-revert inside the window compares equal
+        // and is accepted: the reverted-to value is what the derivation
+        // used.)
         let weak = me.weak();
         let guard = sessions.subscribe_changes({
             let weak = weak.clone();
@@ -743,7 +745,7 @@ impl EntityLiveQuery {
         // appears, the discarded NEW guard would silently unsubscribe
         // re-permission for this query. Keep it impossible.
         let _ = inner.session_guard.set(guard);
-        if sessions.generation() != credential_generation {
+        if sessions.snapshot() != credential_before {
             weak.credential_updated();
         }
 

--- a/core/src/livequery.rs
+++ b/core/src/livequery.rs
@@ -204,14 +204,17 @@ fn create_inner<SE, PA>(
     node_ref: Box<dyn NodeRef>,
     collection_id: CollectionId,
     mut args: MatchArgs,
-    cdata: PA::ContextData,
+    sessions: crate::session::Sessions<PA::ContextData>,
 ) -> Result<(Arc<Inner>, proto::QueryId), RetrievalError>
 where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
-    node.policy_agent.can_access_collection(&cdata, &collection_id)?;
-    args.selection.predicate = node.policy_agent.filter_predicate(&cdata, &collection_id, args.selection.predicate)?;
+    // Derivation runs under the sessions current at creation (policy
+    // checks and filtering, then type resolution). Re-derivation on
+    // change is the liveness PR.
+    node.policy_agent.can_access_collection(&sessions.snapshot(), &collection_id)?;
+    args.selection.predicate = node.policy_agent.filter_predicate(&sessions.snapshot(), &collection_id, args.selection.predicate)?;
 
     // Resolve types in the AST (converts literals for JSON path comparisons)
     args.selection = node.type_resolver.resolve_selection_types(args.selection);
@@ -220,7 +223,7 @@ where
 
     let resultset = EntityResultSet::empty();
     let query_id = proto::QueryId::new();
-    let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(&node, cdata.clone()));
+    let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(&node, sessions.clone()));
 
     let inner = Arc::new(Inner {
         query_id,
@@ -263,14 +266,14 @@ impl EntityLiveQuery {
         node: &Node<SE, PA>,
         collection_id: CollectionId,
         args: MatchArgs,
-        cdata: PA::ContextData,
+        sessions: impl Into<crate::session::Sessions<PA::ContextData>>,
     ) -> Result<Self, RetrievalError>
     where
         SE: StorageEngine + Send + Sync + 'static,
         PA: PolicyAgent + Send + Sync + 'static,
     {
         let node_ref: Box<dyn NodeRef> = Box::new(StrongNodeRef(Arc::clone(&node.0)));
-        Self::new_with_node_ref(node, node_ref, collection_id, args, cdata)
+        Self::new_with_node_ref(node, node_ref, collection_id, args, sessions.into())
     }
 
     /// Create a LiveQuery that does NOT keep the node alive.
@@ -283,14 +286,14 @@ impl EntityLiveQuery {
         node: &Node<SE, PA>,
         collection_id: CollectionId,
         args: MatchArgs,
-        cdata: PA::ContextData,
+        sessions: impl Into<crate::session::Sessions<PA::ContextData>>,
     ) -> Result<Self, RetrievalError>
     where
         SE: StorageEngine + Send + Sync + 'static,
         PA: PolicyAgent + Send + Sync + 'static,
     {
         let node_ref: Box<dyn NodeRef> = Box::new(WeakNodeRefImpl(Arc::downgrade(&node.0)));
-        Self::new_with_node_ref(node, node_ref, collection_id, args, cdata)
+        Self::new_with_node_ref(node, node_ref, collection_id, args, sessions.into())
     }
 
     fn new_with_node_ref<SE, PA>(
@@ -298,21 +301,21 @@ impl EntityLiveQuery {
         node_ref: Box<dyn NodeRef>,
         collection_id: CollectionId,
         args: MatchArgs,
-        cdata: PA::ContextData,
+        sessions: crate::session::Sessions<PA::ContextData>,
     ) -> Result<Self, RetrievalError>
     where
         SE: StorageEngine + Send + Sync + 'static,
         PA: PolicyAgent + Send + Sync + 'static,
     {
         let has_relay = node.subscription_relay.is_some();
-        let (inner, query_id) = create_inner(node, node_ref, collection_id.clone(), args, cdata.clone())?;
+        let (inner, query_id) = create_inner(node, node_ref, collection_id.clone(), args, sessions.clone())?;
 
         let me = Self(inner.clone());
 
         // Ephemeral node: register with relay for remote subscription
         // Remote will call activate() after applying deltas via subscription_established
         if has_relay {
-            node.subscribe_remote_query(query_id, collection_id, inner.selection.value().0, cdata, 1, me.weak());
+            node.subscribe_remote_query(query_id, collection_id, inner.selection.value().0, sessions, 1, me.weak());
         }
 
         Ok(me)

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -138,7 +138,7 @@ where PA: PolicyAgent
     rng: Mutex<SmallRng>,
 
     /// The node's live credential sessions, one per ordinary Context
-    /// (a set-backed context reads this whole set instead), culled by
+    /// (the system context reads this whole set instead), culled by
     /// RAII when the last holder drops.
     pub sessions: crate::session::SessionSet<PA::ContextData>,
 
@@ -857,6 +857,13 @@ where
         self.system.wait_system_ready().await;
         Context::new(Node::clone(self), data)
     }
+
+    /// The context system queries read through: credentialed by the node's
+    /// whole live SessionSet, so reads run under the union of active
+    /// credentials and re-permission as sessions come, go, and refresh.
+    /// Not a user surface; write operations refuse through it.
+    #[allow(dead_code)] // First consumer is the catalog manager (next PR).
+    pub(crate) fn system_context(&self) -> Context { Context::new_system(Node::clone(self)) }
 
     pub(crate) async fn get_from_peer(
         &self,

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -138,7 +138,7 @@ where PA: PolicyAgent
     rng: Mutex<SmallRng>,
 
     /// The node's live credential sessions, one per ordinary Context
-    /// (the system context reads this whole set instead), culled by
+    /// (a set-backed context reads this whole set instead), culled by
     /// RAII when the last holder drops.
     pub sessions: crate::session::SessionSet<PA::ContextData>,
 
@@ -857,13 +857,6 @@ where
         self.system.wait_system_ready().await;
         Context::new(Node::clone(self), data)
     }
-
-    /// The context system queries read through: credentialed by the node's
-    /// whole live SessionSet, so reads run under the union of active
-    /// credentials and re-permission as sessions come, go, and refresh.
-    /// Not a user surface; write operations refuse through it.
-    #[allow(dead_code)] // First consumer is the catalog manager (next PR).
-    pub(crate) fn system_context(&self) -> Context { Context::new_system(Node::clone(self)) }
 
     pub(crate) async fn get_from_peer(
         &self,

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -7,7 +7,6 @@ use rand::prelude::*;
 use rand::rngs::SmallRng;
 use std::{
     fmt,
-    hash::Hash,
     ops::Deref,
     sync::{Arc, Mutex, Weak},
 };
@@ -119,9 +118,7 @@ where PA: PolicyAgent
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
-/// Represents the user session - or whatever other context the PolicyAgent
-/// Needs to perform it's evaluation.
-pub trait ContextData: Send + Sync + Clone + Hash + Eq + 'static {}
+pub use crate::session::ContextData;
 
 pub struct NodeInner<SE, PA>
 where PA: PolicyAgent
@@ -140,7 +137,10 @@ where PA: PolicyAgent
     /// RNG state and Node is shared across tasks; the lock is only ever held for a single draw.
     rng: Mutex<SmallRng>,
 
-    pub(crate) predicate_context: SafeMap<proto::QueryId, PA::ContextData>,
+    /// The node's live credential sessions, one per ordinary Context
+    /// (a set-backed context reads this whole set instead), culled by
+    /// RAII when the last holder drops.
+    pub sessions: crate::session::SessionSet<PA::ContextData>,
 
     /// The reactor for handling subscriptions
     pub(crate) reactor: Reactor,
@@ -202,7 +202,7 @@ where
             policy_agent,
             system: system_manager,
             catalog: catalog.clone(),
-            predicate_context: SafeMap::new(),
+            sessions: crate::session::SessionSet::new(),
             subscription_relay,
             type_resolver: crate::TypeResolver::new(),
         }));
@@ -535,10 +535,18 @@ where
             }
             proto::NodeRequestBody::SubscribeQuery { query_id, collection, selection, version, known_matches } => {
                 let peer_state = self.peer_connections.get(&request.from).ok_or_else(|| anyhow!("Peer {} not connected", request.from))?;
-                // only one cdata is permitted for SubscribePredicate
-                use itertools::Itertools;
-                let cdata = cdata.iterable().exactly_one().map_err(|_| anyhow!("Only one cdata is permitted for SubscribePredicate"))?;
-                peer_state.subscription_handler.subscribe_query(self, query_id, collection, selection, cdata, version, known_matches).await
+                // Every validated credential governs the subscription: the
+                // policy agent evaluates the union (a system query carries
+                // one per live session; user queries carry exactly one).
+                // An EMPTY list ships too (a set-backed query with no live
+                // sessions asks for the server's own verdict); accepting
+                // it is each agent's vacuous-loop semantics, an open
+                // decision: https://github.com/ankurah/ankurah/issues/432
+                let cdatas: Vec<PA::ContextData> = cdata.iterable().cloned().collect();
+                peer_state
+                    .subscription_handler
+                    .subscribe_query(self, query_id, collection, selection, &cdatas, version, known_matches)
+                    .await
             }
         }
     }
@@ -854,7 +862,7 @@ where
         &self,
         collection_id: &CollectionId,
         ids: Vec<proto::EntityId>,
-        cdata: &PA::ContextData,
+        cdata: &Vec<PA::ContextData>,
     ) -> Result<(), RetrievalError> {
         let peer_id = self.get_durable_peer_random().ok_or(RetrievalError::NoDurablePeers)?;
 
@@ -965,15 +973,14 @@ where
         query_id: proto::QueryId,
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
-        cdata: PA::ContextData,
+        sessions: crate::session::Sessions<PA::ContextData>,
         version: u32,
         livequery: crate::livequery::WeakEntityLiveQuery,
     ) {
         if let Some(ref relay) = self.subscription_relay {
             // Resolve types in the AST (converts literals for JSON path comparisons)
             let selection = self.type_resolver.resolve_selection_types(selection);
-            self.predicate_context.insert(query_id, cdata.clone());
-            relay.subscribe_query(query_id, collection_id, selection, cdata, version, livequery);
+            relay.subscribe_query(query_id, collection_id, selection, sessions, version, livequery);
         }
     }
 
@@ -1017,9 +1024,6 @@ where
     PA: PolicyAgent + Send + Sync + 'static,
 {
     fn unsubscribe_remote_predicate(&self, query_id: proto::QueryId) {
-        // Clean up subscription context
-        self.predicate_context.remove(&query_id);
-
         // Notify subscription relay for remote cleanup
         if let Some(ref relay) = self.subscription_relay {
             relay.unsubscribe_predicate(query_id);

--- a/core/src/peer_subscription/client_relay.rs
+++ b/core/src/peer_subscription/client_relay.rs
@@ -38,7 +38,10 @@ pub struct Content<CD: ContextData> {
     pub query_id: proto::QueryId,
     pub collection_id: CollectionId,
     pub selection: ankql::ast::Selection,
-    pub context_data: CD,
+    /// The live credential source; every send reads its then-current
+    /// values, so a reconnect re-registration after a refresh carries the
+    /// fresh ones. A set-backed query sends every live credential.
+    pub sessions: crate::session::Sessions<CD>,
     pub version: u32,
 }
 
@@ -129,7 +132,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         query_id: proto::QueryId,
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
-        context_data: CD,
+        sessions: crate::session::Sessions<CD>,
         version: u32,
         livequery: Q,
     ) {
@@ -138,7 +141,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             self.inner.subscriptions.lock().expect("poisoned lock").insert(
                 query_id,
                 RemoteQueryState {
-                    content: Arc::new(Content { collection_id, selection, context_data, query_id, version }),
+                    content: Arc::new(Content { collection_id, selection, sessions, query_id, version }),
                     status: Status::PendingRemote,
                     livequery,
                 },
@@ -162,7 +165,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
                     state.content = Arc::new(Content {
                         collection_id: old_content.collection_id.clone(),
                         selection: selection.clone(),
-                        context_data: old_content.context_data.clone(),
+                        sessions: old_content.sessions.clone(),
                         query_id: old_content.query_id,
                         version,
                     });
@@ -171,7 +174,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
                         Status::Established(peer_id, _old_version) => {
                             // Update to new version, mark as requested for this peer
                             state.status = Status::Requested(peer_id, version);
-                            Some((peer_id, state.content.collection_id.clone(), state.content.context_data.clone()))
+                            Some((peer_id, state.content.collection_id.clone(), state.content.sessions.clone()))
                             // Return the peer_id to send update to
                         }
                         _ => {
@@ -186,8 +189,8 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         };
 
         match update {
-            Some((peer_id, collection_id, context_data)) => {
-                self.update_query_on_peer(peer_id, query_id, collection_id, selection, version, context_data);
+            Some((peer_id, collection_id, sessions)) => {
+                self.update_query_on_peer(peer_id, query_id, collection_id, selection, version, sessions);
             }
             None => {
                 // Not established yet - use setup_remote_subscriptions for initial setup
@@ -205,7 +208,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
         version: u32,
-        context_data: CD,
+        sessions: crate::session::Sessions<CD>,
     ) {
         let me = self.clone();
         crate::task::spawn(async move {
@@ -215,8 +218,9 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
                     me.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner()).get(&query_id).map(|state| state.livequery.clone())
                 };
 
-                // Send the updated predicate to the peer
-                match node.remote_subscribe(peer_id, query_id, collection_id, selection, &context_data, version).await {
+                // Send the updated predicate to the peer, under the
+                // credentials current at send time.
+                match node.remote_subscribe(peer_id, query_id, collection_id, selection, sessions.snapshot(), version).await {
                     Ok(()) => {
                         // Deltas applied successfully, now activate the livequery
                         if let Some(lq) = livequery {
@@ -323,7 +327,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             match &state.status {
                 Status::Established(established_peer, _) | Status::Requested(established_peer, _) => {
                     if established_peer == peer_id {
-                        contexts.insert(state.content.context_data.clone());
+                        contexts.extend(state.content.sessions.snapshot());
                     }
                 }
                 _ => {}
@@ -384,7 +388,8 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
     async fn attempt_subscribe(self, node: Arc<dyn TNode<CD>>, target_peer: proto::EntityId, content: Arc<Content<CD>>) {
         let query_id = content.query_id;
         let predicate = content.selection.clone();
-        let context_data = content.context_data.clone();
+        // Credentials read at send time from the live source.
+        let cdatas = content.sessions.snapshot();
         let version = content.version;
 
         // Get the livequery for error handling
@@ -392,7 +397,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             { self.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner()).get(&query_id).map(|state| state.livequery.clone()) };
 
         // Call remote_subscribe which fetches known matches, subscribes, applies deltas, and stores events
-        match node.remote_subscribe(target_peer, query_id, content.collection_id.clone(), predicate, &context_data, version).await {
+        match node.remote_subscribe(target_peer, query_id, content.collection_id.clone(), predicate, cdatas, version).await {
             Ok(()) => {
                 // Deltas applied successfully, now activate the livequery
                 // The livequery handles its own errors internally
@@ -487,7 +492,7 @@ pub trait TNode<CD: ContextData>: Send + Sync {
         query_id: proto::QueryId,
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
-        context_data: &CD,
+        context_data: Vec<CD>,
         version: u32,
     ) -> Result<(), RetrievalError>;
 
@@ -509,7 +514,7 @@ where
         query_id: proto::QueryId,
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
-        context_data: &PA::ContextData,
+        context_data: Vec<PA::ContextData>,
         version: u32,
     ) -> Result<(), RetrievalError> {
         let node = self.upgrade().ok_or_else(|| RetrievalError::Other("Node has been dropped".to_string()))?;
@@ -526,7 +531,7 @@ where
         let deltas = match node
             .request(
                 peer_id,
-                context_data,
+                &context_data,
                 ankurah_proto::NodeRequestBody::SubscribeQuery {
                     query_id,
                     collection: collection_id.clone(),
@@ -551,7 +556,7 @@ where
         );
         // 3. Apply deltas to local node using NodeApplier
         let collection = node.collections.get(&collection_id).await?;
-        let event_getter = crate::retrieval::CachedEventGetter::new(collection_id, collection.clone(), &node, context_data);
+        let event_getter = crate::retrieval::CachedEventGetter::new(collection_id, collection.clone(), &node, &context_data);
         let state_getter = crate::retrieval::LocalStateGetter::new(collection);
         crate::node_applier::NodeApplier::apply_deltas(&node, &peer_id, deltas, &event_getter, &state_getter).await?;
 
@@ -622,7 +627,7 @@ mod tests {
             query_id: proto::QueryId,
             collection_id: CollectionId,
             selection: ankql::ast::Selection,
-            _context_data: &CD,
+            _context_data: Vec<CD>,
             _version: u32,
         ) -> Result<(), RetrievalError> {
             self.sent_requests.lock().unwrap().push((peer_id, query_id, collection_id.clone(), selection.clone()));
@@ -690,7 +695,14 @@ mod tests {
         relay.notify_peer_connected(peer_id);
 
         // Notify of new subscription
-        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            query_id,
+            collection_id.clone(),
+            predicate.clone(),
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
 
         // Check initial state - subscription should immediately go to Requested state since peer is connected
         assert!(matches!(relay.get_status(query_id), Some(Status::Requested(_, _))));
@@ -725,7 +737,14 @@ mod tests {
         relay.notify_peer_connected(peer_id);
 
         // Setup established subscription by going through the full flow
-        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            query_id,
+            collection_id.clone(),
+            predicate,
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
 
         // Give async task time to complete
         futures_timer::Delay::new(std::time::Duration::from_millis(10)).await;
@@ -751,7 +770,14 @@ mod tests {
         let peer_id = EntityId::new();
 
         // Add pending subscription (no peers connected yet)
-        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            query_id,
+            collection_id.clone(),
+            predicate.clone(),
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
         assert!(matches!(relay.get_status(query_id), Some(Status::PendingRemote)));
 
         // Clear any previous requests
@@ -786,7 +812,14 @@ mod tests {
 
         // Connect peer and add subscription (should succeed initially)
         relay.notify_peer_connected(peer_id);
-        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            query_id,
+            collection_id.clone(),
+            predicate.clone(),
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
 
         // Give async task time to complete
         futures_timer::Delay::new(std::time::Duration::from_millis(10)).await;
@@ -832,8 +865,22 @@ mod tests {
         let peer_id = EntityId::new();
 
         // Add subscriptions
-        relay.subscribe_query(retryable_query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
-        relay.subscribe_query(non_retryable_query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            retryable_query_id,
+            collection_id.clone(),
+            predicate.clone(),
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
+        relay.subscribe_query(
+            non_retryable_query_id,
+            collection_id.clone(),
+            predicate.clone(),
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
 
         // Manually set different failure types - retryable goes back to pending, non-retryable stays failed
         {
@@ -877,7 +924,14 @@ mod tests {
 
         // Connect peer and setup established subscription
         relay.notify_peer_connected(peer_id);
-        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            query_id,
+            collection_id.clone(),
+            predicate,
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
 
         // Give async task time to complete
         futures_timer::Delay::new(std::time::Duration::from_millis(10)).await;
@@ -914,7 +968,14 @@ mod tests {
         let peer_id = EntityId::new();
 
         // Test setup without message sender - should not crash
-        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            query_id,
+            collection_id.clone(),
+            predicate.clone(),
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
         futures_timer::Delay::new(std::time::Duration::from_millis(10)).await;
 
         // Should still be pending since no sender
@@ -950,7 +1011,14 @@ mod tests {
         let predicate = create_test_selection();
 
         // Add subscription but don't establish it
-        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            query_id,
+            collection_id.clone(),
+            predicate,
+            crate::session::Session::detached(collection_id.clone()).into(),
+            0,
+            MockLiveQuery,
+        );
         assert!(matches!(relay.get_status(query_id), Some(Status::PendingRemote)));
 
         // Unsubscribe from pending subscription

--- a/core/src/peer_subscription/client_relay.rs
+++ b/core/src/peer_subscription/client_relay.rs
@@ -19,18 +19,37 @@ pub trait RemoteQuerySubscriber: Clone + Send + Sync + 'static {
     /// Handles marking initialization as complete and setting last_error on failure
     async fn subscription_established(&self, version: u32);
 
-    /// Set the last error for this subscription
-    fn set_last_error(&self, error: RetrievalError);
+    /// Latch a relay-leg error, floored on the same report sequence as
+    /// the status transition it accompanies: a superseded failure's late
+    /// latch must not overwrite a newer attempt's recovery.
+    fn set_last_error(&self, seq: u64, error: RetrievalError);
+
+    /// Report a remote-leg transition; the livequery folds it into its
+    /// public status signal. `seq` is drawn under the relay's lock at the
+    /// transition and floors delivery: reports dispatch outside the lock,
+    /// so a delayed older report must never overwrite a newer one.
+    fn remote_status(&self, seq: u64, status: crate::livequery::RemoteStatus);
 }
 
 #[derive(Debug, Clone)]
 pub enum Status {
     PendingRemote,
-    Requested(proto::EntityId, u32),     // peer_id, version
-    Established(proto::EntityId, u32),   // peer_id, version
-    PendingUpdate(proto::EntityId, u32), // peer_id, version
+    Requested(proto::EntityId, u32),   // peer_id, version
+    Established(proto::EntityId, u32), // peer_id, version
     /// Non-retryable
     Failed,
+}
+
+/// The public projection of a [`Status`] transition, for the derivable
+/// arms; `Failed` carries no error here, so its reports are built where
+/// the error is in hand (`handle_error`).
+fn projected(status: &Status) -> Option<crate::livequery::RemoteStatus> {
+    match status {
+        Status::PendingRemote => Some(crate::livequery::RemoteStatus::Pending),
+        Status::Requested(_, version) => Some(crate::livequery::RemoteStatus::Requested { version: *version }),
+        Status::Established(_, version) => Some(crate::livequery::RemoteStatus::Established { version: *version }),
+        Status::Failed => None,
+    }
 }
 
 #[derive(Debug)]
@@ -49,6 +68,32 @@ pub struct RemoteQueryState<CD: ContextData, Q: RemoteQuerySubscriber> {
     pub content: Arc<Content<CD>>,
     pub status: Status,
     pub livequery: Q,
+    /// Monotonic stamp for status reports, drawn under the subscriptions
+    /// lock at each transition; the livequery floors on it.
+    pub report_seq: u64,
+    /// Monotonic per-entry attempt id, bumped under the lock every time
+    /// a send is dispatched. `(peer, version)` alone is REUSABLE (a
+    /// reconnect of the same peer re-sends the same version), so reports
+    /// must also match the attempt that produced them or two attempts
+    /// alias and a dead one can resolve its successor's state.
+    pub attempt: u64,
+}
+
+impl<CD: ContextData, Q: RemoteQuerySubscriber> RemoteQueryState<CD, Q> {
+    /// Stamp the CURRENT status for reporting: bump the sequence under
+    /// the lock and project. Dispatch the returned report after the lock
+    /// is released.
+    fn stamp(&mut self) -> Option<(u64, crate::livequery::RemoteStatus, Q)> {
+        let report = projected(&self.status)?;
+        self.report_seq += 1;
+        Some((self.report_seq, report, self.livequery.clone()))
+    }
+
+    /// Stamp with an explicit report (the non-derivable Failed arms).
+    fn stamp_with(&mut self, report: crate::livequery::RemoteStatus) -> (u64, crate::livequery::RemoteStatus, Q) {
+        self.report_seq += 1;
+        (self.report_seq, report, self.livequery.clone())
+    }
 }
 
 struct SubscriptionRelayInner<CD: ContextData, Q: RemoteQuerySubscriber> {
@@ -137,15 +182,20 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         livequery: Q,
     ) {
         debug!("SubscriptionRelay.subscribe_predicate() - New predicate {} needs remote registration", query_id);
-        {
-            self.inner.subscriptions.lock().expect("poisoned lock").insert(
-                query_id,
-                RemoteQueryState {
-                    content: Arc::new(Content { collection_id, selection, sessions, query_id, version }),
-                    status: Status::PendingRemote,
-                    livequery,
-                },
-            );
+        let stamped = {
+            let mut state = RemoteQueryState {
+                content: Arc::new(Content { collection_id, selection, sessions, query_id, version }),
+                status: Status::PendingRemote,
+                livequery,
+                report_seq: 0,
+                attempt: 0,
+            };
+            let stamped = state.stamp();
+            self.inner.subscriptions.lock().expect("poisoned lock").insert(query_id, state);
+            stamped
+        };
+        if let Some((seq, report, livequery)) = stamped {
+            livequery.remote_status(seq, report);
         }
 
         // Immediately attempt setup with available peers
@@ -160,6 +210,15 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             let mut subscriptions = self.inner.subscriptions.lock().expect("poisoned lock");
             match subscriptions.get_mut(&query_id) {
                 Some(state) => {
+                    // Racing reissues dispatch unordered after minting under
+                    // the livequery's lock. A stale write here would be
+                    // re-sent verbatim by the next reconnect or retry, so
+                    // the stored content gets the same floor the completion
+                    // transitions and the server upsert enforce.
+                    if version < state.content.version {
+                        debug!("Ignoring stale update_query for {} (version {} < {})", query_id, version, state.content.version);
+                        return Ok(());
+                    }
                     // Update the content with new predicate and version
                     let old_content = &state.content;
                     state.content = Arc::new(Content {
@@ -173,14 +232,18 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
                     match state.status {
                         Status::Established(peer_id, _old_version) => {
                             // Update to new version, mark as requested for this peer
+                            state.attempt += 1;
                             state.status = Status::Requested(peer_id, version);
-                            Some((peer_id, state.content.collection_id.clone(), state.content.sessions.clone()))
+                            (
+                                state.stamp(),
+                                Some((peer_id, state.content.collection_id.clone(), state.content.sessions.snapshot(), state.attempt)),
+                            )
                             // Return the peer_id to send update to
                         }
                         _ => {
                             // Not established yet, just update to PendingRemote and setup
                             state.status = Status::PendingRemote;
-                            None
+                            (state.stamp(), None)
                         }
                     }
                 }
@@ -188,9 +251,13 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             }
         };
 
-        match update {
-            Some((peer_id, collection_id, sessions)) => {
-                self.update_query_on_peer(peer_id, query_id, collection_id, selection, version, sessions);
+        let (stamped, target) = update;
+        if let Some((seq, report, livequery)) = stamped {
+            livequery.remote_status(seq, report);
+        }
+        match target {
+            Some((peer_id, collection_id, context_data, attempt)) => {
+                self.update_query_on_peer(peer_id, query_id, collection_id, selection, version, context_data, attempt);
             }
             None => {
                 // Not established yet - use setup_remote_subscriptions for initial setup
@@ -201,6 +268,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn update_query_on_peer(
         &self,
         peer_id: proto::EntityId,
@@ -208,35 +276,49 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
         version: u32,
-        sessions: crate::session::Sessions<CD>,
+        context_data: Vec<CD>,
+        attempt: u64,
     ) {
         let me = self.clone();
         crate::task::spawn(async move {
             if let Some(node) = me.inner.node.get() {
-                // Get the livequery for error handling
-                let livequery = {
-                    me.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner()).get(&query_id).map(|state| state.livequery.clone())
-                };
-
-                // Send the updated predicate to the peer, under the
-                // credentials current at send time.
-                match node.remote_subscribe(peer_id, query_id, collection_id, selection, sessions.snapshot(), version).await {
+                // Send the updated predicate to the peer
+                match node.remote_subscribe(peer_id, query_id, collection_id, selection, context_data, version).await {
                     Ok(()) => {
-                        // Deltas applied successfully, now activate the livequery
-                        if let Some(lq) = livequery {
+                        // Claim the completion FIRST, then activate: only
+                        // the attempt that wins the transition may run
+                        // activation, through the livequery its own stamp
+                        // carries (activating before the claim would let a
+                        // dead attempt's late completion activate the local
+                        // leg and clear an error a live attempt latched).
+                        // Acceptance is by attempt identity; the full rule
+                        // lives at attempt_subscribe's completion arm.
+                        let (stamped, kick) = {
+                            let mut subscriptions = me.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner());
+                            match subscriptions.get_mut(&query_id) {
+                                Some(info) => match info.status {
+                                    Status::Requested(peer, v) if peer == peer_id && v == version && info.attempt == attempt => {
+                                        info.status = Status::Established(peer_id, version);
+                                        (info.stamp(), false)
+                                    }
+                                    Status::PendingRemote => (None, true),
+                                    _ => (None, false),
+                                },
+                                None => (None, false),
+                            }
+                        };
+                        if let Some((seq, report, lq)) = stamped {
                             lq.subscription_established(version).await;
+                            lq.remote_status(seq, report);
                         }
-
-                        // Mark as established - subscription succeeded even if livequery activation had issues
-                        let mut subscriptions = me.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner());
-                        if let Some(info) = subscriptions.get_mut(&query_id) {
-                            info.status = Status::Established(peer_id, version);
+                        if kick {
+                            me.setup_remote_subscriptions();
                         }
                         debug!("Successfully updated predicate {} on peer {} subscription", query_id, peer_id);
                     }
                     Err(e) => {
                         // Handle error with retry logic
-                        me.handle_error(query_id, peer_id, e, livequery).await;
+                        me.handle_error(query_id, peer_id, e, version, attempt).await;
                     }
                 }
             }
@@ -283,14 +365,25 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         // Remove from connected peers
         self.inner.connected_peers.remove(&peer_id);
 
-        for info in self.inner.subscriptions.lock().expect("poisoned lock").values_mut() {
-            if let Status::Established(established_peer_id, _) | Status::Requested(established_peer_id, _) = &info.status {
-                if *established_peer_id == peer_id {
-                    // Update state to pending
-                    info.status = Status::PendingRemote;
-                    warn!("Predicate {} orphaned due to peer {} disconnect", info.content.query_id, peer_id);
-                }
-            }
+        let orphaned: Vec<_> = {
+            let mut subscriptions = self.inner.subscriptions.lock().expect("poisoned lock");
+            subscriptions
+                .values_mut()
+                .filter_map(|info| {
+                    if let Status::Established(established_peer_id, _) | Status::Requested(established_peer_id, _) = &info.status {
+                        if *established_peer_id == peer_id {
+                            // Update state to pending
+                            info.status = Status::PendingRemote;
+                            warn!("Predicate {} orphaned due to peer {} disconnect", info.content.query_id, peer_id);
+                            return info.stamp();
+                        }
+                    }
+                    None
+                })
+                .collect()
+        };
+        for (seq, report, livequery) in orphaned {
+            livequery.remote_status(seq, report);
         }
 
         // Resubscribe any orphaned subscriptions
@@ -365,8 +458,9 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
                 .values_mut()
                 .filter_map(|info| {
                     if let Status::PendingRemote = info.status {
+                        info.attempt += 1;
                         info.status = Status::Requested(target_peer, info.content.version);
-                        Some(info.content.clone())
+                        Some((info.content.clone(), info.attempt, info.stamp()))
                     } else {
                         None
                     }
@@ -380,41 +474,66 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
 
         debug!("Registering {} predicates on {} peer subscriptions", pending.len(), self.inner.connected_peers.len());
 
-        for content in pending {
-            crate::task::spawn(self.clone().attempt_subscribe(node.clone(), target_peer, content));
+        for (content, attempt, stamped) in pending {
+            if let Some((seq, report, livequery)) = stamped {
+                livequery.remote_status(seq, report);
+            }
+            crate::task::spawn(self.clone().attempt_subscribe(node.clone(), target_peer, content, attempt));
         }
     }
 
-    async fn attempt_subscribe(self, node: Arc<dyn TNode<CD>>, target_peer: proto::EntityId, content: Arc<Content<CD>>) {
+    async fn attempt_subscribe(self, node: Arc<dyn TNode<CD>>, target_peer: proto::EntityId, content: Arc<Content<CD>>, attempt: u64) {
         let query_id = content.query_id;
         let predicate = content.selection.clone();
-        // Credentials read at send time from the live source.
-        let cdatas = content.sessions.snapshot();
+        let context_data = content.sessions.snapshot();
         let version = content.version;
 
-        // Get the livequery for error handling
-        let livequery =
-            { self.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner()).get(&query_id).map(|state| state.livequery.clone()) };
-
         // Call remote_subscribe which fetches known matches, subscribes, applies deltas, and stores events
-        match node.remote_subscribe(target_peer, query_id, content.collection_id.clone(), predicate, cdatas, version).await {
+        match node.remote_subscribe(target_peer, query_id, content.collection_id.clone(), predicate, context_data, version).await {
             Ok(()) => {
-                // Deltas applied successfully, now activate the livequery
-                // The livequery handles its own errors internally
-                if let Some(lq) = livequery {
+                // Claim the completion FIRST, then activate. A report is
+                // acted on ONLY when it matches the outstanding attempt:
+                // every send stamps Requested(peer, version) and bumps the
+                // attempt, so a report that finds anything else is a dead
+                // attempt's late echo (superseded by a newer send, re-routed
+                // after its peer disconnected, or already resolved). A
+                // matching Requested also implies the version IS the newest
+                // content (a newer mint would have re-stamped the entry,
+                // breaking the match). Dead echoes never mutate state; an
+                // entry sitting at PendingRemote gets a kick so a lost
+                // dispatch cannot strand it. Only the claiming attempt runs
+                // activation, through the livequery its own stamp carries:
+                // activating before the claim would let a dead attempt's
+                // late completion activate the local leg and clear an error
+                // a live attempt latched. (remote_subscribe already merged
+                // the response deltas into storage; that data was attested
+                // by the server regardless of which attempt fetched it.)
+                let (stamped, kick) = {
+                    let mut subscriptions = self.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner());
+                    match subscriptions.get_mut(&query_id) {
+                        Some(info) => match info.status {
+                            Status::Requested(peer, v) if peer == target_peer && v == version && info.attempt == attempt => {
+                                info.status = Status::Established(target_peer, version);
+                                (info.stamp(), false)
+                            }
+                            Status::PendingRemote => (None, true),
+                            _ => (None, false),
+                        },
+                        None => (None, false),
+                    }
+                };
+                if let Some((seq, report, lq)) = stamped {
                     lq.subscription_established(version).await;
+                    lq.remote_status(seq, report);
                 }
-
-                // Mark as established - subscription succeeded even if livequery activation had issues
-                let mut subscriptions = self.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner());
-                if let Some(info) = subscriptions.get_mut(&query_id) {
-                    info.status = Status::Established(target_peer, version);
+                if kick {
+                    self.setup_remote_subscriptions();
                 }
                 debug!("Successfully registered predicate {} on peer {} subscription", query_id, target_peer);
             }
             Err(e) => {
                 // Handle error with retry logic
-                self.handle_error(query_id, target_peer, e, livequery).await;
+                self.handle_error(query_id, target_peer, e, version, attempt).await;
             }
         }
     }
@@ -440,7 +559,14 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
     }
 
     /// Handle errors with retry logic
-    async fn handle_error(&self, query_id: proto::QueryId, target_peer: proto::EntityId, error: RetrievalError, livequery: Option<Q>) {
+    async fn handle_error(
+        &self,
+        query_id: proto::QueryId,
+        target_peer: proto::EntityId,
+        error: RetrievalError,
+        version: u32,
+        attempt: u64,
+    ) {
         let error_msg = error.to_string();
 
         // Evaluate retriability at failure time
@@ -459,23 +585,66 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             _ => false,
         };
 
-        // Update state based on retriability
-        let mut subscriptions = self.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(info) = subscriptions.get_mut(&query_id) {
-            if is_retryable {
-                // Retryable errors go back to pending for retry by background task
-                info.status = Status::PendingRemote;
-                warn!("Retryable failure for predicate {} with peer {}: {} - will retry", query_id, target_peer, error_msg);
-            } else {
-                // Non-retryable errors are permanently failed
-                info.status = Status::Failed;
-                tracing::error!("Permanent failure for predicate {} with peer {}: {} - no retry", query_id, target_peer, error_msg);
-
-                // Set error on livequery
-                if let Some(lq) = livequery {
-                    lq.set_last_error(error);
-                }
+        // A failure is acted on ONLY when it matches the outstanding
+        // attempt (Requested with this peer and version) — the same rule
+        // as the completion sites; see the comment there. A matching
+        // retryable failure re-queues for the retry task; a matching
+        // terminal failure holds Failed (and latches) until a credential
+        // change or selection update re-kicks. A dead attempt's failure
+        // mutates nothing and latches nothing: the entry is either being
+        // driven by a live attempt or sits at PendingRemote, which gets a
+        // kick so a lost dispatch cannot strand it.
+        let (stamped, kick, latch_error) = {
+            let mut subscriptions = self.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner());
+            match subscriptions.get_mut(&query_id) {
+                Some(info) => match info.status {
+                    Status::Requested(peer, v) if peer == target_peer && v == version && info.attempt == attempt => {
+                        if is_retryable {
+                            // Retryable errors go back to pending for retry by background task
+                            info.status = Status::PendingRemote;
+                            warn!("Retryable failure for predicate {} with peer {}: {} - will retry", query_id, target_peer, error_msg);
+                            (info.stamp(), false, false)
+                        } else {
+                            // Non-retryable: report Denied for a local refusal
+                            // to sign, the error text otherwise.
+                            info.status = Status::Failed;
+                            tracing::error!(
+                                "Failure for predicate {} with peer {}: {} - awaiting re-kick",
+                                query_id,
+                                target_peer,
+                                error_msg
+                            );
+                            let report = if let RetrievalError::RequestError(RequestError::AccessDenied(denied)) = &error {
+                                crate::livequery::RemoteStatus::Denied { reason: denied.to_string() }
+                            } else {
+                                crate::livequery::RemoteStatus::Error { message: error_msg.clone() }
+                            };
+                            (Some(info.stamp_with(report)), false, true)
+                        }
+                    }
+                    Status::PendingRemote => {
+                        debug!(
+                            "Failure for predicate {} from a dead attempt (v{} via {}); entry pending re-drive",
+                            query_id, version, target_peer
+                        );
+                        (None, true, false)
+                    }
+                    _ => {
+                        debug!("Ignoring failure for predicate {} from a dead attempt (v{} via {})", query_id, version, target_peer);
+                        (None, false, false)
+                    }
+                },
+                None => (None, false, false),
             }
+        };
+        if let Some((seq, report, lq)) = stamped {
+            if latch_error {
+                lq.set_last_error(seq, error);
+            }
+            lq.remote_status(seq, report);
+        }
+        if kick {
+            self.setup_remote_subscriptions();
         }
     }
 }
@@ -668,8 +837,12 @@ mod tests {
             // Mock - no-op
         }
 
-        fn set_last_error(&self, _error: RetrievalError) {
+        fn set_last_error(&self, _seq: u64, _error: RetrievalError) {
             // For tests, we don't track errors
+        }
+
+        fn remote_status(&self, _seq: u64, _status: crate::livequery::RemoteStatus) {
+            // For tests, we don't track status transitions
         }
     }
 

--- a/core/src/peer_subscription/server.rs
+++ b/core/src/peer_subscription/server.rs
@@ -66,7 +66,7 @@ impl SubscriptionHandler {
         query_id: proto::QueryId,
         collection_id: proto::CollectionId,
         mut selection: ankql::ast::Selection,
-        cdata: &PA::ContextData,
+        cdata: &Vec<PA::ContextData>,
         version: u32,
         known_matches: Vec<proto::KnownEntity>,
     ) -> anyhow::Result<proto::NodeResponseBody>
@@ -77,8 +77,29 @@ impl SubscriptionHandler {
         if version == 0 {
             return Err(anyhow::anyhow!("Invalid version 0 for subscription"));
         }
-        node.policy_agent.can_access_collection(cdata, &collection_id)?;
-        selection.predicate = node.policy_agent.filter_predicate(cdata, &collection_id, selection.predicate)?;
+        // A failed validation removes any STANDING registration for this
+        // query before erroring: re-subscribes re-validate under the
+        // peer's current credentials, and a credential that lost access
+        // must not leave the previous registration streaming under the
+        // grant it replaced — the server-side half of the claw-back. The
+        // removal is floored on this request's version so a DELAYED older
+        // request that now fails validation cannot tear down the live
+        // newer registration that superseded it. (Idempotent; first-time
+        // subscribes have nothing to remove. A tombstone preventing an
+        // older request from re-REGISTERING after removal is follow-up
+        // work: https://github.com/ankurah/ankurah/issues/429)
+        let validated = node
+            .policy_agent
+            .can_access_collection(cdata, &collection_id)
+            .and_then(|()| node.policy_agent.filter_predicate(cdata, &collection_id, selection.predicate.clone()));
+        let filtered = match validated {
+            Ok(filtered) => filtered,
+            Err(denied) => {
+                let _ = self.subscription.remove_predicate_at_or_below(query_id, version);
+                return Err(denied.into());
+            }
+        };
+        selection.predicate = filtered;
         let storage_collection = node.collections.get(&collection_id).await?;
 
         // Add or update the query - idempotent, works whether query exists or not

--- a/core/src/reactor.rs
+++ b/core/src/reactor.rs
@@ -140,15 +140,43 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
 
         // Remove the query from the subscription
         let query_state = subscription.remove_query(query_id).ok_or(SubscriptionError::PredicateNotFound)?;
+        self.cleanup_removed_query(subscription_id, query_id, &query_state);
+        Ok(())
+    }
 
+    /// [`Self::remove_query`] behind a version floor: removes only a
+    /// registration at or below `version`, so a stale request's failure
+    /// cannot tear down its newer successor. Absence and a newer
+    /// registration are both quiet no-ops.
+    pub fn remove_query_at_or_below(
+        &self,
+        subscription_id: ReactorSubscriptionId,
+        query_id: proto::QueryId,
+        version: u32,
+    ) -> Result<(), SubscriptionError> {
+        let subscription = {
+            let subscriptions = self.0.subscriptions.lock().unwrap();
+            subscriptions.get(&subscription_id).cloned().ok_or(SubscriptionError::SubscriptionNotFound)?
+        };
+        if let Some(query_state) = subscription.remove_query_at_or_below(query_id, version) {
+            self.cleanup_removed_query(subscription_id, query_id, &query_state);
+        }
+        Ok(())
+    }
+
+    /// Watcher teardown shared by the removal paths.
+    fn cleanup_removed_query(
+        &self,
+        subscription_id: ReactorSubscriptionId,
+        query_id: proto::QueryId,
+        query_state: &subscription_state::QueryState<E>,
+    ) {
         // Remove from watchers (only if selection was set)
         if let Some(selection) = &query_state.selection {
             let mut watcher_set = self.0.watcher_set.lock().unwrap();
             let watcher_id = (subscription_id, query_id);
             watcher_set.recurse_predicate_watchers(&query_state.collection_id, &selection.predicate, watcher_id, WatcherOp::Remove);
         }
-
-        Ok(())
     }
 
     /// Add entity subscriptions to a subscription
@@ -400,7 +428,7 @@ impl Reactor<Entity, ankurah_proto::Attested<ankurah_proto::Event>> {
         collection_id: proto::CollectionId,
         selection: ankql::ast::Selection,
         node: &crate::node::Node<SE, PA>,
-        cdata: &PA::ContextData,
+        cdatas: &[PA::ContextData],
         version: u32,
     ) -> anyhow::Result<Vec<Entity>>
     where
@@ -414,9 +442,11 @@ impl Reactor<Entity, ankurah_proto::Attested<ankurah_proto::Event>> {
 
         let included_entities = node.fetch_entities_from_local(&collection_id, &selection).await?;
 
-        // Upsert query - register if new or get existing resultset
-        // Gap fetcher is only created if query doesn't exist yet
-        let resultset = subscription.upsert_query(query_id, collection_id.clone(), node, cdata);
+        // Upsert query - register if new or get existing resultset.
+        // Re-subscribes for the same query id arrive with freshly
+        // validated credentials; the stored gap fetcher's session is
+        // refreshed in place so later gap fills read under the latest one.
+        let resultset = subscription.upsert_query(query_id, collection_id.clone(), node, cdatas, version);
 
         // Update query - watcher management is handled internally
         let mut all_entities =

--- a/core/src/reactor.rs
+++ b/core/src/reactor.rs
@@ -4,6 +4,7 @@ pub mod fetch_gap;
 mod property_path;
 mod subscription;
 mod subscription_state;
+pub(crate) use subscription_state::QueryAlreadyRegistered;
 mod update;
 mod watcherset;
 
@@ -176,6 +177,12 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
             let mut watcher_set = self.0.watcher_set.lock().unwrap();
             let watcher_id = (subscription_id, query_id);
             watcher_set.recurse_predicate_watchers(&query_state.collection_id, &selection.predicate, watcher_id, WatcherOp::Remove);
+            // The per-entity watchers are keyed by (subscription, query)
+            // and must leave with the query: left behind, they keep
+            // routing those entities here after removal and merge into a
+            // re-added query's watcher set.
+            let entity_ids: Vec<ankurah_proto::EntityId> = query_state.resultset.keys().collect();
+            watcher_set.cleanup_removed_predicate_watchers(subscription_id, query_id, &entity_ids);
         }
     }
 
@@ -253,6 +260,7 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
     /// Add a query and send initialization notification (for local subscriptions)
     /// Collects ReactorUpdateItems and sends them
     /// pre_notify_hook is called before sending notification (e.g., to mark LiveQuery initialized)
+    #[allow(clippy::too_many_arguments)]
     pub async fn add_query_and_notify<H: PreNotifyHook>(
         &self,
         subscription_id: ReactorSubscriptionId,
@@ -262,6 +270,7 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         node: &dyn crate::node::TNodeErased<E>,
         resultset: EntityResultSet<E>,
         gap_fetcher: std::sync::Arc<dyn GapFetcher<E>>,
+        version: u32,
         pre_notify_hook: H,
     ) -> anyhow::Result<()> {
         // Get subscription reference
@@ -284,7 +293,9 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
             collection_id.clone(),
             selection.clone(),
             included_entities,
-            1, // version 1 for initial add
+            // A first activation is not always version 1: a query healing
+            // from Denied re-enters here at its current version.
+            version,
             &mut reactor_update_items,
         )?;
 
@@ -297,8 +308,8 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         // Mark as loaded
         resultset.set_loaded(true);
 
-        // Call pre-notify hook (e.g., mark LiveQuery as initialized) with version 1
-        pre_notify_hook.pre_notify(1);
+        // Call pre-notify hook (e.g., mark LiveQuery as initialized)
+        pre_notify_hook.pre_notify(version);
 
         // Send the notification with collected items. We always notify because we're initializing the query.
         subscription.send_update(reactor_update_items);
@@ -408,8 +419,12 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
             watcher_set.clear_entity_watchers();
         }
 
-        let subscriptions = self.0.subscriptions.lock().unwrap();
-        for subscription in subscriptions.values() {
+        // Collect the handles and release the GLOBAL mutex before any
+        // per-subscription reset runs: resets broadcast (resultset clears
+        // and ReactorUpdates), and a subscriber that synchronously revokes
+        // a credential re-enters remove_query, which needs this mutex.
+        let subscriptions: Vec<_> = self.0.subscriptions.lock().unwrap().values().cloned().collect();
+        for subscription in subscriptions {
             subscription.system_reset();
         }
     }
@@ -623,7 +638,7 @@ mod tests {
 
         // Add query using the reactor - this should send Initial notification
         reactor
-            .add_query_and_notify(rsub.id(), query_id, collection_id, selection, &mock_node, resultset, mock_gap_fetcher, ())
+            .add_query_and_notify(rsub.id(), query_id, collection_id, selection, &mock_node, resultset, mock_gap_fetcher, 1, ())
             .await
             .unwrap();
 
@@ -735,5 +750,81 @@ mod tests {
         let mut sorted2 = order2.clone();
         sorted2.sort();
         assert_eq!(order2, sorted2, "emission order must be sorted by subscription id on the second run too");
+    }
+
+    /// A deferred ADD whose query is superseded mid-batch is RE-DECIDED
+    /// against the superseding selection, not discarded. The superseding
+    /// update_query only re-adds entities its caller fetched BEFORE
+    /// taking the state lock, so an entity that persisted after that
+    /// fetch is re-decided by nobody else: discarding it here would
+    /// leave a row matching the current selection silently missing until
+    /// the entity next changes. The listener performs the supersede
+    /// re-entrantly from the FIRST deferred write's broadcast, with an
+    /// empty included_entities standing in for the pre-batch fetch,
+    /// which is exactly that interleave.
+    #[tokio::test]
+    async fn superseded_deferred_add_is_redecided_not_discarded() {
+        use ankurah_signals::Signal;
+
+        let reactor = Reactor::<TestEntity, TestEvent>::new();
+        let rsub = reactor.subscribe();
+
+        let query_id = QueryId::new();
+        let collection_id = CollectionId::fixed_name("album");
+        let selection: ankql::ast::Selection = "status = 'pending'".try_into().unwrap();
+        let resultset: EntityResultSet<TestEntity> = EntityResultSet::empty();
+        let mock_gap_fetcher = Arc::new(MockGapFetcher::new());
+        let empty_node = MockNode { entities: vec![] };
+
+        reactor
+            .add_query_and_notify(
+                rsub.id(),
+                query_id,
+                collection_id.clone(),
+                selection,
+                &empty_node,
+                resultset.clone(),
+                mock_gap_fetcher,
+                1,
+                (),
+            )
+            .await
+            .unwrap();
+
+        // The internal subscription handle, so the listener can run the
+        // superseding update_query synchronously from inside dispatch.
+        let subscription = reactor.0.subscriptions.lock().unwrap().get(&rsub.id()).cloned().unwrap();
+
+        let superseded = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let _listener_guard = {
+            let superseded = superseded.clone();
+            let collection_id = collection_id.clone();
+            resultset.listen(Arc::new(move |_| {
+                if !superseded.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                    // Same membership, new text: an ordinary re-permission
+                    // mints a version without changing what matches.
+                    let v2: ankql::ast::Selection = "status = 'pending' AND name != 'nope'".try_into().unwrap();
+                    subscription
+                        .update_query(query_id, collection_id.clone(), v2, vec![], 2, &mut Vec::new())
+                        .expect("re-entrant supersede must not fail");
+                }
+            }))
+        };
+
+        // One batch, two matching entities: two deferred adds. The first
+        // add's broadcast supersedes to version 2; the second add must be
+        // re-decided against version 2's selection, not dropped.
+        let e1 = TestEntity::new("first", "pending");
+        let e2 = TestEntity::new("second", "pending");
+        reactor
+            .notify_change(vec![TestChange { entity: e1.clone(), events: vec![] }, TestChange { entity: e2.clone(), events: vec![] }])
+            .await;
+
+        assert!(superseded.load(std::sync::atomic::Ordering::SeqCst), "the first write's broadcast must have superseded the query");
+        let mut ids: Vec<proto::EntityId> = resultset.keys().collect();
+        ids.sort();
+        let mut expected = vec![e1.id, e2.id];
+        expected.sort();
+        assert_eq!(ids, expected, "both batch entities belong to the superseding selection's resultset");
     }
 }

--- a/core/src/reactor/fetch_gap.rs
+++ b/core/src/reactor/fetch_gap.rs
@@ -31,17 +31,28 @@ pub trait GapFetcher<E: AbstractEntity>: Send + Sync + 'static {
         last_entity: Option<&E>,
         gap_size: usize,
     ) -> Result<Vec<E>, RetrievalError>;
+
+    /// A re-validated subscribe carries a fresh credential; a fetcher that
+    /// holds one adopts it in place, so later gap fills read under the
+    /// latest credential. Returns false when unsupported (or the type does
+    /// not match), and the caller replaces the fetcher instead: fail-safe,
+    /// never a silent opt-out.
+    fn refresh_credential(&self, _new: Box<dyn std::any::Any + Send>) -> bool { false }
 }
 
-/// Concrete implementation of GapFetcher using a WeakNode and typed ContextData
-#[derive(Clone)]
+/// Concrete implementation of GapFetcher using a WeakNode and a live
+/// credential source, read at fetch time so a refreshed credential is
+/// used without rebuilding the fetcher.
 pub struct QueryGapFetcher<SE, PA>
 where
     SE: StorageEngine,
     PA: PolicyAgent,
 {
     weak_node: Weak<NodeInner<SE, PA>>,
-    cdata: PA::ContextData,
+    /// Client side: the creating context's live source (`One`/`Set`),
+    /// refreshed through the context. Server side: a `Held` set this
+    /// fetcher's owner replaces on every re-validated subscribe.
+    sessions: crate::session::Sessions<PA::ContextData>,
 }
 
 impl<SE, PA> QueryGapFetcher<SE, PA>
@@ -49,7 +60,19 @@ where
     SE: StorageEngine,
     PA: PolicyAgent,
 {
-    pub fn new(node: &Node<SE, PA>, cdata: PA::ContextData) -> Self { Self { weak_node: Arc::downgrade(&node.0), cdata } }
+    /// A fetcher reading through the query's live credential source at
+    /// each fetch (client side: the creating context's session or the
+    /// system context's set).
+    pub fn new(node: &Node<SE, PA>, sessions: crate::session::Sessions<PA::ContextData>) -> Self {
+        Self { weak_node: Arc::downgrade(&node.0), sessions }
+    }
+
+    /// The server side's per-query holder, seeded with the subscriber's
+    /// credentials; [`GapFetcher::refresh_credential`] replaces them so
+    /// later gap fills read under the latest ones.
+    pub fn for_server(node: &Node<SE, PA>, cdatas: Vec<PA::ContextData>) -> Self {
+        Self { weak_node: Arc::downgrade(&node.0), sessions: crate::session::SessionHolder::new(cdatas).into() }
+    }
 }
 
 #[async_trait]
@@ -58,6 +81,22 @@ where
     SE: StorageEngine + 'static,
     PA: PolicyAgent + 'static,
 {
+    fn refresh_credential(&self, new: Box<dyn std::any::Any + Send>) -> bool {
+        let Ok(cdatas) = new.downcast::<Vec<PA::ContextData>>() else {
+            return false;
+        };
+        match &self.sessions {
+            // Client-side fetchers read through the context's own source;
+            // their credentials refresh through the context, never
+            // through here.
+            crate::session::Sessions::One(_) | crate::session::Sessions::Set(_) => false,
+            crate::session::Sessions::Held(holder) => {
+                holder.replace(*cdatas);
+                true
+            }
+        }
+    }
+
     async fn fetch_gap(
         &self,
         collection_id: &proto::CollectionId,
@@ -73,7 +112,7 @@ where
 
         // Create a Node wrapper and NodeAndContext
         let node = Node(node_inner);
-        let node_context = NodeAndContext { node, cdata: self.cdata.clone() };
+        let node_context = NodeAndContext { node, sessions: self.sessions.clone() };
 
         // Build gap predicate if we have a last entity
         let gap_selection = if let Some(last) = last_entity {

--- a/core/src/reactor/subscription.rs
+++ b/core/src/reactor/subscription.rs
@@ -57,10 +57,6 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
     /// Get the subscription ID
     pub fn id(&self) -> ReactorSubscriptionId { self.0.subscription_id }
 
-    /// Add a predicate to this subscription
-    // TODO: REMOVE this method - predicates should ONLY be added via set_predicate
-    // This creates an inactive predicate that does nothing until initialize() is called
-
     /// Remove a predicate from this subscription
     pub fn remove_predicate(&self, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
         self.0.reactor.remove_query(self.0.subscription_id, query_id)?;

--- a/core/src/reactor/subscription.rs
+++ b/core/src/reactor/subscription.rs
@@ -57,13 +57,16 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
     /// Get the subscription ID
     pub fn id(&self) -> ReactorSubscriptionId { self.0.subscription_id }
 
-    /// Add a predicate to this subscription
-    // TODO: REMOVE this method - predicates should ONLY be added via set_predicate
-    // This creates an inactive predicate that does nothing until initialize() is called
-
     /// Remove a predicate from this subscription
     pub fn remove_predicate(&self, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
         self.0.reactor.remove_query(self.0.subscription_id, query_id)?;
+        Ok(())
+    }
+
+    /// [`Self::remove_predicate`] behind a version floor; see
+    /// [`crate::reactor::Reactor::remove_query_at_or_below`].
+    pub fn remove_predicate_at_or_below(&self, query_id: proto::QueryId, version: u32) -> Result<(), SubscriptionError> {
+        self.0.reactor.remove_query_at_or_below(self.0.subscription_id, query_id, version)?;
         Ok(())
     }
 

--- a/core/src/reactor/subscription.rs
+++ b/core/src/reactor/subscription.rs
@@ -57,6 +57,10 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
     /// Get the subscription ID
     pub fn id(&self) -> ReactorSubscriptionId { self.0.subscription_id }
 
+    /// Add a predicate to this subscription
+    // TODO: REMOVE this method - predicates should ONLY be added via set_predicate
+    // This creates an inactive predicate that does nothing until initialize() is called
+
     /// Remove a predicate from this subscription
     pub fn remove_predicate(&self, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
         self.0.reactor.remove_query(self.0.subscription_id, query_id)?;

--- a/core/src/reactor/subscription_state.rs
+++ b/core/src/reactor/subscription_state.rs
@@ -44,6 +44,17 @@ impl<E, Ev> UpdateItemAccumulator<E, Ev> for () {
     fn push_remove(&mut self, _entity: &E, _query_id: proto::QueryId) {}
 }
 
+/// Typed conflict from [`Subscription::register_query`]: the caller
+/// (livequery activation) downcasts for it and falls back to the update
+/// path, whose version floor arbitrates racing registrations.
+#[derive(Debug)]
+pub(crate) struct QueryAlreadyRegistered(pub(crate) proto::QueryId);
+
+impl std::fmt::Display for QueryAlreadyRegistered {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "Query {:?} already exists", self.0) }
+}
+impl std::error::Error for QueryAlreadyRegistered {}
+
 type GapFillData<E> = (
     proto::QueryId,
     std::sync::Arc<dyn crate::reactor::fetch_gap::GapFetcher<E>>,
@@ -52,6 +63,10 @@ type GapFillData<E> = (
     EntityResultSet<E>,
     Option<E>,
     usize,
+    // The query version at extraction: the fetch runs unlocked, so the
+    // apply re-checks the query still exists at this version (a removal
+    // or supersede mid-fetch must not repopulate the resultset).
+    u32,
 );
 
 /// State for a single predicate within a subscription
@@ -143,36 +158,43 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
 
     /// System reset - clear all matching entities and notify
     pub fn system_reset(&self) {
-        let state = &mut *self.state.lock().unwrap();
-        let mut update_items: Vec<ReactorUpdateItem<E, Ev>> = Vec::new();
+        // Collect under the state lock; every broadcast-capable call
+        // (resultset clears and the update notification) fires after it
+        // releases, so a subscriber that re-enters the reactor cannot
+        // deadlock on it.
+        let (resultsets, update_items, broadcast) = {
+            let state = &mut *self.state.lock().unwrap();
+            let mut update_items: Vec<ReactorUpdateItem<E, Ev>> = Vec::new();
+            let mut resultsets = Vec::new();
 
-        // For each query in this subscription
-        for (query_id, query_state) in &mut state.queries {
-            // For each entity that was matching this query
-            for entity_id in query_state.resultset.keys() {
-                // Try to get the entity from the subscription's cache
-                if let Some(entity) = state.entities.get(&entity_id) {
-                    update_items.push(ReactorUpdateItem {
-                        entity: entity.clone(),
-                        events: vec![], // No events for system reset
-                        predicate_relevance: vec![(*query_id, MembershipChange::Remove)],
-                    });
+            for (query_id, query_state) in &mut state.queries {
+                for entity_id in query_state.resultset.keys() {
+                    if let Some(entity) = state.entities.get(&entity_id) {
+                        update_items.push(ReactorUpdateItem {
+                            entity: entity.clone(),
+                            events: vec![], // No events for system reset
+                            predicate_relevance: vec![(*query_id, MembershipChange::Remove)],
+                        });
+                    }
                 }
+                resultsets.push(query_state.resultset.clone());
             }
 
-            // Clear the matching entities for this query
-            query_state.resultset.clear();
-            query_state.resultset.set_loaded(false);
+            // Clear entity subscriptions and cached entities
+            state.entity_subscriptions.clear();
+            state.entities.clear();
+
+            (resultsets, update_items, state.broadcast.clone())
+        };
+
+        for resultset in resultsets {
+            let mut write = resultset.write();
+            write.replace_all(Vec::new());
+            write.set_loaded(false);
         }
 
-        // Clear entity subscriptions and cached entities
-        state.entity_subscriptions.clear();
-        state.entities.clear();
-
-        // Send the notification if there were any updates
         if !update_items.is_empty() {
-            let reactor_update = ReactorUpdate { items: update_items };
-            state.broadcast.send(reactor_update);
+            broadcast.send(ReactorUpdate { items: update_items });
         }
     }
 
@@ -209,7 +231,7 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
                 });
                 Ok(())
             }
-            Entry::Occupied(_) => Err(anyhow::anyhow!("Query {:?} already exists", query_id)),
+            Entry::Occupied(_) => Err(anyhow::Error::new(QueryAlreadyRegistered(query_id))),
         }
     }
 
@@ -256,6 +278,17 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         // Get mutable reference to query state (must exist)
         let query_state = state.queries.get_mut(&query_id).ok_or_else(|| anyhow::anyhow!("Query not found for update"))?;
 
+        // Racing updates can apply out of order (each is an independent
+        // send). A strictly older version must not regress the standing
+        // query's selection; equal versions re-apply idempotently (retries).
+        if version < query_state.version {
+            tracing::debug!("Ignoring stale update for query {} (version {} < {})", query_id, version, query_state.version);
+            // A no-op yields no newly-added entities (the contract of the
+            // return value); returning the full resultset here would make
+            // the server re-report every known row as a fresh delta.
+            return Ok(Vec::new());
+        }
+
         // Check if this is the first update (selection is None)
         let is_first_update = query_state.selection.is_none();
 
@@ -275,8 +308,14 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
             query_state.resultset.limit(selection.limit.map(|l| l as usize));
         }
 
-        // Create write guard for atomic updates
-        let mut rw_resultset = query_state.resultset.write();
+        // Create write guard for atomic updates. The guard is taken on a
+        // clone of the resultset handle, NOT through `query_state`: its
+        // drop broadcasts to subscriber callbacks, which must happen
+        // after the state lock releases (a re-entrant subscriber would
+        // deadlock on it), and a guard borrowed through the state guard
+        // could not outlive it.
+        let resultset_handle = query_state.resultset.clone();
+        let mut rw_resultset = resultset_handle.write();
         let mut newly_added: Vec<E> = Vec::new();
 
         // Mark all entities dirty for re-evaluation
@@ -319,10 +358,10 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         // Set loaded as part of the write transaction - flag is set while lock held,
         // then drop releases lock and broadcasts. Subscribers see consistent state.
         rw_resultset.set_loaded(true);
-        drop(rw_resultset);
-
-        // Drop state lock before updating watchers
+        // State first, THEN the resultset guard: its drop broadcasts, and
+        // no subscriber callback may run under the state lock.
         drop(state_guard);
+        drop(rw_resultset);
 
         // Update predicate watchers (setup on first update, or update if predicate changed)
         let should_update_watchers = if is_first_update {
@@ -354,8 +393,13 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
 
     /// Send ReactorUpdate with the given items
     pub fn send_update(&self, items: Vec<ReactorUpdateItem<E, Ev>>) {
-        let state = self.state.lock().unwrap();
-        state.broadcast.send(ReactorUpdate { items });
+        // Clone the broadcast out and release the state lock BEFORE
+        // sending: subscriber callbacks run synchronously and may
+        // re-enter the reactor (a resultset subscriber updating a
+        // selection or credential reaches remove/update paths that take
+        // this same lock).
+        let broadcast = self.state.lock().unwrap().broadcast.clone();
+        broadcast.send(ReactorUpdate { items });
     }
 
     /// Remove a query and return its state for cleanup
@@ -396,6 +440,17 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
     ) -> Vec<WatcherChange> {
         let mut watcher_changes = Vec::new();
         let mut items: IndexMap<proto::EntityId, ReactorUpdateItem<E, Ev>> = IndexMap::new();
+        // Resultset mutations decided during evaluation, applied AFTER
+        // the state lock releases: their write guards broadcast on drop,
+        // and no subscriber callback may run under the state lock (a
+        // callback that updates a credential or selection re-enters the
+        // reactor and would deadlock on it). Each carries the query id,
+        // its version at decision time, the entity, and the decided
+        // direction (true = add); application re-checks liveness under a
+        // re-taken state lock, because a subscriber invoked by an EARLIER
+        // write's broadcast can revoke the credential or re-permission
+        // the query mid-batch.
+        let mut deferred_writes: Vec<(proto::QueryId, u32, EntityResultSet<E>, E, bool)> = Vec::new();
 
         // Take the state lock once for all evaluations
         let mut state_guard = self.state.lock().unwrap();
@@ -428,15 +483,14 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
                 let membership_change = match (did_match, matches) {
                     (false, true) => {
                         // Entity now matches - add to matching set
-                        let entity_clone = entity.clone();
-                        query_state.resultset.write().add(entity_clone.clone());
-                        state.entities.insert(entity_id, entity_clone);
+                        state.entities.insert(entity_id, entity.clone());
+                        deferred_writes.push((query_id, query_state.version, query_state.resultset.clone(), entity.clone(), true));
                         watcher_changes.push(WatcherChange::add(entity_id, self.id, query_id));
                         Some(MembershipChange::Add)
                     }
                     (true, false) => {
                         // Entity no longer matches - remove from matching set
-                        query_state.resultset.write().remove(entity_id);
+                        deferred_writes.push((query_id, query_state.version, query_state.resultset.clone(), entity.clone(), false));
                         watcher_changes.push(WatcherChange::remove(entity_id, self.id, query_id));
                         Some(MembershipChange::Remove)
                     }
@@ -482,12 +536,91 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
             }
         }
 
-        // Collect gap fill data while we have the state lock
-        let gaps_to_fill = self.collect_gaps_to_fill_internal(&state);
         let broadcast = state.broadcast.clone();
 
-        // Drop the state lock before spawning
+        // Release the state lock, then apply the deferred writes (their
+        // guard drops broadcast here, outside every SYNCHRONOUS reactor
+        // lock: the state lock and the global subscriptions/watcher
+        // mutexes; notify_change's async batch-serialization lock stays
+        // held by design, and no synchronous subscriber path re-acquires
+        // it). The liveness gate is three-way, like the gap fills': a
+        // REMOVED query drops the write (the claw-back emptied the
+        // resultset; there is nothing to be consistent with), a
+        // SUPERSEDED query re-decides the entity against its CURRENT
+        // selection under the re-taken lock, and only a live
+        // decision-time version applies the decision as made. The
+        // supersede case cannot discard: the superseding update_query
+        // only re-adds entities its caller fetched BEFORE taking the
+        // state lock, so an entity persisted after that fetch is
+        // re-decided by nobody else, and a discarded add would stay
+        // silently missing until the entity next changes. Convergence
+        // with whatever the superseding update already applied is by
+        // idempotence: `add` no-ops when the id is already indexed and
+        // `remove` when it is not.
+        // When a re-decision disagrees with the decision, the batch's
+        // ReactorUpdate still reports the decision (the item stream
+        // reports what was decided; the resultset is authoritative for
+        // membership), but a DROPPED write's watcher change is dropped
+        // with it below, and the livequery layer drops whole batches
+        // delivered after its own denial (its ChangeSet subscribe gate),
+        // so revoked registrations' membership changes reach no
+        // livequery subscriber.
         drop(state_guard);
+        let mut dropped_writes: Vec<(proto::EntityId, proto::QueryId)> = Vec::new();
+        for (query_id, version, resultset, entity, decided_add) in deferred_writes {
+            let entity_id = *AbstractEntity::id(&entity);
+            let state = self.state.lock().unwrap();
+            let apply_add = match state.queries.get(&query_id) {
+                // A different resultset handle is a different registration
+                // incarnation reusing the query id ((id, version) alone is
+                // reusable): nothing about this decision applies to it.
+                Some(qs) if !qs.resultset.same_instance(&resultset) => {
+                    tracing::debug!("Dropping deferred write for query {} (registration replaced mid-batch)", query_id);
+                    dropped_writes.push((entity_id, query_id));
+                    continue;
+                }
+                Some(qs) if qs.version == version => decided_add,
+                Some(qs) => match qs.selection.as_ref() {
+                    // An evaluation error counts as non-match, fail
+                    // closed, matching the pre-existing decision sites:
+                    // https://github.com/ankurah/ankurah/issues/433
+                    Some(sel) => evaluate_predicate(&entity, &sel.predicate).unwrap_or(false),
+                    // A version with no selection yet is a fresh
+                    // re-registration under the same id; its own fetch
+                    // covers this entity.
+                    None => {
+                        dropped_writes.push((entity_id, query_id));
+                        continue;
+                    }
+                },
+                None => {
+                    tracing::debug!("Dropping deferred write for query {} (removed mid-batch)", query_id);
+                    dropped_writes.push((entity_id, query_id));
+                    continue;
+                }
+            };
+            let mut write = resultset.write();
+            drop(state);
+            if apply_add {
+                write.add(entity);
+            } else {
+                write.remove(entity_id);
+            }
+        }
+        if !dropped_writes.is_empty() {
+            watcher_changes.retain(|wc| {
+                let (WatcherChange::Add { entity_id, query_id, .. } | WatcherChange::Remove { entity_id, query_id, .. }) = wc;
+                !dropped_writes.contains(&(*entity_id, *query_id))
+            });
+        }
+
+        // Gap data collects under a fresh lock AFTER the writes, so a
+        // remove that dropped a LIMIT query below its limit is seen (the
+        // write marked its gap flag).
+        let gaps_to_fill = {
+            let state = self.state.lock().unwrap();
+            self.collect_gaps_to_fill_internal(&state)
+        };
 
         // Spawn background task for gap filling and notification
         // fill_gaps_and_notify will register entity watchers for gap-filled entities
@@ -514,22 +647,20 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
             state.queries.get(&query_id).and_then(|query_state| self.extract_gap_data(query_id, query_state))
         };
 
-        let Some((query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size)) = gap_data else {
+        let Some((query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size, version)) = gap_data else {
             return;
         };
 
         // Clear gap_dirty flag immediately
         resultset.clear_gap_dirty();
 
-        // Process gap fill
-        let gap_filled_entities =
-            Self::process_gap_fill_entities(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size).await;
+        // Process gap fill (applies and registers watchers under the
+        // liveness gate)
+        let gap_filled_entities = self
+            .process_gap_fill_entities(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size, version)
+            .await;
 
-        // Register entity watchers and append entities
-        if !gap_filled_entities.is_empty() {
-            self.add_entity_watchers(query_id, gap_filled_entities.iter().map(|e| *AbstractEntity::id(e)));
-            entities.extend(gap_filled_entities);
-        }
+        entities.extend(gap_filled_entities);
     }
 
     /// Fill gaps for a specific query and push ReactorUpdateItems to the accumulator
@@ -541,28 +672,27 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
             state.queries.get(&query_id).and_then(|query_state| self.extract_gap_data(query_id, query_state))
         };
 
-        let Some((query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size)) = gap_data else {
+        let Some((query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size, version)) = gap_data else {
             return;
         };
 
         // Clear gap_dirty flag immediately
         resultset.clear_gap_dirty();
 
-        // Process gap fill
-        let gap_filled_entities =
-            Self::process_gap_fill_entities(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size).await;
+        // Process gap fill (applies and registers watchers under the
+        // liveness gate)
+        let gap_filled_entities = self
+            .process_gap_fill_entities(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size, version)
+            .await;
 
-        // Register entity watchers and push items for gap-filled entities
-        if !gap_filled_entities.is_empty() {
-            self.add_entity_watchers(query_id, gap_filled_entities.iter().map(|e| *AbstractEntity::id(e)));
-
-            for entity in gap_filled_entities {
-                reactor_updates.push_initial(&entity, query_id);
-            }
+        for entity in gap_filled_entities {
+            reactor_updates.push_initial(&entity, query_id);
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn process_gap_fill_entities(
+        &self,
         query_id: proto::QueryId,
         gap_fetcher: std::sync::Arc<dyn crate::reactor::fetch_gap::GapFetcher<E>>,
         collection_id: proto::CollectionId,
@@ -570,6 +700,7 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         resultset: EntityResultSet<E>,
         last_entity: Option<E>,
         gap_size: usize,
+        version: u32,
     ) -> Vec<E> {
         tracing::debug!("Gap filling for query {} - need {} entities", query_id, gap_size);
 
@@ -578,6 +709,35 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
                 if !gap_entities.is_empty() {
                     tracing::debug!("Gap filling fetched {} entities for query {}", gap_entities.len(), query_id);
 
+                    // The fetch ran unlocked: apply only if the query
+                    // still exists at the version fetched for — a removal
+                    // (denial claw-back, teardown) or supersede during
+                    // the await must not repopulate. Gate and apply under
+                    // the state lock so a concurrent removal serializes;
+                    // the resultset broadcast rides the write guard past
+                    // the lock. A supersede re-arms the gap flag (this
+                    // extraction cleared it) so the current version
+                    // refills instead of staying short.
+                    let state = self.state.lock().unwrap();
+                    match state.queries.get(&query_id) {
+                        // A replaced registration incarnation reusing the
+                        // id: this fetch was for the old handle; touch
+                        // nothing (not even the gap flag).
+                        Some(qs) if !qs.resultset.same_instance(&resultset) => {
+                            tracing::debug!("Dropping gap fill for query {} (registration replaced mid-fetch)", query_id);
+                            return Vec::new();
+                        }
+                        Some(qs) if qs.version == version => {}
+                        Some(_) => {
+                            tracing::debug!("Dropping gap fill for query {} (superseded mid-fetch)", query_id);
+                            resultset.mark_gap_dirty();
+                            return Vec::new();
+                        }
+                        None => {
+                            tracing::debug!("Dropping gap fill for query {} (removed mid-fetch)", query_id);
+                            return Vec::new();
+                        }
+                    }
                     let mut write = resultset.write();
                     let mut added_entities = Vec::new();
 
@@ -586,6 +746,14 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
                             added_entities.push(entity);
                         }
                     }
+                    // Watchers register after both locks drop, mirroring
+                    // update_query's order (state and resultset are never
+                    // held into watcher_set). A removal landing in the
+                    // gap leaves inert watchers that route to an absent
+                    // query until the next registration's diff.
+                    drop(state);
+                    drop(write);
+                    self.add_entity_watchers(query_id, added_entities.iter().map(|e| *AbstractEntity::id(e)));
 
                     added_entities
                 } else {
@@ -609,27 +777,21 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         broadcast: ankurah_signals::broadcast::Broadcast<ReactorUpdate<E, Ev>>,
     ) {
         // Clear gap_dirty flags immediately for all queries
-        for (_, _, _, _, ref resultset, _, _) in &gaps_to_fill {
+        for (_, _, _, _, ref resultset, _, _, _) in &gaps_to_fill {
             resultset.clear_gap_dirty();
         }
 
-        // Process all gap fills concurrently
+        // Process all gap fills concurrently (each applies and registers
+        // watchers under its own liveness gate)
         let gap_fill_futures =
-            gaps_to_fill.into_iter().map(|(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size)| {
-                Self::process_gap_fill(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size)
+            gaps_to_fill.into_iter().map(|(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size, version)| {
+                self.process_gap_fill(query_id, gap_fetcher, collection_id, selection, resultset, last_entity, gap_size, version)
             });
 
-        let gap_results: Vec<(ankurah_proto::QueryId, Vec<ReactorUpdateItem<E, Ev>>)> = future::join_all(gap_fill_futures).await;
+        let gap_results: Vec<Vec<ReactorUpdateItem<E, Ev>>> = future::join_all(gap_fill_futures).await;
 
-        // Collect all the new items from gap filling and register entity watchers
-        for (query_id, gap_items) in gap_results {
-            if !gap_items.is_empty() {
-                // Register entity watchers for gap-filled entities
-                let entity_ids: Vec<_> = gap_items.iter().map(|item| *AbstractEntity::id(&item.entity)).collect();
-                self.add_entity_watchers(query_id, entity_ids.into_iter());
-
-                items.extend(gap_items);
-            }
+        for gap_items in gap_results {
+            items.extend(gap_items);
         }
 
         // Send the consolidated update
@@ -666,10 +828,13 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
             resultset.clone(),
             last_entity,
             gap_size,
+            query_state.version,
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn process_gap_fill(
+        &self,
         query_id: proto::QueryId,
         gap_fetcher: std::sync::Arc<dyn crate::reactor::fetch_gap::GapFetcher<E>>,
         collection_id: proto::CollectionId,
@@ -677,14 +842,39 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         resultset: EntityResultSet<E>,
         last_entity: Option<E>,
         gap_size: usize,
-    ) -> (proto::QueryId, Vec<ReactorUpdateItem<E, Ev>>) {
+        version: u32,
+    ) -> Vec<ReactorUpdateItem<E, Ev>> {
         tracing::debug!("Gap filling for query {} - need {} entities", query_id, gap_size);
 
-        let gap_items = match gap_fetcher.fetch_gap(&collection_id, &selection, last_entity.as_ref(), gap_size).await {
+        match gap_fetcher.fetch_gap(&collection_id, &selection, last_entity.as_ref(), gap_size).await {
             Ok(gap_entities) => {
                 if !gap_entities.is_empty() {
                     tracing::debug!("Gap filling fetched {} entities for query {}", gap_entities.len(), query_id);
 
+                    // Same liveness gate and ordering as
+                    // process_gap_fill_entities: gate and apply under the
+                    // state lock, re-arm the gap flag on supersede,
+                    // watchers after both locks drop.
+                    let state = self.state.lock().unwrap();
+                    match state.queries.get(&query_id) {
+                        // A replaced registration incarnation reusing the
+                        // id: this fetch was for the old handle; touch
+                        // nothing (not even the gap flag).
+                        Some(qs) if !qs.resultset.same_instance(&resultset) => {
+                            tracing::debug!("Dropping gap fill for query {} (registration replaced mid-fetch)", query_id);
+                            return Vec::new();
+                        }
+                        Some(qs) if qs.version == version => {}
+                        Some(_) => {
+                            tracing::debug!("Dropping gap fill for query {} (superseded mid-fetch)", query_id);
+                            resultset.mark_gap_dirty();
+                            return Vec::new();
+                        }
+                        None => {
+                            tracing::debug!("Dropping gap fill for query {} (removed mid-fetch)", query_id);
+                            return Vec::new();
+                        }
+                    }
                     let mut write = resultset.write();
                     let mut gap_items = Vec::new();
 
@@ -697,6 +887,9 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
                             });
                         }
                     }
+                    drop(state);
+                    drop(write);
+                    self.add_entity_watchers(query_id, gap_items.iter().map(|item| *AbstractEntity::id(&item.entity)));
 
                     gap_items
                 } else {
@@ -708,9 +901,7 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
                 tracing::warn!("Gap filling failed for query {}: {}", query_id, e);
                 Vec::new()
             }
-        };
-
-        (query_id, gap_items)
+        }
     }
 }
 
@@ -719,7 +910,6 @@ impl Subscription<crate::entity::Entity, ankurah_proto::Attested<ankurah_proto::
     /// Upsert a query - register if it doesn't exist, or return the existing resultset
     /// Idempotent - safe to call multiple times with the same query_id
     /// Creates the gap fetcher on first insert; a re-upsert refreshes its credentials in place (wholesale replacement of the fetcher is the fallback for fetchers that cannot refresh)
-    /// Constructs gap_fetcher lazily (only if query doesn't exist)
     pub fn upsert_query<SE, PA>(
         &self,
         query_id: proto::QueryId,

--- a/core/src/reactor/subscription_state.rs
+++ b/core/src/reactor/subscription_state.rs
@@ -65,6 +65,13 @@ pub struct QueryState<E: AbstractEntity + Filterable> {
     pub(crate) paused: bool, // When true, skip notifications (used during initialization and updates)
     pub(crate) resultset: EntityResultSet<E>,
     pub(crate) version: u32,
+    /// The newest version whose credentials the gap fetcher holds.
+    /// Tracked apart from `version` (the selection floor in
+    /// `update_query`): racing re-subscribes refresh credentials before
+    /// their selection lands, so the refresh needs its own floor or a
+    /// delayed stale subscribe regresses the credentials behind a newer
+    /// selection.
+    pub(crate) credential_version: u32,
 }
 
 // We would call this ReactorSubscription, but that name is reserved for the public API
@@ -191,7 +198,15 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         use std::collections::hash_map::Entry;
         match state.queries.entry(query_id) {
             Entry::Vacant(v) => {
-                v.insert(QueryState { collection_id, selection: None, gap_fetcher, paused: false, resultset, version: 0 });
+                v.insert(QueryState {
+                    collection_id,
+                    selection: None,
+                    gap_fetcher,
+                    paused: false,
+                    resultset,
+                    version: 0,
+                    credential_version: 0,
+                });
                 Ok(())
             }
             Entry::Occupied(_) => Err(anyhow::anyhow!("Query {:?} already exists", query_id)),
@@ -347,6 +362,24 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
     pub fn remove_query(&self, query_id: proto::QueryId) -> Option<QueryState<E>> {
         let mut state = self.state.lock().unwrap();
         state.queries.remove(&query_id)
+    }
+
+    /// Remove a query ONLY if its registered version is at or below the
+    /// given one. The server's claw-back on failed re-validation uses
+    /// this floor: a delayed OLDER request that fails validation must not
+    /// tear down the live newer registration it was superseded by.
+    pub fn remove_query_at_or_below(&self, query_id: proto::QueryId, version: u32) -> Option<QueryState<E>> {
+        let mut state = self.state.lock().unwrap();
+        match state.queries.get(&query_id) {
+            // The floor compares the NEWEST version the entry has seen:
+            // between a newer subscribe's upsert (which seeds
+            // credential_version) and its update_query (which stores
+            // version), `version` still holds the old value, and flooring
+            // on it alone would let a delayed older denial remove the
+            // in-flight newer registration.
+            Some(qs) if qs.version.max(qs.credential_version) <= version => state.queries.remove(&query_id),
+            _ => None,
+        }
     }
 
     /// Get all queries for cleanup (used by unsubscribe)
@@ -685,13 +718,15 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
 impl Subscription<crate::entity::Entity, ankurah_proto::Attested<ankurah_proto::Event>> {
     /// Upsert a query - register if it doesn't exist, or return the existing resultset
     /// Idempotent - safe to call multiple times with the same query_id
+    /// Creates the gap fetcher on first insert; a re-upsert refreshes its credentials in place (wholesale replacement of the fetcher is the fallback for fetchers that cannot refresh)
     /// Constructs gap_fetcher lazily (only if query doesn't exist)
     pub fn upsert_query<SE, PA>(
         &self,
         query_id: proto::QueryId,
         collection_id: proto::CollectionId,
         node: &crate::node::Node<SE, PA>,
-        cdata: &PA::ContextData,
+        cdatas: &[PA::ContextData],
+        version: u32,
     ) -> EntityResultSet<crate::entity::Entity>
     where
         SE: crate::storage::StorageEngine + Send + Sync + 'static,
@@ -703,8 +738,7 @@ impl Subscription<crate::entity::Entity, ankurah_proto::Attested<ankurah_proto::
         match state.queries.entry(query_id) {
             Entry::Vacant(v) => {
                 let resultset = EntityResultSet::empty();
-                // Only create gap fetcher if query doesn't exist
-                let gap_fetcher = std::sync::Arc::new(crate::reactor::fetch_gap::QueryGapFetcher::new(node, cdata.clone()));
+                let gap_fetcher = std::sync::Arc::new(crate::reactor::fetch_gap::QueryGapFetcher::for_server(node, cdatas.to_vec()));
                 v.insert(QueryState {
                     collection_id,
                     selection: None,
@@ -712,10 +746,33 @@ impl Subscription<crate::entity::Entity, ankurah_proto::Attested<ankurah_proto::
                     paused: false,
                     resultset: resultset.clone(),
                     version: 0,
+                    credential_version: version,
                 });
                 resultset
             }
-            Entry::Occupied(o) => o.get().resultset.clone(),
+            Entry::Occupied(o) => {
+                // A re-subscribe carries freshly validated credentials and
+                // the stored fetcher adopts them in place (its private set's
+                // members are replaced), so later gap fills read under the
+                // latest ones. A fetcher that cannot refresh is replaced
+                // instead, never left serving stale claims. The refresh is
+                // floored on its own version: a delayed stale subscribe
+                // must not regress the credentials behind a newer one
+                // (the selection has its own floor in update_query).
+                // AUDITED EXCEPTION to the no-broadcast-under-state rule:
+                // the refresh mutates a SessionHolder, whose private set
+                // has no subscribers by construction, so its registration
+                // and revocation dispatches reach nobody.
+                let entry = o.into_mut();
+                if version >= entry.credential_version {
+                    entry.credential_version = version;
+                    if !entry.gap_fetcher.refresh_credential(Box::new(cdatas.to_vec())) {
+                        entry.gap_fetcher =
+                            std::sync::Arc::new(crate::reactor::fetch_gap::QueryGapFetcher::for_server(node, cdatas.to_vec()));
+                    }
+                }
+                entry.resultset.clone()
+            }
         }
     }
 }

--- a/core/src/reactor/watcherset.rs
+++ b/core/src/reactor/watcherset.rs
@@ -155,6 +155,9 @@ impl WatcherSet {
         for entity_id in removed_entities {
             if let Some(entity_watcher) = self.entity_watchers.get_mut(entity_id) {
                 entity_watcher.remove(&EntityWatcherId::Predicate(subscription_id, query_id));
+                if entity_watcher.is_empty() {
+                    self.entity_watchers.remove(entity_id);
+                }
             }
         }
     }

--- a/core/src/resultset.rs
+++ b/core/src/resultset.rs
@@ -405,14 +405,6 @@ impl<E: AbstractEntity> EntityResultSet<E> {
         self.0.loaded.load(Ordering::Relaxed)
     }
 
-    pub fn clear(&self) {
-        let mut st = self.0.state.lock().unwrap();
-        st.order.clear();
-        st.index.clear();
-        drop(st);
-        self.0.broadcast.send(());
-    }
-
     /// Get an iterator over entity IDs without cloning entities
     pub fn keys(&self) -> EntityResultSetKeyIterator {
         // TODO make a signal trait for tracked keys
@@ -421,6 +413,12 @@ impl<E: AbstractEntity> EntityResultSet<E> {
         let keys: Vec<proto::EntityId> = st.order.iter().map(|e| *e.entity.id()).collect();
         EntityResultSetKeyIterator::new(keys)
     }
+
+    /// Handle identity: whether two EntityResultSet values share one
+    /// underlying instance. The deferred-write and gap-fill liveness
+    /// gates require it because (query id, version) alone is reusable
+    /// across registration incarnations of the same query.
+    pub(crate) fn same_instance(&self, other: &Self) -> bool { std::sync::Arc::ptr_eq(&self.0, &other.0) }
 
     /// Check if an entity with the given ID exists
     pub fn contains_key(&self, id: &proto::EntityId) -> bool {
@@ -448,6 +446,11 @@ impl<E: AbstractEntity> EntityResultSet<E> {
         let st = self.0.state.lock().unwrap();
         st.gap_dirty
     }
+
+    /// Re-arm gap filling: a fill that was extracted (clearing the flag)
+    /// but then dropped by the liveness gate re-marks, so the query's
+    /// CURRENT version re-extracts instead of staying short forever.
+    pub(crate) fn mark_gap_dirty(&self) { self.0.state.lock().unwrap_or_else(|e| e.into_inner()).gap_dirty = true; }
 
     /// Clear the gap_dirty flag (called after gap filling is complete)
     pub(crate) fn clear_gap_dirty(&self) {
@@ -510,8 +513,10 @@ impl<E: AbstractEntity> EntityResultSet<E> {
             st.index.insert(id, i);
         }
 
-        drop(st);
-        self.0.broadcast.send(());
+        // No broadcast here: the sole production caller (update_query)
+        // runs this under the reactor's state lock, where subscriber
+        // callbacks must not fire, and its enclosing write transaction
+        // always broadcasts at the end of the same update.
     }
 
     /// Set the limit for this result set
@@ -526,11 +531,9 @@ impl<E: AbstractEntity> EntityResultSet<E> {
         st.limit = limit;
 
         // Apply the new limit by truncating if necessary
-        let mut entities_removed = false;
         if let Some(limit) = limit {
             if st.order.len() > limit {
                 st.order.truncate(limit);
-                entities_removed = true;
 
                 // Rebuild index after truncation
                 st.index.clear();
@@ -541,12 +544,8 @@ impl<E: AbstractEntity> EntityResultSet<E> {
             }
         }
 
-        drop(st);
-
-        // Only broadcast if entities were actually removed
-        if entities_removed {
-            self.0.broadcast.send(());
-        }
+        // No broadcast even when a truncation removed entities: see
+        // order_by — the enclosing write transaction broadcasts.
     }
 }
 

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -4,9 +4,8 @@
 //! A Session wraps the current ContextData in a signal, so a long-lived
 //! handle's credential can change (a token refresh, a re-login) without
 //! rebuilding the Context or the livequeries under it: holders keep the
-//! session and read the current value at use time, and change
-//! subscribers hear each effective update (the liveness PR's relay
-//! re-permissions remote subscriptions on it).
+//! session and read the current value at use time, and subscribers (the
+//! relay) react to a change by re-permissioning remote subscriptions.
 //! The SessionSet tracks the node's live sessions, undeduplicated: two
 //! sessions whose credentials compare equal today are still independent
 //! and may diverge tomorrow, so any deduplication happens at the point of
@@ -40,12 +39,20 @@ pub trait ContextData: Send + Sync + Clone + std::hash::Hash + Eq + 'static {}
 
 /// One live credential: the value a single principal acts under,
 /// replaceable in place. An ordinary context registers exactly one in
-/// the node's [`SessionSet`]; a set-backed context reads through the
+/// the node's [`SessionSet`]; the system context reads through the
 /// whole set instead. Queries and their machinery (livequeries, gap
 /// fetchers, the relay) hold their context's [`Sessions`] source and
 /// read its current value once per operation.
 pub struct Session<CD: ContextData> {
     current: Mut<CD>,
+    /// Needed to close the TOCTOU between deriving state from a credential
+    /// snapshot and subscribing to its changes (the livequery constructor
+    /// re-checks it once its listener is live). Value comparison cannot
+    /// serve as that re-check: a change-and-revert inside the window (a
+    /// re-login to another user and back) leaves the value equal to the
+    /// snapshot while an in-window send may have shipped the interloper.
+    /// Bumped before the value stores, once per effective update.
+    generation: std::sync::atomic::AtomicU64,
     /// The owning [`SessionSet`] slot, absent for detached sessions.
     registry: Option<(Weak<SessionSetInner<CD>>, u64)>,
 }
@@ -54,7 +61,9 @@ impl<CD: ContextData> Session<CD> {
     /// A session outside any SessionSet: infrastructure credentials (and
     /// server-side per-query holders) that must not participate in the
     /// node's active-session enumeration.
-    pub fn detached(cdata: CD) -> Arc<Self> { Arc::new(Self { current: Mut::new(cdata), registry: None }) }
+    pub fn detached(cdata: CD) -> Arc<Self> {
+        Arc::new(Self { current: Mut::new(cdata), generation: std::sync::atomic::AtomicU64::new(0), registry: None })
+    }
 
     /// A snapshot of the current credential. Take one per logical
     /// operation, so a mid-operation update cannot mix credentials. (Named
@@ -63,8 +72,8 @@ impl<CD: ContextData> Session<CD> {
     pub fn snapshot(&self) -> CD { self.current.value() }
 
     /// Replace the credential. A value comparing equal to the current one
-    /// is a complete no-op, no store and no notification: `Eq` is
-    /// operational identity per [`ContextData`], so
+    /// is a complete no-op — no store, no generation bump, no
+    /// notification: `Eq` is operational identity per [`ContextData`], so
     /// equal means nothing observable changed and there is nothing to
     /// re-permission. A token refresh carries a new token, compares
     /// unequal, and notifies holders and change subscribers.
@@ -77,8 +86,17 @@ impl<CD: ContextData> Session<CD> {
         if self.current.value() == cdata {
             return;
         }
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        if let Some((registry, _)) = &self.registry {
+            if let Some(registry) = registry.upgrade() {
+                registry.generation.fetch_add(1, Ordering::SeqCst);
+            }
+        }
         self.current.set(cdata);
     }
+
+    /// The effective-update count; see the field doc for the TOCTOU it closes.
+    pub fn generation(&self) -> u64 { self.generation.load(Ordering::SeqCst) }
 
     /// Subscribe to credential changes; the listener receives each new
     /// value. Dropping the guard unsubscribes.
@@ -121,6 +139,7 @@ impl<CD: ContextData> Session<CD> {
     pub(crate) fn revoke(&self) {
         if let Some((registry, slot)) = &self.registry {
             if let Some(registry) = registry.upgrade() {
+                registry.generation.fetch_add(1, Ordering::SeqCst);
                 if registry.sessions.lock().unwrap_or_else(|e| e.into_inner()).remove(slot).is_some() {
                     // Fire outside the lock: subscribers read the set back.
                     registry.changed.send(());
@@ -156,6 +175,11 @@ struct SessionSetInner<CD: ContextData> {
     /// Fires on any membership change (register, cull) and on any live
     /// member's value change (each slot forwards its session's signal).
     changed: Broadcast<()>,
+    /// Composite update count, bumped BEFORE the change it counts becomes
+    /// observable (registrations, culls, and member updates alike), so the
+    /// snapshot-then-subscribe re-check ([`Session::generation`]) works
+    /// over the whole set.
+    generation: AtomicU64,
 }
 
 struct SessionSlot<CD: ContextData> {
@@ -167,13 +191,20 @@ struct SessionSlot<CD: ContextData> {
 
 impl<CD: ContextData> SessionSet<CD> {
     pub fn new() -> Self {
-        Self(Arc::new(SessionSetInner { sessions: Mutex::new(HashMap::new()), next_slot: AtomicU64::new(0), changed: Broadcast::new() }))
+        Self(Arc::new(SessionSetInner {
+            sessions: Mutex::new(HashMap::new()),
+            next_slot: AtomicU64::new(0),
+            changed: Broadcast::new(),
+            generation: AtomicU64::new(0),
+        }))
     }
 
     /// Register a new live session holding `cdata`.
     pub fn register(&self, cdata: CD) -> Arc<Session<CD>> {
+        self.0.generation.fetch_add(1, Ordering::SeqCst);
         let slot = self.0.next_slot.fetch_add(1, Ordering::Relaxed);
-        let session = Arc::new(Session { current: Mut::new(cdata), registry: Some((Arc::downgrade(&self.0), slot)) });
+        let session =
+            Arc::new(Session { current: Mut::new(cdata), generation: AtomicU64::new(0), registry: Some((Arc::downgrade(&self.0), slot)) });
         let forward = {
             let changed = self.0.changed.clone();
             session.subscribe_changes(move |_new: CD| changed.send(()))
@@ -198,14 +229,20 @@ impl<CD: ContextData> SessionSet<CD> {
 
     /// The current credential of every live session, in slot order.
     pub fn current(&self) -> Vec<CD> { self.sessions().iter().map(|session| session.snapshot()).collect() }
+
+    /// The composite update count; see [`Session::generation`] for the
+    /// TOCTOU it closes. Moves on registrations, culls, and member
+    /// updates alike.
+    pub fn generation(&self) -> u64 { self.0.generation.load(Ordering::SeqCst) }
 }
 
 /// The credential source behind a query: exactly one session (an ordinary
 /// context's query), the node's whole live set (a system query), or a
 /// held set the query's server side replaces wholesale on re-validated
 /// subscribes. Sends snapshot the CURRENT credentials; subscribers fire
-/// on any change. Only `One` can write: the other arms act as no
-/// single principal.
+/// on any change, and the composite generation closes the same
+/// snapshot-then-subscribe TOCTOU as [`Session::generation`]. Only `One`
+/// can write: the other arms act as no single principal.
 pub enum Sessions<CD: ContextData> {
     One(Arc<Session<CD>>),
     Set(SessionSet<CD>),
@@ -239,6 +276,30 @@ impl<CD: ContextData> Sessions<CD> {
             Self::One(session) => vec![session.snapshot()],
             Self::Set(set) => set.current(),
             Self::Held(holder) => holder.0.set.current(),
+        }
+    }
+
+    /// Subscribe to credential changes; the listener receives the new
+    /// current credentials. For a set, membership changes fire too.
+    pub fn subscribe_changes<F>(&self, listener: F) -> SubscriptionGuard
+    where F: IntoSubscribeListener<Vec<CD>> {
+        match self {
+            Self::One(session) => {
+                let listener = listener.into_subscribe_listener();
+                session.subscribe_changes(move |cdata: CD| listener(vec![cdata]))
+            }
+            Self::Set(set) => set.subscribe(listener),
+            Self::Held(holder) => holder.0.set.subscribe(listener),
+        }
+    }
+
+    /// The update count; see [`Session::generation`] for the TOCTOU it
+    /// closes.
+    pub fn generation(&self) -> u64 {
+        match self {
+            Self::One(session) => session.generation(),
+            Self::Set(set) => set.generation(),
+            Self::Held(holder) => holder.0.set.generation(),
         }
     }
 }
@@ -335,6 +396,10 @@ impl<CD: ContextData> Subscribe<Vec<CD>> for SessionSet<CD> {
     }
 }
 
+impl<CD: ContextData> Default for SessionSet<CD> {
+    fn default() -> Self { Self::new() }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -406,7 +471,7 @@ mod tests {
 
     /// A token refresh — same subject, new token — is a real change: it
     /// compares unequal and fires the subscriber. An identical update is
-    /// a complete no-op: no notification.
+    /// a complete no-op: no notification, no generation bump.
     #[test]
     fn refresh_notifies_and_identical_update_is_a_noop() {
         let session = Session::detached(TestCd { subject: 1, token: 1 });
@@ -421,8 +486,10 @@ mod tests {
         session.update(refreshed);
         assert_eq!(seen.lock().unwrap().as_slice(), &[2], "the refresh fires the subscriber");
 
+        let before = session.generation();
         session.update(TestCd { subject: 1, token: 2 });
         assert_eq!(seen.lock().unwrap().as_slice(), &[2], "an identical update does not notify");
+        assert_eq!(session.generation(), before, "an identical update does not bump the generation");
         assert_eq!(session.snapshot().token, 2, "the stored value is unchanged");
     }
 
@@ -432,6 +499,21 @@ mod tests {
         let set: SessionSet<TestCd> = SessionSet::new();
         let _infra = Session::detached(TestCd { subject: 1, token: 0 });
         assert!(set.sessions().is_empty());
+    }
+
+    /// The generation bumps once per effective update and not for gated
+    /// no-ops: the snapshot-then-subscribe re-check must see exactly the
+    /// updates that changed something.
+    #[test]
+    fn generation_counts_every_effective_update() {
+        let session = Session::detached(TestCd { subject: 1, token: 1 });
+        let before = session.generation();
+        session.update(TestCd { subject: 1, token: 2 });
+        assert_eq!(session.generation(), before + 1, "a refresh bumps");
+        session.update(TestCd { subject: 2, token: 3 });
+        assert_eq!(session.generation(), before + 2);
+        session.update(TestCd { subject: 2, token: 3 });
+        assert_eq!(session.generation(), before + 2, "an identical update does not bump");
     }
 
     /// The set is a signal over the union of current credentials: it
@@ -463,6 +545,48 @@ mod tests {
         drop(b);
         assert_eq!(fired.lock().unwrap().last(), Some(&Vec::new()));
         assert_eq!(fired.lock().unwrap().len(), count + 1, "exactly the final cull fired");
+    }
+
+    /// The set's composite generation moves on registrations, culls, and
+    /// member updates alike, closing the construction window for
+    /// set-backed consumers the way [`Session::generation`] does for
+    /// single-session ones.
+    #[test]
+    fn set_generation_counts_every_change() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let after_new = set.generation();
+        let a = set.register(TestCd { subject: 1, token: 0 });
+        assert!(set.generation() > after_new, "a registration bumps");
+        let after_register = set.generation();
+        a.update(TestCd { subject: 1, token: 1 });
+        assert!(set.generation() > after_register, "a member update bumps the set too");
+        let after_update = set.generation();
+        drop(a);
+        assert!(set.generation() > after_update, "a cull bumps");
+    }
+
+    /// A `Sessions` source unifies the two credential shapes: One
+    /// snapshots a vec of one and forwards its session's updates; Set
+    /// snapshots the union.
+    #[test]
+    fn sessions_source_unifies_one_and_set() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let session = set.register(TestCd { subject: 1, token: 1 });
+
+        let one: Sessions<TestCd> = session.clone().into();
+        assert_eq!(one.snapshot(), vec![TestCd { subject: 1, token: 1 }]);
+
+        let many: Sessions<TestCd> = set.clone().into();
+        let _b = set.register(TestCd { subject: 2, token: 2 });
+        assert_eq!(many.snapshot().len(), 2, "a Set source snapshots every live credential");
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let _guard = one.subscribe_changes(move |current: Vec<TestCd>| {
+            sink.lock().unwrap().push(current.len());
+        });
+        session.update(TestCd { subject: 1, token: 9 });
+        assert_eq!(seen.lock().unwrap().as_slice(), &[1], "a One source forwards its session's update as a vec of one");
     }
 
     /// Peek reads the union without tracking; the porcelain and the

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -1,0 +1,478 @@
+//! Live credential holders: one [`Session`] per ordinary Context,
+//! enumerable through the node's [`SessionSet`].
+//!
+//! A Session wraps the current ContextData in a signal, so a long-lived
+//! handle's credential can change (a token refresh, a re-login) without
+//! rebuilding the Context or the livequeries under it: holders keep the
+//! session and read the current value at use time, and change
+//! subscribers hear each effective update (the liveness PR's relay
+//! re-permissions remote subscriptions on it).
+//! The SessionSet tracks the node's live sessions, undeduplicated: two
+//! sessions whose credentials compare equal today are still independent
+//! and may diverge tomorrow, so any deduplication happens at the point of
+//! consumption, over current values. Membership is liveness itself: the
+//! `Arc<Session>` strong count is the token, and the last drop culls the
+//! slot.
+
+use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex, Weak,
+};
+
+use ankurah_signals::{
+    broadcast::{Broadcast, BroadcastId},
+    signal::{Listener, ListenerGuard},
+    subscribe::IntoSubscribeListener,
+    Get, Mut, Peek, Signal, Subscribe, SubscriptionGuard,
+};
+
+/// Represents the user session - or whatever other context the PolicyAgent
+/// needs to perform its evaluation. The credential vocabulary lives here
+/// beside its live holder; node.rs re-exports it for path compatibility.
+///
+/// `Eq` is operational identity: values compare equal only when
+/// substituting one for the other changes nothing observable (for a
+/// token credential, the token included), and `Hash` agrees with it.
+/// [`Session::update`] delivery gates on this — an update comparing
+/// equal to the current value is a no-op.
+pub trait ContextData: Send + Sync + Clone + std::hash::Hash + Eq + 'static {}
+
+/// One live credential: the value a single principal acts under,
+/// replaceable in place. An ordinary context registers exactly one in
+/// the node's [`SessionSet`]; a set-backed context reads through the
+/// whole set instead. Queries and their machinery (livequeries, gap
+/// fetchers, the relay) hold their context's [`Sessions`] source and
+/// read its current value once per operation.
+pub struct Session<CD: ContextData> {
+    current: Mut<CD>,
+    /// The owning [`SessionSet`] slot, absent for detached sessions.
+    registry: Option<(Weak<SessionSetInner<CD>>, u64)>,
+}
+
+impl<CD: ContextData> Session<CD> {
+    /// A session outside any SessionSet: infrastructure credentials (and
+    /// server-side per-query holders) that must not participate in the
+    /// node's active-session enumeration.
+    pub fn detached(cdata: CD) -> Arc<Self> { Arc::new(Self { current: Mut::new(cdata), registry: None }) }
+
+    /// A snapshot of the current credential. Take one per logical
+    /// operation, so a mid-operation update cannot mix credentials. (Named
+    /// snapshot, not get: the signals lexicon's `get` is an
+    /// observer-tracked read, and this is deliberately untracked.)
+    pub fn snapshot(&self) -> CD { self.current.value() }
+
+    /// Replace the credential. A value comparing equal to the current one
+    /// is a complete no-op, no store and no notification: `Eq` is
+    /// operational identity per [`ContextData`], so
+    /// equal means nothing observable changed and there is nothing to
+    /// re-permission. A token refresh carries a new token, compares
+    /// unequal, and notifies holders and change subscribers.
+    pub fn update(&self, cdata: CD) {
+        // The compare and the store take the lock separately; a racing
+        // update can only make this comparison stale in ways that
+        // linearize legally (a suppressed call was a no-op against SOME
+        // current value, and the racing update's own notification covers
+        // the change).
+        if self.current.value() == cdata {
+            return;
+        }
+        self.current.set(cdata);
+    }
+
+    /// Subscribe to credential changes; the listener receives each new
+    /// value. Dropping the guard unsubscribes.
+    pub fn subscribe_changes<F>(&self, listener: F) -> SubscriptionGuard
+    where F: IntoSubscribeListener<CD> {
+        self.current.subscribe(listener)
+    }
+}
+
+// A Session IS a signal over its credential, so it implements the standard
+// signals vocabulary by delegation (beside the inherent, doc-carrying
+// `snapshot`, the same coexistence `Mut::value` has with its trait impls).
+impl<CD: ContextData> Signal for Session<CD> {
+    fn listen(&self, listener: Listener) -> ListenerGuard { self.current.listen(listener) }
+    fn broadcast_id(&self) -> BroadcastId { self.current.broadcast_id() }
+}
+
+impl<CD: ContextData> Get<CD> for Session<CD> {
+    fn get(&self) -> CD { self.current.get() }
+}
+
+impl<CD: ContextData> Peek<CD> for Session<CD> {
+    fn peek(&self) -> CD { self.current.value() }
+}
+
+impl<CD: ContextData> Subscribe<CD> for Session<CD> {
+    fn subscribe<F>(&self, listener: F) -> SubscriptionGuard
+    where F: IntoSubscribeListener<CD> {
+        self.current.subscribe(listener)
+    }
+}
+
+impl<CD: ContextData> Session<CD> {
+    /// Remove this session from its set NOW, without waiting for the last
+    /// Arc to drop. Culling by Drop alone defers removal to Arc liveness:
+    /// a reader's upgraded Arc (a snapshot in flight) keeps the slot
+    /// listed, so a replace that registered successors could be observed
+    /// TOGETHER with the members it replaced. Explicit revocation removes
+    /// the slot immediately; the eventual Drop then finds it gone.
+    pub(crate) fn revoke(&self) {
+        if let Some((registry, slot)) = &self.registry {
+            if let Some(registry) = registry.upgrade() {
+                if registry.sessions.lock().unwrap_or_else(|e| e.into_inner()).remove(slot).is_some() {
+                    // Fire outside the lock: subscribers read the set back.
+                    registry.changed.send(());
+                }
+            }
+        }
+    }
+}
+
+impl<CD: ContextData> Drop for Session<CD> {
+    fn drop(&mut self) { self.revoke(); }
+}
+
+impl<CD: ContextData> std::fmt::Debug for Session<CD> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The credential is deliberately omitted: CDs can carry tokens,
+        // and Debug output reaches logs.
+        f.debug_struct("Session").field("detached", &self.registry.is_none()).finish()
+    }
+}
+
+/// The node's live sessions. Registration happens at Context construction;
+/// culling is RAII (the last `Arc<Session>` drop removes the slot).
+pub struct SessionSet<CD: ContextData>(Arc<SessionSetInner<CD>>);
+
+impl<CD: ContextData> Clone for SessionSet<CD> {
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+struct SessionSetInner<CD: ContextData> {
+    sessions: Mutex<HashMap<u64, SessionSlot<CD>>>,
+    next_slot: AtomicU64,
+    /// Fires on any membership change (register, cull) and on any live
+    /// member's value change (each slot forwards its session's signal).
+    changed: Broadcast<()>,
+}
+
+struct SessionSlot<CD: ContextData> {
+    session: Weak<Session<CD>>,
+    /// Forwards the member's change signal into `changed`; dropped with
+    /// the slot.
+    _forward: SubscriptionGuard,
+}
+
+impl<CD: ContextData> SessionSet<CD> {
+    pub fn new() -> Self {
+        Self(Arc::new(SessionSetInner { sessions: Mutex::new(HashMap::new()), next_slot: AtomicU64::new(0), changed: Broadcast::new() }))
+    }
+
+    /// Register a new live session holding `cdata`.
+    pub fn register(&self, cdata: CD) -> Arc<Session<CD>> {
+        let slot = self.0.next_slot.fetch_add(1, Ordering::Relaxed);
+        let session = Arc::new(Session { current: Mut::new(cdata), registry: Some((Arc::downgrade(&self.0), slot)) });
+        let forward = {
+            let changed = self.0.changed.clone();
+            session.subscribe_changes(move |_new: CD| changed.send(()))
+        };
+        self.0
+            .sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(slot, SessionSlot { session: Arc::downgrade(&session), _forward: forward });
+        // Fire outside the lock: subscribers read the set back.
+        self.0.changed.send(());
+        session
+    }
+
+    /// Every currently live session, in slot order.
+    pub fn sessions(&self) -> Vec<Arc<Session<CD>>> {
+        let map = self.0.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        let mut live: Vec<_> = map.iter().filter_map(|(slot, entry)| Some((*slot, entry.session.upgrade()?))).collect();
+        live.sort_by_key(|(slot, _)| *slot);
+        live.into_iter().map(|(_, session)| session).collect()
+    }
+
+    /// The current credential of every live session, in slot order.
+    pub fn current(&self) -> Vec<CD> { self.sessions().iter().map(|session| session.snapshot()).collect() }
+}
+
+/// The credential source behind a query: exactly one session (an ordinary
+/// context's query), the node's whole live set (a system query), or a
+/// held set the query's server side replaces wholesale on re-validated
+/// subscribes. Sends snapshot the CURRENT credentials; subscribers fire
+/// on any change. Only `One` can write: the other arms act as no
+/// single principal.
+pub enum Sessions<CD: ContextData> {
+    One(Arc<Session<CD>>),
+    Set(SessionSet<CD>),
+    Held(SessionHolder<CD>),
+}
+
+impl<CD: ContextData> Clone for Sessions<CD> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::One(session) => Self::One(session.clone()),
+            Self::Set(set) => Self::Set(set.clone()),
+            Self::Held(holder) => Self::Held(holder.clone()),
+        }
+    }
+}
+
+impl<CD: ContextData> std::fmt::Debug for Sessions<CD> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::One(session) => f.debug_tuple("Sessions::One").field(session).finish(),
+            Self::Set(set) => f.debug_tuple("Sessions::Set").field(&set.sessions().len()).finish(),
+            Self::Held(holder) => f.debug_tuple("Sessions::Held").field(&holder.0.set.sessions().len()).finish(),
+        }
+    }
+}
+
+impl<CD: ContextData> Sessions<CD> {
+    /// The current credentials, one per live session.
+    pub fn snapshot(&self) -> Vec<CD> {
+        match self {
+            Self::One(session) => vec![session.snapshot()],
+            Self::Set(set) => set.current(),
+            Self::Held(holder) => holder.0.set.current(),
+        }
+    }
+}
+
+impl<CD: ContextData> From<Arc<Session<CD>>> for Sessions<CD> {
+    fn from(session: Arc<Session<CD>>) -> Self { Self::One(session) }
+}
+
+impl<CD: ContextData> From<SessionHolder<CD>> for Sessions<CD> {
+    fn from(holder: SessionHolder<CD>) -> Self { Self::Held(holder) }
+}
+
+/// A set plus the memberships that constitute it -- the server's
+/// per-query credential holder ("held" as in: it keeps the member
+/// sessions registered, and replaces them wholesale when a re-validated
+/// subscribe delivers fresh credentials). Replacement revokes FIRST so a
+/// concurrent reader's snapshot sees the old members, the new members,
+/// partial-old, or an empty set, but never old-union-new: during a
+/// narrowing re-subscribe the transient fails closed. The set is private
+/// to its holder and has no change subscribers, so registrations and
+/// culls dispatch to nobody; mutating it under a lock is safe. Cloning
+/// shares the ONE holder (handles alias the same set and held members).
+pub struct SessionHolder<CD: ContextData>(Arc<SessionHolderInner<CD>>);
+
+struct SessionHolderInner<CD: ContextData> {
+    set: SessionSet<CD>,
+    held: Mutex<Vec<Arc<Session<CD>>>>,
+}
+
+impl<CD: ContextData> Clone for SessionHolder<CD> {
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+impl<CD: ContextData> SessionHolder<CD> {
+    pub(crate) fn new(cdatas: Vec<CD>) -> Self {
+        let set = SessionSet::new();
+        let held = cdatas.into_iter().map(|cdata| set.register(cdata)).collect();
+        Self(Arc::new(SessionHolderInner { set, held: Mutex::new(held) }))
+    }
+
+    /// Replace every member with the given credentials.
+    pub(crate) fn replace(&self, cdatas: Vec<CD>) {
+        let mut held = self.0.held.lock().unwrap_or_else(|e| e.into_inner());
+        // Revoke explicitly BEFORE registering successors: Drop-based
+        // culling is deferred by any reader's upgraded Arc, under which
+        // an overlapping snapshot could list old and new members
+        // together — the union would read under the credential being
+        // replaced. Revocation removes the slots immediately, so the
+        // transient states are old, partial-old, empty, or new: never a
+        // union, failing closed in the narrowing direction.
+        for session in held.drain(..) {
+            session.revoke();
+        }
+        *held = cdatas.into_iter().map(|cdata| self.0.set.register(cdata)).collect();
+    }
+}
+
+impl<CD: ContextData> From<SessionSet<CD>> for Sessions<CD> {
+    fn from(set: SessionSet<CD>) -> Self { Self::Set(set) }
+}
+
+// The SessionSet is a signal over the union of its members' current
+// credentials: it fires on membership changes and on any member's value
+// change, and reads compute the union fresh (consumers recompute from the
+// full current set; diffs would buy them nothing).
+impl<CD: ContextData> Signal for SessionSet<CD> {
+    fn listen(&self, listener: Listener) -> ListenerGuard { ListenerGuard::new(self.0.changed.reference().listen(listener)) }
+    fn broadcast_id(&self) -> BroadcastId { self.0.changed.id() }
+}
+
+impl<CD: ContextData> Get<Vec<CD>> for SessionSet<CD> {
+    fn get(&self) -> Vec<CD> {
+        ankurah_signals::CurrentObserver::track(self);
+        self.current()
+    }
+}
+
+impl<CD: ContextData> Peek<Vec<CD>> for SessionSet<CD> {
+    fn peek(&self) -> Vec<CD> { self.current() }
+}
+
+impl<CD: ContextData> Subscribe<Vec<CD>> for SessionSet<CD> {
+    fn subscribe<F>(&self, listener: F) -> SubscriptionGuard
+    where F: IntoSubscribeListener<Vec<CD>> {
+        let listener = listener.into_subscribe_listener();
+        // A weak inner breaks the cycle set -> broadcast -> listener -> set.
+        let weak = Arc::downgrade(&self.0);
+        let subscription = self.listen(Arc::new(move |_| {
+            if let Some(inner) = weak.upgrade() {
+                listener(SessionSet(inner).current());
+            }
+        }));
+        SubscriptionGuard::new(subscription)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A value-carrying test credential. Equality is full-value
+    /// (operational identity per the [`ContextData`] contract), so a
+    /// token refresh — same subject, new token — compares unequal and an
+    /// identical update compares equal.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    struct TestCd {
+        subject: u8,
+        token: u8,
+    }
+    impl ContextData for TestCd {}
+
+    /// Revocation removes a member IMMEDIATELY, even while an Arc still
+    /// holds the Session alive — the property SessionHolder::replace
+    /// relies on so an overlapping snapshot can never list a replaced
+    /// member alongside its successor (a union would read under the
+    /// credential being replaced).
+    #[test]
+    fn revocation_is_immediate_despite_live_holders() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let old_member = set.register(TestCd { subject: 1, token: 0 });
+        old_member.revoke();
+        let _new_member = set.register(TestCd { subject: 2, token: 0 });
+        let visible: Vec<u8> = set.current().into_iter().map(|cd| cd.subject).collect();
+        assert_eq!(visible, vec![2], "the revoked member must not appear while its Arc lives, got {:?}", visible);
+        drop(old_member); // the eventual Drop finds the slot already gone
+        assert_eq!(set.current().len(), 1);
+    }
+
+    /// Sessions appear in the set while any holder lives and vanish when
+    /// the last holder drops.
+    #[test]
+    fn membership_is_liveness() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let a = set.register(TestCd { subject: 1, token: 0 });
+        let b = set.register(TestCd { subject: 2, token: 0 });
+        assert_eq!(set.sessions().len(), 2);
+
+        let extension = a.clone();
+        drop(a);
+        assert_eq!(set.sessions().len(), 2, "an extension holder keeps the session live");
+        drop(extension);
+        assert_eq!(set.sessions().len(), 1, "the last drop culls the slot");
+        drop(b);
+        assert!(set.sessions().is_empty());
+    }
+
+    /// Updates are visible to every holder and fire change subscribers
+    /// with the new value.
+    #[test]
+    fn update_is_shared_and_reactive() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let session = set.register(TestCd { subject: 1, token: 1 });
+        let holder = session.clone();
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let _guard = session.subscribe_changes(move |value: TestCd| {
+            sink.lock().unwrap().push(value.token);
+        });
+
+        session.update(TestCd { subject: 2, token: 2 });
+        assert_eq!(holder.snapshot().token, 2, "holders read the new value");
+        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "subscriber fired with the new value");
+    }
+
+    /// A token refresh — same subject, new token — is a real change: it
+    /// compares unequal and fires the subscriber. An identical update is
+    /// a complete no-op: no notification.
+    #[test]
+    fn refresh_notifies_and_identical_update_is_a_noop() {
+        let session = Session::detached(TestCd { subject: 1, token: 1 });
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let _guard = session.subscribe_changes(move |value: TestCd| {
+            sink.lock().unwrap().push(value.token);
+        });
+
+        let refreshed = TestCd { subject: 1, token: 2 };
+        assert_ne!(session.snapshot(), refreshed, "a refresh carries a new token, so it compares unequal");
+        session.update(refreshed);
+        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "the refresh fires the subscriber");
+
+        session.update(TestCd { subject: 1, token: 2 });
+        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "an identical update does not notify");
+        assert_eq!(session.snapshot().token, 2, "the stored value is unchanged");
+    }
+
+    /// Detached sessions never enter the set.
+    #[test]
+    fn detached_sessions_are_invisible() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let _infra = Session::detached(TestCd { subject: 1, token: 0 });
+        assert!(set.sessions().is_empty());
+    }
+
+    /// The set is a signal over the union of current credentials: it
+    /// fires on registration, on any member's update, and on a cull, and
+    /// a culled member stops firing it.
+    #[test]
+    fn set_fires_on_membership_and_member_updates() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let sink = fired.clone();
+        let _guard = set.subscribe(move |current: Vec<TestCd>| {
+            sink.lock().unwrap().push(current.iter().map(|cd| cd.token).collect::<Vec<_>>());
+        });
+
+        let a = set.register(TestCd { subject: 1, token: 10 });
+        assert_eq!(fired.lock().unwrap().last(), Some(&vec![10]), "registration fires with the new union");
+
+        a.update(TestCd { subject: 1, token: 11 });
+        assert_eq!(fired.lock().unwrap().last(), Some(&vec![11]), "a member's update fires with its new value");
+
+        let b = set.register(TestCd { subject: 2, token: 20 });
+        assert_eq!(fired.lock().unwrap().last(), Some(&vec![11, 20]));
+
+        drop(a);
+        assert_eq!(fired.lock().unwrap().last(), Some(&vec![20]), "a cull fires with the shrunken union");
+
+        let count = fired.lock().unwrap().len();
+        // The culled member's session is gone; nothing it held fires again.
+        drop(b);
+        assert_eq!(fired.lock().unwrap().last(), Some(&Vec::new()));
+        assert_eq!(fired.lock().unwrap().len(), count + 1, "exactly the final cull fired");
+    }
+
+    /// Peek reads the union without tracking; the porcelain and the
+    /// inherent accessors agree.
+    #[test]
+    fn porcelain_and_inherent_accessors_agree() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let session = set.register(TestCd { subject: 1, token: 1 });
+        assert_eq!(session.peek(), session.snapshot());
+        assert_eq!(set.peek(), set.current());
+        assert_eq!(set.peek(), vec![TestCd { subject: 1, token: 1 }]);
+    }
+}

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -39,20 +39,12 @@ pub trait ContextData: Send + Sync + Clone + std::hash::Hash + Eq + 'static {}
 
 /// One live credential: the value a single principal acts under,
 /// replaceable in place. An ordinary context registers exactly one in
-/// the node's [`SessionSet`]; the system context reads through the
+/// the node's [`SessionSet`]; a set-backed context reads through the
 /// whole set instead. Queries and their machinery (livequeries, gap
 /// fetchers, the relay) hold their context's [`Sessions`] source and
 /// read its current value once per operation.
 pub struct Session<CD: ContextData> {
     current: Mut<CD>,
-    /// Needed to close the TOCTOU between deriving state from a credential
-    /// snapshot and subscribing to its changes (the livequery constructor
-    /// re-checks it once its listener is live). Value comparison cannot
-    /// serve as that re-check: a change-and-revert inside the window (a
-    /// re-login to another user and back) leaves the value equal to the
-    /// snapshot while an in-window send may have shipped the interloper.
-    /// Bumped before the value stores, once per effective update.
-    generation: std::sync::atomic::AtomicU64,
     /// The owning [`SessionSet`] slot, absent for detached sessions.
     registry: Option<(Weak<SessionSetInner<CD>>, u64)>,
 }
@@ -61,9 +53,7 @@ impl<CD: ContextData> Session<CD> {
     /// A session outside any SessionSet: infrastructure credentials (and
     /// server-side per-query holders) that must not participate in the
     /// node's active-session enumeration.
-    pub fn detached(cdata: CD) -> Arc<Self> {
-        Arc::new(Self { current: Mut::new(cdata), generation: std::sync::atomic::AtomicU64::new(0), registry: None })
-    }
+    pub fn detached(cdata: CD) -> Arc<Self> { Arc::new(Self { current: Mut::new(cdata), registry: None }) }
 
     /// A snapshot of the current credential. Take one per logical
     /// operation, so a mid-operation update cannot mix credentials. (Named
@@ -72,8 +62,8 @@ impl<CD: ContextData> Session<CD> {
     pub fn snapshot(&self) -> CD { self.current.value() }
 
     /// Replace the credential. A value comparing equal to the current one
-    /// is a complete no-op — no store, no generation bump, no
-    /// notification: `Eq` is operational identity per [`ContextData`], so
+    /// is a complete no-op, no store and no notification: `Eq` is
+    /// operational identity per [`ContextData`], so
     /// equal means nothing observable changed and there is nothing to
     /// re-permission. A token refresh carries a new token, compares
     /// unequal, and notifies holders and change subscribers.
@@ -86,17 +76,8 @@ impl<CD: ContextData> Session<CD> {
         if self.current.value() == cdata {
             return;
         }
-        self.generation.fetch_add(1, Ordering::SeqCst);
-        if let Some((registry, _)) = &self.registry {
-            if let Some(registry) = registry.upgrade() {
-                registry.generation.fetch_add(1, Ordering::SeqCst);
-            }
-        }
         self.current.set(cdata);
     }
-
-    /// The effective-update count; see the field doc for the TOCTOU it closes.
-    pub fn generation(&self) -> u64 { self.generation.load(Ordering::SeqCst) }
 
     /// Subscribe to credential changes; the listener receives each new
     /// value. Dropping the guard unsubscribes.
@@ -139,7 +120,6 @@ impl<CD: ContextData> Session<CD> {
     pub(crate) fn revoke(&self) {
         if let Some((registry, slot)) = &self.registry {
             if let Some(registry) = registry.upgrade() {
-                registry.generation.fetch_add(1, Ordering::SeqCst);
                 if registry.sessions.lock().unwrap_or_else(|e| e.into_inner()).remove(slot).is_some() {
                     // Fire outside the lock: subscribers read the set back.
                     registry.changed.send(());
@@ -175,11 +155,6 @@ struct SessionSetInner<CD: ContextData> {
     /// Fires on any membership change (register, cull) and on any live
     /// member's value change (each slot forwards its session's signal).
     changed: Broadcast<()>,
-    /// Composite update count, bumped BEFORE the change it counts becomes
-    /// observable (registrations, culls, and member updates alike), so the
-    /// snapshot-then-subscribe re-check ([`Session::generation`]) works
-    /// over the whole set.
-    generation: AtomicU64,
 }
 
 struct SessionSlot<CD: ContextData> {
@@ -191,20 +166,13 @@ struct SessionSlot<CD: ContextData> {
 
 impl<CD: ContextData> SessionSet<CD> {
     pub fn new() -> Self {
-        Self(Arc::new(SessionSetInner {
-            sessions: Mutex::new(HashMap::new()),
-            next_slot: AtomicU64::new(0),
-            changed: Broadcast::new(),
-            generation: AtomicU64::new(0),
-        }))
+        Self(Arc::new(SessionSetInner { sessions: Mutex::new(HashMap::new()), next_slot: AtomicU64::new(0), changed: Broadcast::new() }))
     }
 
     /// Register a new live session holding `cdata`.
     pub fn register(&self, cdata: CD) -> Arc<Session<CD>> {
-        self.0.generation.fetch_add(1, Ordering::SeqCst);
         let slot = self.0.next_slot.fetch_add(1, Ordering::Relaxed);
-        let session =
-            Arc::new(Session { current: Mut::new(cdata), generation: AtomicU64::new(0), registry: Some((Arc::downgrade(&self.0), slot)) });
+        let session = Arc::new(Session { current: Mut::new(cdata), registry: Some((Arc::downgrade(&self.0), slot)) });
         let forward = {
             let changed = self.0.changed.clone();
             session.subscribe_changes(move |_new: CD| changed.send(()))
@@ -229,20 +197,14 @@ impl<CD: ContextData> SessionSet<CD> {
 
     /// The current credential of every live session, in slot order.
     pub fn current(&self) -> Vec<CD> { self.sessions().iter().map(|session| session.snapshot()).collect() }
-
-    /// The composite update count; see [`Session::generation`] for the
-    /// TOCTOU it closes. Moves on registrations, culls, and member
-    /// updates alike.
-    pub fn generation(&self) -> u64 { self.0.generation.load(Ordering::SeqCst) }
 }
 
 /// The credential source behind a query: exactly one session (an ordinary
 /// context's query), the node's whole live set (a system query), or a
 /// held set the query's server side replaces wholesale on re-validated
 /// subscribes. Sends snapshot the CURRENT credentials; subscribers fire
-/// on any change, and the composite generation closes the same
-/// snapshot-then-subscribe TOCTOU as [`Session::generation`]. Only `One`
-/// can write: the other arms act as no single principal.
+/// on any change. Only `One` can write: the other arms act as no
+/// single principal.
 pub enum Sessions<CD: ContextData> {
     One(Arc<Session<CD>>),
     Set(SessionSet<CD>),
@@ -290,16 +252,6 @@ impl<CD: ContextData> Sessions<CD> {
             }
             Self::Set(set) => set.subscribe(listener),
             Self::Held(holder) => holder.0.set.subscribe(listener),
-        }
-    }
-
-    /// The update count; see [`Session::generation`] for the TOCTOU it
-    /// closes.
-    pub fn generation(&self) -> u64 {
-        match self {
-            Self::One(session) => session.generation(),
-            Self::Set(set) => set.generation(),
-            Self::Held(holder) => holder.0.set.generation(),
         }
     }
 }
@@ -396,10 +348,6 @@ impl<CD: ContextData> Subscribe<Vec<CD>> for SessionSet<CD> {
     }
 }
 
-impl<CD: ContextData> Default for SessionSet<CD> {
-    fn default() -> Self { Self::new() }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -471,7 +419,7 @@ mod tests {
 
     /// A token refresh — same subject, new token — is a real change: it
     /// compares unequal and fires the subscriber. An identical update is
-    /// a complete no-op: no notification, no generation bump.
+    /// a complete no-op: no notification.
     #[test]
     fn refresh_notifies_and_identical_update_is_a_noop() {
         let session = Session::detached(TestCd { subject: 1, token: 1 });
@@ -486,10 +434,8 @@ mod tests {
         session.update(refreshed);
         assert_eq!(seen.lock().unwrap().as_slice(), &[2], "the refresh fires the subscriber");
 
-        let before = session.generation();
         session.update(TestCd { subject: 1, token: 2 });
         assert_eq!(seen.lock().unwrap().as_slice(), &[2], "an identical update does not notify");
-        assert_eq!(session.generation(), before, "an identical update does not bump the generation");
         assert_eq!(session.snapshot().token, 2, "the stored value is unchanged");
     }
 
@@ -499,21 +445,6 @@ mod tests {
         let set: SessionSet<TestCd> = SessionSet::new();
         let _infra = Session::detached(TestCd { subject: 1, token: 0 });
         assert!(set.sessions().is_empty());
-    }
-
-    /// The generation bumps once per effective update and not for gated
-    /// no-ops: the snapshot-then-subscribe re-check must see exactly the
-    /// updates that changed something.
-    #[test]
-    fn generation_counts_every_effective_update() {
-        let session = Session::detached(TestCd { subject: 1, token: 1 });
-        let before = session.generation();
-        session.update(TestCd { subject: 1, token: 2 });
-        assert_eq!(session.generation(), before + 1, "a refresh bumps");
-        session.update(TestCd { subject: 2, token: 3 });
-        assert_eq!(session.generation(), before + 2);
-        session.update(TestCd { subject: 2, token: 3 });
-        assert_eq!(session.generation(), before + 2, "an identical update does not bump");
     }
 
     /// The set is a signal over the union of current credentials: it
@@ -545,24 +476,6 @@ mod tests {
         drop(b);
         assert_eq!(fired.lock().unwrap().last(), Some(&Vec::new()));
         assert_eq!(fired.lock().unwrap().len(), count + 1, "exactly the final cull fired");
-    }
-
-    /// The set's composite generation moves on registrations, culls, and
-    /// member updates alike, closing the construction window for
-    /// set-backed consumers the way [`Session::generation`] does for
-    /// single-session ones.
-    #[test]
-    fn set_generation_counts_every_change() {
-        let set: SessionSet<TestCd> = SessionSet::new();
-        let after_new = set.generation();
-        let a = set.register(TestCd { subject: 1, token: 0 });
-        assert!(set.generation() > after_new, "a registration bumps");
-        let after_register = set.generation();
-        a.update(TestCd { subject: 1, token: 1 });
-        assert!(set.generation() > after_register, "a member update bumps the set too");
-        let after_update = set.generation();
-        drop(a);
-        assert!(set.generation() > after_update, "a cull bumps");
     }
 
     /// A `Sessions` source unifies the two credential shapes: One

--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -112,6 +112,10 @@ impl PolicyAgent for JwtAgent {
     {
         debug!("JwtAgent sign_request");
         let mut auth_data = Vec::new();
+        // All-or-nothing: one unsignable member (Root's auth_data errors
+        // by design) fails the whole request even when other members
+        // could serve. Skip-vs-fail is an open decision:
+        // https://github.com/ankurah/ankurah/issues/432
         for ctx in cdata.iterable() {
             auth_data.push(ctx.auth_data()?);
         }
@@ -239,20 +243,37 @@ impl PolicyAgent for JwtAgent {
             return Ok(predicate);
         }
 
-        let claims = data
-            .iterable()
-            .find_map(|ctx| match ctx {
-                JwtContext::User { claims, .. } => Some(claims),
-                _ => None,
-            })
-            .ok_or(AccessDenied::ByPolicy("No authenticated context for row filtering"))?;
-
-        let mut result = predicate;
-        for filter in scoped_predicates(&state.config, collection.as_str(), claims, ScopeAccess::Read)? {
-            result = Predicate::And(Box::new(result), Box::new(filter));
+        // Each authenticated context sees its own scoped slice; the
+        // query's visibility is their union (OR of the per-context
+        // narrowings), mirroring enforce_read_scope's any-of evaluation.
+        // A single-credential query degenerates to its one narrowing.
+        let mut per_context: Vec<Predicate> = Vec::new();
+        for ctx in data.iterable() {
+            let JwtContext::User { claims, .. } = ctx else {
+                continue;
+            };
+            // The union is over AUTHORIZED contexts, not merely
+            // authenticated ones (mirrors enforce_read_scope): a context
+            // without collection access contributes no branch, else its
+            // scoped slice would expose rows no authorized credential
+            // could read. Access here means the read OR write privilege
+            // BY DESIGN: a write grant implies visibility of the rows it
+            // governs (scope rules still narrow each credential's slice),
+            // so a write-only credential's branch belongs in the union.
+            if !state.config.can_access_collection(ctx.roles(), collection) {
+                continue;
+            }
+            let mut narrowed = predicate.clone();
+            for filter in scoped_predicates(&state.config, collection.as_str(), claims, ScopeAccess::Read)? {
+                narrowed = Predicate::And(Box::new(narrowed), Box::new(filter));
+            }
+            per_context.push(narrowed);
         }
 
-        Ok(result)
+        per_context
+            .into_iter()
+            .reduce(|union, next| Predicate::Or(Box::new(union), Box::new(next)))
+            .ok_or(AccessDenied::ByPolicy("No authorized context for row filtering"))
     }
 
     fn check_read<C>(

--- a/extensions/jwt-auth/src/agent_state.rs
+++ b/extensions/jwt-auth/src/agent_state.rs
@@ -70,7 +70,12 @@ pub(crate) fn start_ephemeral_policy_sync<SE, PA>(
             return;
         }
     };
-    let lq = match EntityLiveQuery::new_weak_node(node, proto::CollectionId::from("jwtpolicy"), args, JwtContext::NoUser) {
+    let lq = match EntityLiveQuery::new_weak_node(
+        node,
+        proto::CollectionId::from("jwtpolicy"),
+        args,
+        ankurah_core::session::Session::detached(JwtContext::NoUser),
+    ) {
         Ok(lq) => lq,
         Err(e) => {
             tracing::error!("on_node_ready: failed to create policy livequery: {}", e);

--- a/extensions/jwt-auth/src/claims.rs
+++ b/extensions/jwt-auth/src/claims.rs
@@ -1,12 +1,13 @@
 use crate::error::AuthError;
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 
 /// JWT claims carried in every token issued by the auth system.
 ///
 /// Note: `sub` is stored in the standard JWT `subject` field (not in custom claims)
 /// to avoid serde conflicts with `jwt_simple`'s `#[serde(flatten)]` on custom claims.
 /// The `sub` field here is populated by `SigningKeys::verify()` from the standard claim.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct JwtClaims {
     /// User entity ID (ankurah EntityId serialized as string).
     /// When signing, this is placed in the standard JWT `sub` claim.
@@ -28,6 +29,85 @@ pub struct JwtClaims {
     /// Captures any JSON fields not explicitly defined above.
     #[serde(flatten)]
     pub custom: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Total equality is honest: `serde_json` cannot represent NaN or
+/// infinity (parsing rejects them and `Number::from_f64` refuses them),
+/// so the reflexivity hole in `Value`'s `PartialEq` is unreachable.
+impl Eq for JwtClaims {}
+
+/// Full-value hash agreeing with `Eq` (the `ContextData` contract).
+/// `serde_json::Value` implements no `Hash`, so the `custom` map is
+/// hashed by a recursive walk — objects in sorted key order, because
+/// map equality is order-independent.
+impl Hash for JwtClaims {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.sub.hash(state);
+        self.roles.hash(state);
+        self.email.hash(state);
+        self.name.hash(state);
+        self.custom.len().hash(state);
+        let mut keys: Vec<&String> = self.custom.keys().collect();
+        keys.sort();
+        for key in keys {
+            key.hash(state);
+            hash_json_value(&self.custom[key], state);
+        }
+    }
+}
+
+/// Hash a JSON value such that values equal under `serde_json`'s own
+/// `PartialEq` hash equal: arm-tagged, arrays in order, objects in
+/// sorted key order. Numbers hash by their canonical arm (unsigned,
+/// signed, then float bits), mirroring `serde_json::Number` equality,
+/// which never compares across arms.
+fn hash_json_value<H: Hasher>(value: &serde_json::Value, state: &mut H) {
+    use serde_json::Value;
+    match value {
+        Value::Null => 0u8.hash(state),
+        Value::Bool(b) => {
+            1u8.hash(state);
+            b.hash(state);
+        }
+        Value::Number(n) => {
+            2u8.hash(state);
+            if let Some(u) = n.as_u64() {
+                0u8.hash(state);
+                u.hash(state);
+            } else if let Some(i) = n.as_i64() {
+                1u8.hash(state);
+                i.hash(state);
+            } else {
+                // serde_json number equality is IEEE (-0.0 == 0.0), so
+                // the hash must not split zero by sign bit.
+                2u8.hash(state);
+                let float = n.as_f64().expect("a serde_json Number is one of u64/i64/f64");
+                let float = if float == 0.0 { 0.0 } else { float };
+                float.to_bits().hash(state);
+            }
+        }
+        Value::String(s) => {
+            3u8.hash(state);
+            s.hash(state);
+        }
+        Value::Array(items) => {
+            4u8.hash(state);
+            items.len().hash(state);
+            for item in items {
+                hash_json_value(item, state);
+            }
+        }
+        Value::Object(map) => {
+            5u8.hash(state);
+            map.len().hash(state);
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            for key in keys {
+                key.hash(state);
+                hash_json_value(&map[key], state);
+            }
+        }
+    }
 }
 
 /// Parse a JWT token without verifying the signature.

--- a/extensions/jwt-auth/src/context.rs
+++ b/extensions/jwt-auth/src/context.rs
@@ -2,6 +2,7 @@ use crate::claims::JwtClaims;
 use ankurah_core::node::ContextData;
 use ankurah_core::policy::AccessDenied;
 use ankurah_proto as proto;
+use async_trait::async_trait;
 
 /// The context data extracted from a validated JWT, used for all policy checks.
 /// `Root` represents a privileged system context that bypasses all RBAC checks.
@@ -10,7 +11,7 @@ use ankurah_proto as proto;
 /// Equality and hash are full-value — claims and token — because
 /// `ContextData`'s contract is operational identity and `Session` update
 /// delivery gates on it: a token refresh compares unequal and
-/// propagates; an identical update is a no-op.
+/// re-permissions; an identical update is a no-op.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum JwtContext {
     User { claims: JwtClaims, token: String },
@@ -71,4 +72,5 @@ impl JwtContext {
     }
 }
 
+#[async_trait]
 impl ContextData for JwtContext {}

--- a/extensions/jwt-auth/src/context.rs
+++ b/extensions/jwt-auth/src/context.rs
@@ -2,7 +2,6 @@ use crate::claims::JwtClaims;
 use ankurah_core::node::ContextData;
 use ankurah_core::policy::AccessDenied;
 use ankurah_proto as proto;
-use async_trait::async_trait;
 
 /// The context data extracted from a validated JWT, used for all policy checks.
 /// `Root` represents a privileged system context that bypasses all RBAC checks.
@@ -72,5 +71,4 @@ impl JwtContext {
     }
 }
 
-#[async_trait]
 impl ContextData for JwtContext {}

--- a/extensions/jwt-auth/src/context.rs
+++ b/extensions/jwt-auth/src/context.rs
@@ -2,13 +2,16 @@ use crate::claims::JwtClaims;
 use ankurah_core::node::ContextData;
 use ankurah_core::policy::AccessDenied;
 use ankurah_proto as proto;
-use async_trait::async_trait;
-use std::hash::{Hash, Hasher};
 
 /// The context data extracted from a validated JWT, used for all policy checks.
 /// `Root` represents a privileged system context that bypasses all RBAC checks.
 /// `NoUser` represents an unauthenticated context (e.g. for reading the policy collection).
-#[derive(Debug, Clone)]
+///
+/// Equality and hash are full-value — claims and token — because
+/// `ContextData`'s contract is operational identity and `Session` update
+/// delivery gates on it: a token refresh compares unequal and
+/// propagates; an identical update is a no-op.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum JwtContext {
     User { claims: JwtClaims, token: String },
     Root,
@@ -68,28 +71,4 @@ impl JwtContext {
     }
 }
 
-impl PartialEq for JwtContext {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (JwtContext::User { claims: a, .. }, JwtContext::User { claims: b, .. }) => a.sub == b.sub,
-            (JwtContext::Root, JwtContext::Root) => true,
-            (JwtContext::NoUser, JwtContext::NoUser) => true,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for JwtContext {}
-
-impl Hash for JwtContext {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(self).hash(state);
-        match self {
-            JwtContext::User { claims, .. } => claims.sub.hash(state),
-            JwtContext::Root | JwtContext::NoUser => {}
-        }
-    }
-}
-
-#[async_trait]
 impl ContextData for JwtContext {}

--- a/extensions/jwt-auth/tests/context_tests.rs
+++ b/extensions/jwt-auth/tests/context_tests.rs
@@ -25,8 +25,13 @@ fn test_jwt_context_accessors() {
     assert_eq!(ctx.token_bytes(), Some(b"fake-token".as_slice()));
 }
 
+/// Equality is full-value (operational identity per the ContextData
+/// contract): same subject with different claims or token compares
+/// UNEQUAL — Session update delivery gates on this, and a token refresh
+/// must register as a change — and only an identical value compares
+/// equal, with the hash agreeing.
 #[test]
-fn test_jwt_context_equality_by_sub() {
+fn test_jwt_context_equality_is_full_value() {
     let ctx1 = JwtContext::from_claims(
         JwtClaims {
             sub: "user-1".into(),
@@ -37,6 +42,7 @@ fn test_jwt_context_equality_by_sub() {
         },
         "token-1".into(),
     );
+    // Same subject, different claims and token: a re-login or refresh.
     let ctx2 = JwtContext::from_claims(
         JwtClaims {
             sub: "user-1".into(),
@@ -57,8 +63,43 @@ fn test_jwt_context_equality_by_sub() {
         },
         "token-3".into(),
     );
-    assert_eq!(ctx1, ctx2);
+    assert_ne!(ctx1, ctx2, "same subject with different claims or token is a different credential");
     assert_ne!(ctx1, ctx3);
+    let identical = ctx1.clone();
+    assert_eq!(ctx1, identical, "only an identical value compares equal");
+
+    let mut set = std::collections::HashSet::new();
+    set.insert(ctx1);
+    assert!(set.contains(&identical), "hash agrees with eq");
+    assert!(!set.contains(&ctx2));
+}
+
+/// Hash agrees with Eq over custom claims regardless of map insertion
+/// order: json map equality is order-independent, so the hash walks
+/// objects in sorted key order.
+#[test]
+fn test_jwt_context_hash_ignores_custom_claim_insertion_order() {
+    let mut ab = serde_json::Map::new();
+    ab.insert("a".into(), serde_json::json!({"n": 1, "s": ["x", 2.5, null]}));
+    ab.insert("b".into(), serde_json::json!(true));
+    let mut ba = serde_json::Map::new();
+    ba.insert("b".into(), serde_json::json!(true));
+    ba.insert("a".into(), serde_json::json!({"n": 1, "s": ["x", 2.5, null]}));
+
+    let claims = |custom: serde_json::Map<String, serde_json::Value>| JwtClaims {
+        sub: "user-1".into(),
+        roles: vec![],
+        email: "a@b.com".into(),
+        name: None,
+        custom,
+    };
+    let c1 = JwtContext::from_claims(claims(ab), "t".into());
+    let c2 = JwtContext::from_claims(claims(ba), "t".into());
+    assert_eq!(c1, c2, "map equality is insertion-order independent");
+
+    let mut set = std::collections::HashSet::new();
+    set.insert(c1);
+    assert!(set.contains(&c2), "the hash must agree");
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/jwt-auth/tests/filter_predicate_tests.rs
+++ b/extensions/jwt-auth/tests/filter_predicate_tests.rs
@@ -190,3 +190,104 @@ fn test_filter_predicate_injection_payload_is_inert() {
         other => panic!("Expected AND predicate, got: {:?}", other),
     }
 }
+
+/// Multiple authenticated contexts see the UNION of their scoped slices:
+/// the effective filter is the OR of each context's narrowed predicate,
+/// never just the first context's.
+#[test]
+fn test_filter_predicate_unions_across_contexts() {
+    let config_json = r#"{
+        "roles": { "Worker": ["view_records"] },
+        "collections": {
+            "record": {
+                "read": "view_records",
+                "write": "manage_records",
+                "scope": [{ "filter": "owner = $jwt.sub" }]
+            }
+        }
+    }"#;
+    let config: PolicyConfig = serde_json::from_str(config_json).unwrap();
+
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_ephemeral();
+    agent.update_config(config);
+    agent.set_keys(JwtKeys::Signing(keys.clone()));
+
+    let make_ctx = |sub: &str| {
+        let claims = JwtClaims {
+            sub: sub.into(),
+            roles: vec!["Worker".into()],
+            email: format!("{sub}@co.com"),
+            name: None,
+            custom: serde_json::Map::new(),
+        };
+        let token = keys.sign(&claims, Duration::from_hours(1)).unwrap();
+        JwtContext::from_claims(claims, token)
+    };
+
+    let contexts = vec![make_ctx("worker-1"), make_ctx("worker-2")];
+    let predicate = make_predicate("status = 'active'");
+    let collection = CollectionId::from("record");
+
+    let result = agent.filter_predicate(&contexts, &collection, predicate).unwrap();
+
+    match &result {
+        Predicate::Or(first, second) => {
+            let first = format!("{}", first);
+            let second = format!("{}", second);
+            assert!(first.contains("worker-1") && first.contains("active"), "first narrowing: {}", first);
+            assert!(second.contains("worker-2") && second.contains("active"), "second narrowing: {}", second);
+        }
+        other => panic!("Expected OR of per-context narrowings, got: {:?}", other),
+    }
+}
+
+/// The union is over AUTHORIZED contexts only: an authenticated context
+/// whose roles lack the collection's read privilege contributes no
+/// branch (its scoped slice would expose rows no authorized credential
+/// could read), and a set with no authorized context is denied outright.
+#[test]
+fn test_filter_predicate_excludes_unauthorized_contexts() {
+    let config_json = r#"{
+        "roles": { "Worker": ["view_records"], "Guest": ["view_lobby"] },
+        "collections": {
+            "record": {
+                "read": "view_records",
+                "write": "manage_records",
+                "scope": [{ "filter": "owner = $jwt.sub" }]
+            }
+        }
+    }"#;
+    let config: PolicyConfig = serde_json::from_str(config_json).unwrap();
+
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_ephemeral();
+    agent.update_config(config);
+    agent.set_keys(JwtKeys::Signing(keys.clone()));
+
+    let make_ctx = |sub: &str, role: &str| {
+        let claims = JwtClaims {
+            sub: sub.into(),
+            roles: vec![role.into()],
+            email: format!("{sub}@co.com"),
+            name: None,
+            custom: serde_json::Map::new(),
+        };
+        let token = keys.sign(&claims, Duration::from_hours(1)).unwrap();
+        JwtContext::from_claims(claims, token)
+    };
+
+    let alice = make_ctx("alice-authorized", "Worker");
+    let bob = make_ctx("bob-unauthorized", "Guest");
+    let predicate = make_predicate("status = 'active'");
+    let collection = CollectionId::from("record");
+
+    let result = agent.filter_predicate(&vec![alice, bob.clone()], &collection, predicate.clone()).unwrap();
+    let display = format!("{}", result);
+    assert!(matches!(result, Predicate::And(..)), "one authorized context degenerates to its single narrowing, got: {}", display);
+    assert!(display.contains("alice-authorized"), "the authorized context's scope must be present in: {}", display);
+    assert!(!display.contains("bob-unauthorized"), "the unauthorized context must contribute no branch to: {}", display);
+
+    let denied = agent.filter_predicate(&vec![bob], &collection, predicate);
+    assert!(denied.is_err(), "a set with no authorized context is denied, got: {:?}", denied);
+}

--- a/extensions/jwt-auth/tests/session_refresh_tests.rs
+++ b/extensions/jwt-auth/tests/session_refresh_tests.rs
@@ -1,0 +1,668 @@
+//! Credential refresh re-permissions relayed subscriptions: updating a
+//! Context's JwtContext re-sends its live queries to the durable peer,
+//! which re-validates the new token and re-scopes the query under the new
+//! claims. Visibility follows the credential, with no livequery teardown.
+//!
+//! The scoping is server-authoritative: the client agent grants reads but
+//! carries no scope rules, so the durable node's `owner = $jwt.sub`
+//! injection is the only visibility filter, exactly the deployment shape
+//! where clients cannot be trusted to narrow their own queries.
+
+mod common;
+use common::*;
+
+use ankurah::core::node::MatchArgs;
+use ankurah::{Model, Node, Ref};
+use ankurah_connector_local_process::LocalProcessConnection;
+use ankurah_jwt_auth::{JwtAgent, JwtContext, JwtKeys, PolicyConfig};
+use ankurah_storage_sled::SledStorageEngine;
+use std::sync::Arc;
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ScopeTarget {
+    pub name: String,
+}
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ScopeItem {
+    pub owner: Ref<ScopeTarget>,
+    pub label: String,
+}
+
+/// The durable node scopes scopeitem reads to the caller's own subject.
+const SERVER_CONFIG: &str = r#"{
+    "roles": {
+        "Member": ["item:read", "target:read"]
+    },
+    "collections": {
+        "scopeitem": {
+            "read": "item:read",
+            "scope": [
+                { "filter": "owner = $jwt.sub" }
+            ]
+        },
+        "scopetarget": {
+            "read": "target:read"
+        }
+    }
+}"#;
+
+/// The client grants the same reads with NO scope rules.
+const CLIENT_CONFIG: &str = r#"{
+    "roles": {
+        "Member": ["item:read", "target:read"]
+    },
+    "collections": {
+        "scopeitem": {
+            "read": "item:read"
+        },
+        "scopetarget": {
+            "read": "target:read"
+        }
+    }
+}"#;
+
+/// Poll on IDENTITY, not count: a re-permission that swaps WHICH row
+/// matches keeps the count at 1 throughout, so a count poll returns
+/// before the swap and the follow-up id assert races it.
+async fn eventually_ids(lq: &ankurah::LiveQuery<ScopeItemView>, expected: &[ankurah::proto::EntityId]) -> bool {
+    for _ in 0..100 {
+        if lq.ids() == expected {
+            return true;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    lq.ids() == expected
+}
+
+async fn eventually_count(lq: &ankurah::LiveQuery<ScopeItemView>, expected: usize) -> usize {
+    for _ in 0..100 {
+        let count = lq.ids().len();
+        if count == expected {
+            return count;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    lq.ids().len()
+}
+
+async fn eventually(mut condition: impl FnMut() -> bool) -> bool {
+    for _ in 0..100 {
+        if condition() {
+            return true;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    condition()
+}
+
+/// The deployed shape: jwt policy sync mirrors scope rules onto clients,
+/// so the CLIENT also injects `owner = $jwt.sub` into the query. A
+/// refresh must re-derive that client-side filter under the new claims
+/// rather than re-sending the one baked at creation; a baked `owner =
+/// alice` ANDed with the server's `owner = bob` would go permanently
+/// dark. The local re-filter also drops alice's now-out-of-scope item
+/// from the resultset.
+#[tokio::test]
+async fn refresh_rederives_client_scope_rules() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server_agent = JwtAgent::new_ephemeral();
+    server_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    server_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), server_agent);
+    server.system.create().await?;
+
+    // The client carries the SAME scoped config the policy sync would mirror.
+    let client_agent = JwtAgent::new_ephemeral();
+    client_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    client_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), client_agent);
+
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let root = server.context(JwtContext::system())?;
+    let (alice_id, bob_id) = {
+        let trx = root.begin();
+        let alice = trx.create(&ScopeTarget { name: "alice".into() }).await?;
+        let bob = trx.create(&ScopeTarget { name: "bob".into() }).await?;
+        let ids = (alice.id(), bob.id());
+        trx.commit().await?;
+        ids
+    };
+    let (alice_item, bob_item) = {
+        let trx = root.begin();
+        let a = trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-1".into() }).await?.id();
+        let b = trx.create(&ScopeItem { owner: bob_id.into(), label: "bob-1".into() }).await?.id();
+        trx.commit().await?;
+        (a, b)
+    };
+
+    let alice_claims = make_claims(&alice_id.to_base64(), &["Member"], "alice@example.com");
+    let alice_token = sign_token(&keys, &alice_claims);
+    let ctx = client.context(JwtContext::from_claims(alice_claims, alice_token))?;
+
+    let args = MatchArgs { selection: "true".try_into()?, cached: false };
+    let lq = ctx.query::<ScopeItemView>(args)?;
+    lq.wait_initialized().await;
+    assert_eq!(lq.ids(), vec![alice_item], "alice's credential sees exactly her item");
+
+    let bob_claims = make_claims(&bob_id.to_base64(), &["Member"], "bob@example.com");
+    let bob_token = sign_token(&keys, &bob_claims);
+    ctx.update_cdata(JwtContext::from_claims(bob_claims, bob_token))?;
+    lq.wait_initialized().await;
+
+    // The client-side filter is now `owner = bob`: alice's item drops out
+    // of the local resultset and bob's arrives through the re-subscribe.
+    assert!(eventually_ids(&lq, &[bob_item]).await, "bob's item replaces alice's after re-permission, got {:?}", lq.ids());
+
+    {
+        let trx = root.begin();
+        trx.create(&ScopeItem { owner: bob_id.into(), label: "bob-2".into() }).await?;
+        trx.commit().await?;
+    }
+    assert_eq!(eventually_count(&lq, 2).await, 2, "new in-scope commits flow under the re-derived filter");
+
+    {
+        let trx = root.begin();
+        trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-2".into() }).await?;
+        trx.commit().await?;
+    }
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+    assert_eq!(lq.ids().len(), 2, "old-credential commits must not arrive");
+    Ok(())
+}
+
+/// One credential update re-permissions EVERY live query under the
+/// context, each through its own version authority: a re-login with two
+/// standing queries re-derives and re-subscribes both.
+#[tokio::test]
+async fn one_update_repermissions_every_query_under_the_context() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server_agent = JwtAgent::new_ephemeral();
+    server_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    server_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), server_agent);
+    server.system.create().await?;
+
+    let client_agent = JwtAgent::new_ephemeral();
+    client_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    client_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), client_agent);
+
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let root = server.context(JwtContext::system())?;
+    let (alice_id, bob_id) = {
+        let trx = root.begin();
+        let alice = trx.create(&ScopeTarget { name: "alice".into() }).await?;
+        let bob = trx.create(&ScopeTarget { name: "bob".into() }).await?;
+        let ids = (alice.id(), bob.id());
+        trx.commit().await?;
+        ids
+    };
+    let (alice_item, bob_item) = {
+        let trx = root.begin();
+        let a = trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-1".into() }).await?.id();
+        let b = trx.create(&ScopeItem { owner: bob_id.into(), label: "bob-1".into() }).await?.id();
+        trx.commit().await?;
+        (a, b)
+    };
+
+    let alice_claims = make_claims(&alice_id.to_base64(), &["Member"], "alice@example.com");
+    let alice_token = sign_token(&keys, &alice_claims);
+    let ctx = client.context(JwtContext::from_claims(alice_claims, alice_token))?;
+
+    let first = ctx.query::<ScopeItemView>(MatchArgs { selection: "true".try_into()?, cached: false })?;
+    let second = ctx.query::<ScopeItemView>(MatchArgs { selection: "true".try_into()?, cached: false })?;
+    first.wait_initialized().await;
+    second.wait_initialized().await;
+    assert_eq!(first.ids(), vec![alice_item], "first query sees alice's item");
+    assert_eq!(second.ids(), vec![alice_item], "second query sees alice's item");
+    assert_eq!((first.selection().value().1, second.selection().value().1), (1, 1));
+
+    let bob_claims = make_claims(&bob_id.to_base64(), &["Member"], "bob@example.com");
+    let bob_token = sign_token(&keys, &bob_claims);
+    ctx.update_cdata(JwtContext::from_claims(bob_claims, bob_token))?;
+    first.wait_initialized().await;
+    second.wait_initialized().await;
+    assert_eq!(first.selection().value().1, 2, "first query re-permissioned");
+    assert_eq!(second.selection().value().1, 2, "second query re-permissioned");
+    assert!(eventually_ids(&first, &[bob_item]).await, "first query re-scopes to bob, got {:?}", first.ids());
+    assert!(eventually_ids(&second, &[bob_item]).await, "second query re-scopes to bob, got {:?}", second.ids());
+    Ok(())
+}
+
+/// A DURABLE node's local livequery also re-permissions: `update_cdata`
+/// re-derives the scope filter and re-activates the reactor registration,
+/// so visibility follows the credential with no relay involved.
+#[tokio::test]
+async fn refresh_repermissions_durable_local_queries() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let agent = JwtAgent::new_ephemeral();
+    agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent);
+    node.system.create().await?;
+
+    let root = node.context(JwtContext::system())?;
+    let (alice_id, bob_id) = {
+        let trx = root.begin();
+        let alice = trx.create(&ScopeTarget { name: "alice".into() }).await?;
+        let bob = trx.create(&ScopeTarget { name: "bob".into() }).await?;
+        let ids = (alice.id(), bob.id());
+        trx.commit().await?;
+        ids
+    };
+    let (alice_item, bob_item) = {
+        let trx = root.begin();
+        let a = trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-1".into() }).await?.id();
+        let b = trx.create(&ScopeItem { owner: bob_id.into(), label: "bob-1".into() }).await?.id();
+        trx.commit().await?;
+        (a, b)
+    };
+
+    let alice_claims = make_claims(&alice_id.to_base64(), &["Member"], "alice@example.com");
+    let alice_token = sign_token(&keys, &alice_claims);
+    let ctx = node.context(JwtContext::from_claims(alice_claims, alice_token))?;
+
+    let lq = ctx.query::<ScopeItemView>("true")?;
+    lq.wait_initialized().await;
+    assert_eq!(lq.ids(), vec![alice_item], "alice sees exactly her item");
+
+    let bob_claims = make_claims(&bob_id.to_base64(), &["Member"], "bob@example.com");
+    let bob_token = sign_token(&keys, &bob_claims);
+    ctx.update_cdata(JwtContext::from_claims(bob_claims, bob_token))?;
+    lq.wait_initialized().await;
+    assert!(eventually_ids(&lq, &[bob_item]).await, "bob's item replaces alice's after the local re-filter, got {:?}", lq.ids());
+
+    let bob_item_2 = {
+        let trx = root.begin();
+        trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-2".into() }).await?;
+        let b2 = trx.create(&ScopeItem { owner: bob_id.into(), label: "bob-2".into() }).await?.id();
+        trx.commit().await?;
+        b2
+    };
+    assert_eq!(eventually_count(&lq, 2).await, 2, "one new item arrives");
+    let mut expected = vec![bob_item, bob_item_2];
+    expected.sort();
+    let mut actual = lq.ids();
+    actual.sort();
+    assert_eq!(actual, expected, "bob's items exactly; alice's new item did not leak in");
+    Ok(())
+}
+
+/// One livequery, two credentials: subscribed as alice it sees alice's
+/// items; after `update_cdata` to bob's token the SAME subscription is
+/// re-scoped by the server, bob's existing item arrives, new bob items
+/// flow, and new alice items no longer do.
+#[tokio::test]
+async fn refresh_moves_subscription_visibility() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server_agent = JwtAgent::new_ephemeral();
+    server_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    server_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), server_agent);
+    server.system.create().await?;
+
+    let client_agent = JwtAgent::new_ephemeral();
+    client_agent.update_config(serde_json::from_str::<PolicyConfig>(CLIENT_CONFIG)?);
+    client_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), client_agent);
+
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let root = server.context(JwtContext::system())?;
+    let (alice_id, bob_id) = {
+        let trx = root.begin();
+        let alice = trx.create(&ScopeTarget { name: "alice".into() }).await?;
+        let bob = trx.create(&ScopeTarget { name: "bob".into() }).await?;
+        let ids = (alice.id(), bob.id());
+        trx.commit().await?;
+        ids
+    };
+    {
+        let trx = root.begin();
+        trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-1".into() }).await?;
+        trx.create(&ScopeItem { owner: bob_id.into(), label: "bob-1".into() }).await?;
+        trx.commit().await?;
+    }
+
+    let alice_claims = make_claims(&alice_id.to_base64(), &["Member"], "alice@example.com");
+    let alice_token = sign_token(&keys, &alice_claims);
+    let ctx = client.context(JwtContext::from_claims(alice_claims, alice_token))?;
+
+    let args = MatchArgs { selection: "true".try_into()?, cached: false };
+    let lq = ctx.query::<ScopeItemView>(args)?;
+    lq.wait_initialized().await;
+    assert_eq!(lq.ids().len(), 1, "alice's credential sees exactly her item");
+
+    // The refresh: bob's token through the SAME context and subscription.
+    let bob_claims = make_claims(&bob_id.to_base64(), &["Member"], "bob@example.com");
+    let bob_token = sign_token(&keys, &bob_claims);
+    ctx.update_cdata(JwtContext::from_claims(bob_claims, bob_token))?;
+    lq.wait_initialized().await;
+
+    // Bob's pre-existing item arrives through the re-subscribe deltas.
+    // (Alice's item stays resident locally; revocation never claws back
+    // rows the node already holds.)
+    assert_eq!(eventually_count(&lq, 2).await, 2, "bob's existing item arrives after re-permission");
+
+    // Forward visibility follows the new credential: bob's commits flow...
+    {
+        let trx = root.begin();
+        trx.create(&ScopeItem { owner: bob_id.into(), label: "bob-2".into() }).await?;
+        trx.commit().await?;
+    }
+    assert_eq!(eventually_count(&lq, 3).await, 3, "new in-scope commits reach the re-permissioned subscription");
+
+    // ...and alice's no longer do.
+    {
+        let trx = root.begin();
+        trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-2".into() }).await?;
+        trx.commit().await?;
+    }
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+    assert_eq!(lq.ids().len(), 3, "commits scoped to the old credential must not arrive");
+
+    Ok(())
+}
+
+/// A credential change that REVOKES access does not freeze the query:
+/// re-permission flips it to Denied, claws the rows back out of the live
+/// resultset (locally persisted state is untouched), and a re-login
+/// heals it, rows returning.
+#[tokio::test]
+async fn logout_claws_back_the_resultset() -> anyhow::Result<()> {
+    use ankurah::core::livequery::LocalStatus;
+    use ankurah::signals::Peek;
+
+    let keys = common::test_keys();
+
+    let server_agent = JwtAgent::new_ephemeral();
+    server_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    server_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), server_agent);
+    server.system.create().await?;
+
+    let client_agent = JwtAgent::new_ephemeral();
+    client_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    client_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), client_agent);
+
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let root = server.context(JwtContext::system())?;
+    let (alice_id, alice_item) = {
+        let trx = root.begin();
+        let alice = trx.create(&ScopeTarget { name: "alice".into() }).await?;
+        let alice_id = alice.id();
+        let item = trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-1".into() }).await?.id();
+        trx.commit().await?;
+        (alice_id, item)
+    };
+
+    let alice_claims = make_claims(&alice_id.to_base64(), &["Member"], "alice@example.com");
+    let alice_token = sign_token(&keys, &alice_claims);
+    let ctx = client.context(JwtContext::from_claims(alice_claims.clone(), alice_token.clone()))?;
+
+    let lq = ctx.query::<ScopeItemView>(MatchArgs { selection: "true".try_into()?, cached: false })?;
+    lq.wait_initialized().await;
+    assert_eq!(lq.ids(), vec![alice_item], "alice sees her item while logged in");
+
+    // Logout: the anonymous credential cannot read the collection at all.
+    ctx.update_cdata(JwtContext::NoUser)?;
+    assert_eq!(eventually_count(&lq, 0).await, 0, "logout claws the rows back out of the live resultset");
+    assert!(
+        matches!(lq.status().peek().local, LocalStatus::Denied { .. }),
+        "the query reports Denied rather than freezing, got {:?}",
+        lq.status().peek().local
+    );
+    // The local denial above is INSTANT (the client's own policy agent
+    // refuses synchronously), but the intent still ships upstream for the
+    // server's own verdict. Wait for that verdict to land on the remote
+    // leg before committing: the server's claw-back runs BEFORE it sends
+    // the refusal, so the refusal's arrival is the observable point after
+    // which the old registration provably cannot stream. Committing on
+    // the local denial alone races the in-flight re-validation and the
+    // absence assertion below becomes timing-dependent.
+    assert!(
+        eventually(|| matches!(lq.status().peek().remote, ankurah::core::livequery::RemoteStatus::Error { .. })).await,
+        "the server's refusal lands on the remote leg, got {:?}",
+        lq.status().peek().remote
+    );
+
+    // The server tore down its side too (the failed re-validation removed
+    // the standing registration): a commit that alice WOULD see must not
+    // stream to the denied subscription.
+    let alice_item_2 = {
+        let trx = root.begin();
+        let item = trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-2".into() }).await?.id();
+        trx.commit().await?;
+        item
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    assert_eq!(
+        lq.ids(),
+        Vec::<ankurah::proto::EntityId>::new(),
+        "nothing streams into a denied query, even rows the old credential could see"
+    );
+    // The resultset alone cannot distinguish the server's teardown from
+    // the client's own claw-back (the local registration is gone either
+    // way). LOCAL STORAGE can: had the server kept streaming under the
+    // old grant, the delta would have been persisted on arrival.
+    let raw_scope_items = client.collections.get(&ankurah::proto::CollectionId::fixed_name("scopeitem")).await?;
+    assert!(
+        raw_scope_items.get_state(alice_item_2).await.is_err(),
+        "the denied-window commit must never reach client storage: the server removed the registration"
+    );
+
+    // Re-login: the query heals, initialization completes, and BOTH rows
+    // arrive (the one clawed back and the one committed while denied).
+    ctx.update_cdata(JwtContext::from_claims(alice_claims, alice_token))?;
+    tokio::time::timeout(std::time::Duration::from_secs(5), lq.wait_initialized())
+        .await
+        .expect("initialization completes after the re-login heals the query");
+    assert_eq!(eventually_count(&lq, 2).await, 2, "the re-login restores visibility including the row committed while denied");
+    let mut ids = lq.ids();
+    ids.sort();
+    let mut expected = vec![alice_item, alice_item_2];
+    expected.sort();
+    assert_eq!(ids, expected, "exactly alice's two items, no strays");
+    // The positive arm self-validates the collection name above: after
+    // the heal streams the missed row, the SAME raw read must find it.
+    // (A wrong collection id would fail here, not pass vacuously there.)
+    assert!(
+        raw_scope_items.get_state(alice_item_2).await.is_ok(),
+        "after the heal, the recovered row is in client storage under the asserted collection"
+    );
+    Ok(())
+}
+
+/// A reactor-notification subscriber may revoke the credential from
+/// inside its callback. The callback runs synchronously inside the
+/// reactor's send_update; the revocation's claw-back synchronously
+/// removes the reactor registration, which takes the same subscription
+/// state lock — this deadlocked while send_update broadcast under that
+/// lock, and pins that it no longer does.
+#[tokio::test(flavor = "multi_thread")]
+async fn reactor_subscriber_may_revoke_reentrantly() -> anyhow::Result<()> {
+    use ankurah::core::livequery::LocalStatus;
+    use ankurah::signals::{Peek, Subscribe};
+
+    let keys = common::test_keys();
+
+    let server_agent = JwtAgent::new_ephemeral();
+    server_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    server_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), server_agent);
+    server.system.create().await?;
+
+    let client_agent = JwtAgent::new_ephemeral();
+    client_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    client_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), client_agent);
+
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let root = server.context(JwtContext::system())?;
+    let alice_id = {
+        let trx = root.begin();
+        let alice = trx.create(&ScopeTarget { name: "alice".into() }).await?;
+        let alice_id = alice.id();
+        trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-1".into() }).await?;
+        trx.commit().await?;
+        alice_id
+    };
+
+    let alice_claims = make_claims(&alice_id.to_base64(), &["Member"], "alice@example.com");
+    let alice_token = sign_token(&keys, &alice_claims);
+    let ctx = client.context(JwtContext::from_claims(alice_claims, alice_token))?;
+
+    let lq = ctx.query::<ScopeItemView>(MatchArgs { selection: "true".try_into()?, cached: false })?;
+    lq.wait_initialized().await;
+
+    let revoked = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let _guard = {
+        let ctx2 = ctx.clone();
+        let revoked = revoked.clone();
+        lq.subscribe(move |_changes: ankurah::changes::ChangeSet<ScopeItemView>| {
+            if !revoked.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                ctx2.update_cdata(JwtContext::NoUser).expect("re-entrant revocation must not fail");
+            }
+        })
+    };
+
+    // Drive a reactor notification from an activation so the subscriber
+    // fires inside send_update's dispatch: the narrowed selection drops
+    // alice's row, and that membership change is the notified item (a
+    // same-selection update produces no items and sends nothing).
+    lq.update_selection("label = 'nothing-matches-this'")?;
+
+    assert!(
+        eventually_count(&lq, 0).await == 0 && matches!(lq.status().peek().local, LocalStatus::Denied { .. }),
+        "the re-entrant revocation completes: rows clawed back and status Denied, got {:?} / {:?}",
+        lq.ids(),
+        lq.status().peek().local
+    );
+    assert!(revoked.load(std::sync::atomic::Ordering::SeqCst), "the subscriber must have fired and revoked");
+    Ok(())
+}
+
+/// A RESULTSET-channel subscriber may revoke the credential from inside
+/// its callback, and a multi-entity batch stays coherent through it.
+/// Two pins in one: the deferred membership writes broadcast outside the
+/// reactor state lock (revoking in-callback reaches remove_predicate and
+/// that lock: pre-deferral this deadlocked), and each deferred write is
+/// liveness-gated (the batch's second write lands AFTER the revocation
+/// removed the query; ungated it would repopulate a denied resultset).
+#[tokio::test(flavor = "multi_thread")]
+async fn resultset_subscriber_may_revoke_and_the_batch_stays_clawed_back() -> anyhow::Result<()> {
+    use ankurah::core::livequery::LocalStatus;
+    use ankurah::signals::{Peek, Subscribe};
+
+    let keys = common::test_keys();
+
+    let server_agent = JwtAgent::new_ephemeral();
+    server_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    server_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), server_agent);
+    server.system.create().await?;
+
+    let client_agent = JwtAgent::new_ephemeral();
+    client_agent.update_config(serde_json::from_str::<PolicyConfig>(SERVER_CONFIG)?);
+    client_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), client_agent);
+
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let root = server.context(JwtContext::system())?;
+    let alice_id = {
+        let trx = root.begin();
+        let alice = trx.create(&ScopeTarget { name: "alice".into() }).await?;
+        let alice_id = alice.id();
+        trx.commit().await?;
+        alice_id
+    };
+
+    let alice_claims = make_claims(&alice_id.to_base64(), &["Member"], "alice@example.com");
+    let alice_token = sign_token(&keys, &alice_claims);
+    let ctx = client.context(JwtContext::from_claims(alice_claims, alice_token))?;
+
+    let lq = ctx.query::<ScopeItemView>(MatchArgs { selection: "true".try_into()?, cached: false })?;
+    lq.wait_initialized().await;
+
+    let revoked = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let _guard = {
+        let ctx2 = ctx.clone();
+        let revoked = revoked.clone();
+        lq.resultset().subscribe(move |_items: Vec<ScopeItemView>| {
+            if !revoked.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                ctx2.update_cdata(JwtContext::NoUser).expect("re-entrant revocation must not fail");
+            }
+        })
+    };
+    // A ChangeSet observer alongside: the batch's ReactorUpdate is
+    // dispatched AFTER the deferred writes, by which time the revocation
+    // (synchronous inside the first write's broadcast) has already landed
+    // as Denied, so the changeset channel must deliver NO membership
+    // changes from the dead registration.
+    let changeset_adds = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let _cs_guard = {
+        let changeset_adds = changeset_adds.clone();
+        lq.subscribe(move |changes: ankurah::changes::ChangeSet<ScopeItemView>| {
+            let adds = changes
+                .changes
+                .iter()
+                .filter(|c| matches!(c, ankurah::changes::ItemChange::Add { .. } | ankurah::changes::ItemChange::Initial { .. }))
+                .count();
+            changeset_adds.fetch_add(adds, std::sync::atomic::Ordering::SeqCst);
+        })
+    };
+
+    // One transaction, two rows: two deferred membership writes in one
+    // reactor batch. The first write's broadcast revokes; the gate must
+    // drop the second.
+    {
+        let trx = root.begin();
+        trx.create(&ScopeItem { owner: alice_id.into(), label: "batch-1".into() }).await?;
+        trx.create(&ScopeItem { owner: alice_id.into(), label: "batch-2".into() }).await?;
+        trx.commit().await?;
+    }
+
+    // Order the waits: the query starts EMPTY, so a bare count==0 check
+    // is trivially true before the batch even arrives. First the
+    // subscriber proves delivery reached the resultset channel, then the
+    // revocation lands as Denied, and only then is emptiness a claim
+    // about the deferred-write gate rather than about nothing.
+    assert!(
+        eventually(|| revoked.load(std::sync::atomic::Ordering::SeqCst)).await,
+        "the subscriber must fire on the batch delivery and revoke"
+    );
+    assert!(
+        eventually(|| matches!(lq.status().peek().local, LocalStatus::Denied { .. })).await,
+        "the re-entrant revocation lands as Denied, got {:?}",
+        lq.status().peek().local
+    );
+    // A beat for an ungated second write to surface, then the claims:
+    // nothing from the batch survives the claw-back, and the dead
+    // registration's membership changes never reached the changeset
+    // channel either.
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+    assert!(lq.ids().is_empty(), "no batch row survives the revocation (the second deferred write is liveness-gated), got {:?}", lq.ids());
+    assert_eq!(
+        changeset_adds.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "no membership change from the revoked batch reaches changeset subscribers"
+    );
+    Ok(())
+}

--- a/extensions/jwt-auth/tests/system_query_tests.rs
+++ b/extensions/jwt-auth/tests/system_query_tests.rs
@@ -1,0 +1,167 @@
+//! Set-backed (system) queries: a livequery credentialed by the node's
+//! whole SessionSet reads under the UNION of live credentials and follows
+//! logins, logouts, and refreshes reactively. Credential denial is a
+//! reported status, not a failure: with no eligible credential the query
+//! exists, serves nothing, and heals itself when a session arrives. This
+//! is the exact shape the catalog manager's standing queries use.
+
+mod common;
+use common::*;
+
+use ankurah::core::livequery::{EntityLiveQuery, LocalStatus, QueryStatus, RemoteStatus};
+use ankurah::core::node::MatchArgs;
+use ankurah::signals::Peek;
+use ankurah::{Model, Node, Ref};
+use ankurah_connector_local_process::LocalProcessConnection;
+use ankurah_jwt_auth::{JwtAgent, JwtContext, JwtKeys, PolicyConfig};
+use ankurah_storage_sled::SledStorageEngine;
+use std::sync::Arc;
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ScopeTarget {
+    pub name: String,
+}
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ScopeItem {
+    pub owner: Ref<ScopeTarget>,
+    pub label: String,
+}
+
+/// Both sides scope scopeitem reads to the caller's own subject, so the
+/// set-backed query's visibility is exactly the union of the live
+/// subjects' slices.
+const SCOPED_CONFIG: &str = r#"{
+    "roles": {
+        "Member": ["item:read", "target:read"]
+    },
+    "collections": {
+        "scopeitem": {
+            "read": "item:read",
+            "scope": [
+                { "filter": "owner = $jwt.sub" }
+            ]
+        },
+        "scopetarget": {
+            "read": "target:read"
+        }
+    }
+}"#;
+
+async fn eventually(mut condition: impl FnMut() -> bool) -> bool {
+    for _ in 0..100 {
+        if condition() {
+            return true;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    condition()
+}
+
+/// The full arc of a set-backed query's life: denied with no sessions,
+/// scoped to one login, widened to the union of two, narrowed by a
+/// logout, and denied again when the last session culls.
+#[tokio::test]
+async fn set_backed_query_follows_the_session_set() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server_agent = JwtAgent::new_ephemeral();
+    server_agent.update_config(serde_json::from_str::<PolicyConfig>(SCOPED_CONFIG)?);
+    server_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), server_agent);
+    server.system.create().await?;
+
+    let client_agent = JwtAgent::new_ephemeral();
+    client_agent.update_config(serde_json::from_str::<PolicyConfig>(SCOPED_CONFIG)?);
+    client_agent.set_keys(JwtKeys::Signing(keys.clone()));
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), client_agent);
+
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let root = server.context(JwtContext::system())?;
+    let (alice_id, bob_id) = {
+        let trx = root.begin();
+        let alice = trx.create(&ScopeTarget { name: "alice".into() }).await?;
+        let bob = trx.create(&ScopeTarget { name: "bob".into() }).await?;
+        let ids = (alice.id(), bob.id());
+        trx.commit().await?;
+        ids
+    };
+    let (alice_item, bob_item) = {
+        let trx = root.begin();
+        let a = trx.create(&ScopeItem { owner: alice_id.into(), label: "alice-1".into() }).await?.id();
+        let b = trx.create(&ScopeItem { owner: bob_id.into(), label: "bob-1".into() }).await?.id();
+        trx.commit().await?;
+        (a, b)
+    };
+
+    // The set-backed query, created with ZERO live sessions. Construction
+    // succeeds; denial is its status.
+    let args = MatchArgs { selection: "true".try_into()?, cached: true };
+    let lq = EntityLiveQuery::new(&client, "scopeitem".into(), args, client.sessions.clone())?.map::<ScopeItemView>();
+
+    let status: QueryStatus = lq.status().peek();
+    assert!(matches!(status.local, LocalStatus::Denied { .. }), "no credential grants: local leg is Denied, got {:?}", status.local);
+    assert!(lq.ids().is_empty(), "a denied query serves nothing");
+    // The remote leg settles into a refusal (the server rejects the
+    // credential-less subscribe; its refusal arrives as error text).
+    assert!(
+        eventually(|| matches!(lq.status().peek().remote, RemoteStatus::Error { .. } | RemoteStatus::Denied { .. })).await,
+        "remote leg reports the server's refusal, got {:?}",
+        lq.status().peek().remote
+    );
+
+    // Alice logs in: her session joins the set, the query re-derives,
+    // re-subscribes, and serves her slice.
+    let alice_claims = make_claims(&alice_id.to_base64(), &["Member"], "alice@example.com");
+    let alice_token = sign_token(&keys, &alice_claims);
+    let alice_ctx = client.context(JwtContext::from_claims(alice_claims, alice_token))?;
+
+    assert!(
+        eventually(|| matches!(
+            lq.status().peek(),
+            QueryStatus { local: LocalStatus::Active { .. }, remote: RemoteStatus::Established { .. } }
+        ))
+        .await,
+        "one login heals both legs, got {:?}",
+        lq.status().peek()
+    );
+    assert!(eventually(|| lq.ids() == vec![alice_item]).await, "alice's login scopes the query to her item, got {:?}", lq.ids());
+    // A heal re-enters the reactor's first-activation path at the
+    // CURRENT version, so initialization completes and waiters return;
+    // registering it at any earlier version would leave
+    // initialized_version behind the current version and hang this wait
+    // forever.
+    tokio::time::timeout(std::time::Duration::from_secs(5), lq.wait_initialized())
+        .await
+        .expect("initialization must complete after the query heals from Denied");
+
+    // Bob logs in too: the union widens to both slices.
+    let bob_claims = make_claims(&bob_id.to_base64(), &["Member"], "bob@example.com");
+    let bob_token = sign_token(&keys, &bob_claims);
+    let bob_ctx = client.context(JwtContext::from_claims(bob_claims, bob_token))?;
+
+    let both = {
+        let mut both = vec![alice_item, bob_item];
+        both.sort();
+        both
+    };
+    assert!(eventually(|| lq.ids_sorted() == both).await, "two logins union their slices, got {:?}", lq.ids_sorted());
+
+    // Alice logs out (her context drops, RAII culls her session): the
+    // union narrows to bob's slice.
+    drop(alice_ctx);
+    assert!(eventually(|| lq.ids() == vec![bob_item]).await, "a logout narrows the union, got {:?}", lq.ids());
+
+    // Bob logs out too: nothing grants, and the query returns to Denied
+    // rather than dying.
+    drop(bob_ctx);
+    assert!(
+        eventually(|| matches!(lq.status().peek().local, LocalStatus::Denied { .. })).await,
+        "the last logout returns the query to Denied, got {:?}",
+        lq.status().peek().local
+    );
+    assert!(eventually(|| lq.ids().is_empty()).await, "a denied query serves nothing again, got {:?}", lq.ids());
+    Ok(())
+}

--- a/tests/tests/activation_races.rs
+++ b/tests/tests/activation_races.rs
@@ -1,0 +1,106 @@
+//! Racing activations on one livequery must converge to the NEWEST
+//! selection: whatever a superseded activation does on its way out, the
+//! successor must land, serve, and wake waiters. The interleave is
+//! forced with a storage engine that delays `fetch_states` by a marker
+//! embedded in the selection, so the test is deterministic rather than
+//! a timing coin flip. Concurrent activations of one query are not
+//! serialized (issue #146); the broader coherence map for that substrate
+//! is issue #431. This pin guards the convergence invariant against any
+//! cleanup on the superseded path taking down its successor.
+
+mod common;
+use common::*;
+
+use ankurah::core::livequery::{LocalStatus, QueryStatus, RemoteStatus};
+use ankurah::core::storage::{StorageCollection, StorageEngine};
+use ankurah::error::MutationError;
+use ankurah::proto::{Attested, CollectionId, EntityId, EntityState, Event, EventId};
+use ankurah::signals::Peek;
+use ankurah::{Node, PermissiveAgent};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// A `fetch_states` delay keyed on a marker inside the selection, so each
+/// activation's local fetch can be given its own duration.
+struct DelayEngine(Arc<SledStorageEngine>);
+
+fn delay_for(selection: &ankql::ast::Selection) -> Option<Duration> {
+    let text = format!("{:?}", selection.predicate);
+    if text.contains("SLOW_A") {
+        Some(Duration::from_millis(300))
+    } else if text.contains("SLOW_B") {
+        Some(Duration::from_millis(3000))
+    } else {
+        None
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageEngine for DelayEngine {
+    type Value = Vec<u8>;
+    async fn collection(&self, id: &CollectionId) -> Result<Arc<dyn StorageCollection>, ankurah::error::RetrievalError> {
+        Ok(Arc::new(DelayCollection(self.0.collection(id).await?)))
+    }
+    async fn delete_all_collections(&self) -> Result<bool, MutationError> { self.0.delete_all_collections().await }
+}
+
+struct DelayCollection(Arc<dyn StorageCollection>);
+
+#[async_trait::async_trait]
+impl StorageCollection for DelayCollection {
+    async fn set_state(&self, state: Attested<EntityState>) -> Result<bool, MutationError> { self.0.set_state(state).await }
+    async fn get_state(&self, id: EntityId) -> Result<Attested<EntityState>, ankurah::error::RetrievalError> { self.0.get_state(id).await }
+    async fn fetch_states(&self, selection: &ankql::ast::Selection) -> Result<Vec<Attested<EntityState>>, ankurah::error::RetrievalError> {
+        if let Some(d) = delay_for(selection) {
+            tokio::time::sleep(d).await;
+        }
+        self.0.fetch_states(selection).await
+    }
+    async fn add_event(&self, e: &Attested<Event>) -> Result<bool, MutationError> { self.0.add_event(e).await }
+    async fn get_events(&self, ids: Vec<EventId>) -> Result<Vec<Attested<Event>>, ankurah::error::RetrievalError> {
+        self.0.get_events(ids).await
+    }
+    async fn dump_entity_events(&self, id: EntityId) -> Result<Vec<Attested<Event>>, ankurah::error::RetrievalError> {
+        self.0.dump_entity_events(id).await
+    }
+}
+
+/// v2's activation fetches for 300ms; v3 is minted at 100ms, inside
+/// that fetch, so v2 completes while already superseded, with v3's own
+/// activation (a 3000ms fetch) still in flight. Whatever the superseded
+/// v2 path does on its way out, v3 must land at Active version 3
+/// serving its one matching row, and a waiter must wake. The failure
+/// shape this discriminates: any superseded-path cleanup that removes
+/// the registration its successor is about to update leaves the
+/// livequery permanently deregistered, stale-statused, and unwakeable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn superseding_selection_survives_a_stale_activations_clawback() -> anyhow::Result<()> {
+    let node = Node::new_durable(Arc::new(DelayEngine(Arc::new(SledStorageEngine::new_test().unwrap()))), PermissiveAgent::new());
+    node.system.create().await?;
+    let ctx = node.context(DEFAULT_CONTEXT)?;
+
+    {
+        let trx = ctx.begin();
+        trx.create(&Album { name: "SLOW_A".into(), year: "a".into() }).await?;
+        trx.create(&Album { name: "SLOW_B".into(), year: "b".into() }).await?;
+        trx.commit().await?;
+    }
+
+    let lq = ctx.query_wait::<AlbumView>("name = 'nothing'").await?;
+    assert_eq!(lq.status().peek(), QueryStatus { local: LocalStatus::Active { version: 1 }, remote: RemoteStatus::None });
+
+    lq.update_selection("name = 'SLOW_A'")?; // v2: activation with a 300ms fetch
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    lq.update_selection("name = 'SLOW_B'")?; // v3: activation with a 3000ms fetch
+
+    let waited = tokio::time::timeout(Duration::from_millis(6000), lq.wait_initialized()).await;
+    assert!(waited.is_ok(), "a waiter on the newest selection must wake");
+
+    assert_eq!(lq.ids().len(), 1, "the v3 selection matches one row; the livequery must serve it, got {:?}", lq.ids());
+    assert_eq!(
+        lq.status().peek(),
+        QueryStatus { local: LocalStatus::Active { version: 3 }, remote: RemoteStatus::None },
+        "the newest selection must be the one serving"
+    );
+    Ok(())
+}

--- a/tests/tests/query_status.rs
+++ b/tests/tests/query_status.rs
@@ -1,0 +1,148 @@
+//! The livequery status signal: two legs, each reporting where the
+//! CURRENT selection stands. The local leg says what this node's reactor
+//! serves; the remote leg follows the relay's transitions (pending,
+//! requested, established, refused) and un-fails as conditions change.
+//! Nothing latches.
+
+mod common;
+use common::*;
+
+use ankurah::core::livequery::{LocalStatus, QueryStatus, RemoteStatus};
+use ankurah::signals::Peek;
+
+async fn eventually(mut condition: impl FnMut() -> bool) -> bool {
+    for _ in 0..100 {
+        if condition() {
+            return true;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+    condition()
+}
+
+/// A relayed query's remote leg walks pending/requested to established,
+/// and a selection update walks it there again at the new version.
+#[tokio::test]
+async fn remote_leg_reaches_established_and_follows_updates() -> anyhow::Result<()> {
+    let server = durable_sled_setup().await?;
+    let client = ephemeral_sled_setup().await?;
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let server_ctx = server.context(DEFAULT_CONTEXT)?;
+    {
+        let trx = server_ctx.begin();
+        trx.create(&Album { name: "first".into(), year: "1999".into() }).await?;
+        trx.commit().await?;
+    }
+
+    let client_ctx = client.context(DEFAULT_CONTEXT)?;
+    let lq = client_ctx.query_wait::<AlbumView>(nocache("true")?).await?;
+
+    assert!(
+        eventually(|| lq.status().peek()
+            == QueryStatus { local: LocalStatus::Active { version: 1 }, remote: RemoteStatus::Established { version: 1 } })
+        .await,
+        "the initial subscription establishes at version 1, got {:?}",
+        lq.status().peek()
+    );
+
+    lq.update_selection_wait("name = 'first'").await?;
+    assert!(
+        eventually(|| lq.status().peek()
+            == QueryStatus { local: LocalStatus::Active { version: 2 }, remote: RemoteStatus::Established { version: 2 } })
+        .await,
+        "a selection update re-establishes at version 2, got {:?}",
+        lq.status().peek()
+    );
+    Ok(())
+}
+
+/// A durable node's own query has no remote leg: its status reports
+/// RemoteStatus::None for life, and the local leg tracks its versions.
+#[tokio::test]
+async fn durable_local_query_has_no_remote_leg() -> anyhow::Result<()> {
+    let server = durable_sled_setup().await?;
+    let ctx = server.context(DEFAULT_CONTEXT)?;
+
+    let lq = ctx.query_wait::<AlbumView>("true").await?;
+    assert_eq!(
+        lq.status().peek(),
+        QueryStatus { local: LocalStatus::Active { version: 1 }, remote: RemoteStatus::None },
+        "a durable-local query serves locally with no remote leg"
+    );
+
+    lq.update_selection_wait("name = 'anything'").await?;
+    assert_eq!(
+        lq.status().peek(),
+        QueryStatus { local: LocalStatus::Active { version: 2 }, remote: RemoteStatus::None },
+        "updates advance the local leg; the remote leg stays None"
+    );
+    Ok(())
+}
+
+/// The status signal is safe to re-enter: a subscriber may call
+/// update_selection from inside its callback (the classic reactive
+/// pattern) without deadlocking — dispatch never runs under the query's
+/// locks, and a re-entrant enqueue is picked up by the active drainer.
+#[tokio::test(flavor = "multi_thread")]
+async fn status_subscriber_may_reenter_update_selection() -> anyhow::Result<()> {
+    use ankurah::signals::Subscribe;
+
+    let server = durable_sled_setup().await?;
+    let ctx = server.context(DEFAULT_CONTEXT)?;
+
+    let lq = ctx.query_wait::<AlbumView>("true").await?;
+
+    let reentered = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let _guard = {
+        let lq2 = lq.clone();
+        let reentered = reentered.clone();
+        lq.status().subscribe(move |_status: QueryStatus| {
+            // Re-enter exactly once, synchronously, from inside dispatch.
+            if !reentered.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                lq2.update_selection("name = 'reentrant'").expect("re-entrant update_selection must not fail");
+            }
+        })
+    };
+
+    // Drive one transition so the subscriber fires (version 2), whose
+    // callback issues version 3.
+    lq.update_selection("name = 'outer'")?;
+
+    assert!(
+        eventually(|| lq.status().peek().local == (LocalStatus::Active { version: 3 })).await,
+        "the re-entrant update must complete and activate, got {:?}",
+        lq.status().peek()
+    );
+    assert!(reentered.load(std::sync::atomic::Ordering::SeqCst), "the subscriber must have re-entered");
+    Ok(())
+}
+
+/// Before any registration lands, both legs report Pending: Active is
+/// only ever reported by a registration that actually completed, so a
+/// disconnected ephemeral node's query says so instead of claiming
+/// service.
+#[tokio::test]
+async fn unestablished_query_reports_pending_on_both_legs() -> anyhow::Result<()> {
+    let server = durable_sled_setup().await?;
+    let client = ephemeral_sled_setup().await?;
+    {
+        let conn = LocalProcessConnection::new(&server, &client).await?;
+        client.system.wait_system_ready().await;
+        drop(conn);
+    }
+    let ctx = client.context(DEFAULT_CONTEXT)?;
+
+    // The peer is gone: the remote leg cannot establish and the local
+    // activation waits on it, so nothing ever lands and neither leg may
+    // claim service.
+    let lq = ctx.query::<AlbumView>(nocache("true")?)?;
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+    assert_eq!(
+        lq.status().peek(),
+        QueryStatus { local: LocalStatus::Pending, remote: RemoteStatus::Pending },
+        "an unestablished relayed query reports Pending on both legs"
+    );
+    Ok(())
+}

--- a/tests/tests/session_cdata.rs
+++ b/tests/tests/session_cdata.rs
@@ -1,18 +1,70 @@
-//! Live credential sessions, the vocabulary layer: a Context holds a
-//! Session registered in the node's SessionSet, and
-//! `Context::update_cdata` replaces the credential in place for
-//! subsequent operations. Standing queries keep their creation
-//! credential until the liveness PR wires re-permission.
+//! Live credential sessions: a Context's CData can be replaced in place
+//! (`Context::update_cdata`), holders read the current value per
+//! operation, and the relay re-permissions remote subscriptions by
+//! re-sending them under the new credential through the existing
+//! versioned update flow. The node's SessionSet tracks live sessions,
+//! extended through livequeries and culled by RAII.
 
 mod common;
 use common::*;
 
 use ankurah::core::node::ContextData;
+use ankurah::signals::With;
 
 /// A second ContextData type, for the wrong-type rejection path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct OtherCd;
 impl ContextData for OtherCd {}
+
+/// An update whose value compares equal to the current credential is a
+/// complete no-op at the context surface: the subscription keeps its
+/// version, nothing tears down, and later commits still arrive. (The
+/// value-different path — a real re-login re-permissioning in place —
+/// is driven end to end under real credentials in
+/// extensions/jwt-auth/tests/session_refresh_tests.rs.)
+#[tokio::test]
+async fn identical_update_cdata_is_a_noop() -> anyhow::Result<()> {
+    let server = durable_sled_setup().await?;
+    let client = ephemeral_sled_setup().await?;
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let server_ctx = server.context(DEFAULT_CONTEXT)?;
+    let client_ctx = client.context(DEFAULT_CONTEXT)?;
+
+    {
+        let trx = server_ctx.begin();
+        trx.create(&Album { name: "first".into(), year: "1999".into() }).await?;
+        trx.commit().await?;
+    }
+
+    let lq = client_ctx.query_wait::<AlbumView>(nocache("true")?).await?;
+    assert_eq!(lq.resultset().len(), 1, "initial subscription delivers the existing album");
+    assert_eq!(lq.selection().value().1, 1, "initial subscription is version 1");
+
+    // Every DEFAULT_CONTEXT value compares equal, so this update is
+    // gated as a no-op: Eq is operational identity, and nothing
+    // observable changed.
+    client_ctx.update_cdata(DEFAULT_CONTEXT)?;
+    lq.wait_initialized().await;
+    assert_eq!(lq.selection().value().1, 1, "an identical update leaves the subscription version untouched");
+    assert!(lq.error().with(|e| e.is_none()), "the no-op leaves no error behind");
+
+    // The subscription is untouched and still live end to end.
+    {
+        let trx = server_ctx.begin();
+        trx.create(&Album { name: "second".into(), year: "2001".into() }).await?;
+        trx.commit().await?;
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while lq.resultset().len() < 2 {
+        if std::time::Instant::now() > deadline {
+            panic!("commit after re-permission never arrived (resultset len {})", lq.resultset().len());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    Ok(())
+}
 
 /// The SessionSet tracks context liveness, extended through livequeries:
 /// a query keeps its credential session live after the user drops the

--- a/tests/tests/session_cdata.rs
+++ b/tests/tests/session_cdata.rs
@@ -1,0 +1,51 @@
+//! Live credential sessions, the vocabulary layer: a Context holds a
+//! Session registered in the node's SessionSet, and
+//! `Context::update_cdata` replaces the credential in place for
+//! subsequent operations. Standing queries keep their creation
+//! credential until the liveness PR wires re-permission.
+
+mod common;
+use common::*;
+
+use ankurah::core::node::ContextData;
+
+/// A second ContextData type, for the wrong-type rejection path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct OtherCd;
+impl ContextData for OtherCd {}
+
+/// The SessionSet tracks context liveness, extended through livequeries:
+/// a query keeps its credential session live after the user drops the
+/// Context handle, and the last drop culls the slot.
+#[tokio::test]
+async fn sessions_extend_through_livequeries() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    assert!(node.sessions.sessions().is_empty());
+
+    let ctx = node.context(DEFAULT_CONTEXT)?;
+    assert_eq!(node.sessions.sessions().len(), 1, "context construction registers a session");
+
+    let second = node.context(DEFAULT_CONTEXT)?;
+    assert_eq!(node.sessions.sessions().len(), 2, "sessions are per-context, never deduplicated");
+    drop(second);
+    assert_eq!(node.sessions.sessions().len(), 1);
+
+    ctx.register_model::<Album>().await?;
+    let lq = ctx.query_wait::<AlbumView>("true").await?;
+    drop(ctx);
+    assert_eq!(node.sessions.sessions().len(), 1, "a live query extends its session past the context drop");
+    drop(lq);
+    assert!(node.sessions.sessions().is_empty(), "the last holder culls the session");
+    Ok(())
+}
+
+/// `update_cdata` with a different ContextData type than the node's
+/// policy agent uses is rejected across the type-erased boundary.
+#[tokio::test]
+async fn update_cdata_rejects_wrong_type() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    let ctx = node.context(DEFAULT_CONTEXT)?;
+    assert!(ctx.update_cdata(OtherCd).is_err(), "a mismatched ContextData type is refused");
+    assert!(ctx.update_cdata(DEFAULT_CONTEXT).is_ok(), "the node's own type is accepted");
+    Ok(())
+}

--- a/tests/tests/weak_node_livequery.rs
+++ b/tests/tests/weak_node_livequery.rs
@@ -16,7 +16,7 @@ async fn test_weak_node_livequery_does_not_keep_node_alive() -> Result<()> {
     // Create a LiveQuery with a weak node binding
     let collection_id = CollectionId::fixed_name("pet");
     let args: MatchArgs = "true".try_into()?;
-    let weak_lq = EntityLiveQuery::new_weak_node(&node, collection_id, args, DEFAULT_CONTEXT)?;
+    let weak_lq = EntityLiveQuery::new_weak_node(&node, collection_id, args, ankurah::core::session::Session::detached(DEFAULT_CONTEXT))?;
 
     // Get the query_id before dropping the node
     let query_id = weak_lq.query_id();
@@ -36,7 +36,12 @@ async fn test_weak_node_livequery_does_not_keep_node_alive() -> Result<()> {
     let weak_node = node2.weak();
 
     let args2: MatchArgs = "true".try_into()?;
-    let weak_lq2 = EntityLiveQuery::new_weak_node(&node2, CollectionId::fixed_name("pet"), args2, DEFAULT_CONTEXT)?;
+    let weak_lq2 = EntityLiveQuery::new_weak_node(
+        &node2,
+        CollectionId::fixed_name("pet"),
+        args2,
+        ankurah::core::session::Session::detached(DEFAULT_CONTEXT),
+    )?;
 
     // Node should be alive while we hold it
     assert!(weak_node.upgrade().is_some(), "Node should be alive");
@@ -59,7 +64,7 @@ async fn test_entity_livequery_keeps_node_alive() -> Result<()> {
     // Create a regular EntityLiveQuery
     let collection_id = CollectionId::fixed_name("pet");
     let args: MatchArgs = "true".try_into()?;
-    let lq = EntityLiveQuery::new(&node, collection_id, args, DEFAULT_CONTEXT)?;
+    let lq = EntityLiveQuery::new(&node, collection_id, args, ankurah::core::session::Session::detached(DEFAULT_CONTEXT))?;
 
     // Get weak ref to test node liveness
     let weak_node = node.weak();


### PR DESCRIPTION
**Stacked on #434.** The vocabulary and the live-source structure landed in the base PR #434 (sessions threaded everywhere a credential was baked: livequery construction, relay sends, gap fetchers, the union carry, the jwt equality contract), independently mergeable because standing queries there behave exactly as on main. This PR is the reactions layer: re-permission, denial as state, status, the effects queue, attempt identity, and the reactor liveness gates. Its tip tree is byte-identical to the pre-split branch, so the review record below covers the composed result.

A Context's credential becomes live, a query's credentials become plural, and a query's condition becomes observable. One `Session` per Context wraps the current ContextData in a signal; holders read the value at use time instead of freezing clones at construction; `Context::update_cdata` replaces the credential in place, so a token refresh or a re-login no longer means rebuilding the Context and every livequery under it. A query is credentialed by a `Sessions` source: one session (an ordinary context's query) or the node's whole live `SessionSet` (a system query reading under the union of active credentials, the shape the catalog manager's standing queries will use). And every livequery exposes a two-leg reactive `status()` that fails, un-fails, and re-fails as credentials, peers, and the server move, with credential denial reported as a status on set-backed queries and the predicate never altered. Targets main, independent of #425 (which is rebuilt over this after it lands). Two commits: the mechanism, then the proofs.

## What this adds

**`Session<CD>`, `SessionSet<CD>`, and `Sessions<CD>`** (core/src/session.rs). A Session is one live credential: interior-mutable current value plus change reactivity, both via the existing `ankurah_signals::Mut`. Sessions are strictly per-context and never deduplicated: two credentials that compare equal today are independent sessions that can diverge tomorrow, so deduplication belongs at the point of consumption, over current values. The node's SessionSet enumerates live sessions; membership is the `Arc<Session>` strong count itself, culled by RAII, and a live query extends its session past the Context handle's drop. The set is itself a first-class signal implementing the standard vocabulary (`Signal`/`Get`/`Peek`/`Subscribe`) at `Vec<CData>`, firing on registrations, culls, and member updates alike. `Sessions` is the credential source everything holds, one enum for the three places credentials come from: `One(Arc<Session>)` (an ordinary context), `Set(SessionSet)` (the system context, the node's whole live set), or `Held(SessionHolder)` (the server's per-query holder: a private set plus the memberships that constitute it, replaced wholesale on every re-validated subscribe, revoking before registering so an overlapping snapshot can see old, partial-old, empty, or new members but never a union). One `snapshot() -> Vec<CData>` and composite generations close the snapshot-then-listen window for every shape; only `One` can write. `Session::detached` covers infrastructure credentials that must stay out of the node's enumeration. The `ContextData` trait moves here, its natural home, behind a node.rs re-export.

**Read-through instead of frozen clones.** `NodeAndContext` snapshots its credential source once per logical operation (one credential set per commit, per fetch, per get, never mixed mid-operation); the gap fetcher and the relay's per-query `Content` hold the source and read the then-current values at each use, so a reconnect re-registration after a refresh carries the fresh credentials.

**The union rides the wire that was already shaped for it.** The request envelope has always carried `Vec<AuthData>`, and the PolicyAgent's read-side checks (`can_access_collection`, `filter_predicate`, `check_read`) were already generic over N credentials, with commits pinned to exactly one. This PR supplies what was missing: the live client-side source of N (the SessionSet), the server's SubscribeQuery arm (it demanded exactly one credential; it now validates all and evaluates the union), a per-query server-side holder (the `Sessions::Held` arm, session.rs) whose replacement discipline fails closed in the revocation direction, and the one real defect the N-shaped surface hid: jwt's `filter_predicate` took the FIRST authenticated context's claims when scope rules existed. It now ORs the per-context narrowings of the contexts authorized for the collection (an authenticated context without the collection's read privilege contributes no branch, and a set with none is denied), mirroring `enforce_read_scope`'s existing per-credential evaluation. A vec of one reproduces today's behavior exactly, everywhere.

**The system context.** `Node::system_context()` (pub(crate)) builds a Context whose credential source is the node's whole SessionSet: its queries read under the union and re-permission as sessions come, go, and refresh. Write operations, registration, and `update_cdata` refuse through it, because those act as one principal.

**`QueryStatus`: two legs, nothing latches.** Every livequery exposes `status()`, one reactive value. The local leg says what this node's reactor serves: `Pending` (no registration has landed yet), `Denied { reason }`, or `Active { version }`. `Active` is only ever reported by a registration that actually landed (the reactor's pre-notify hook is its sole writer, version-floored), so the local leg cannot claim service that never installed; an activation failure leaves the last truthful state standing with the error latched on `error()`. The remote leg says where the upstream subscription stands: `None` on durable nodes, `Pending`, `Requested`/`Established` per version, `Denied` for a local refusal to sign, `Error` carrying the server's refusals and other non-retryable failures. The relay reports every transition through the existing subscriber callback, each report stamped with a sequence drawn under the relay's lock and floored at the livequery, so out-of-order delivery can never leave the public status stale. No signal fires while a livequery lock is held: status and selection dispatch through an ordered effects queue drained outside the locks (single drainer; a re-entrant enqueue is picked up by the active drainer), and resultset broadcasts ride their write guard past release. A status or resultset subscriber may therefore call `update_selection` from inside its callback instead of deadlocking, which the reentrancy test pins. Completions and failures are accepted by ATTEMPT IDENTITY: every send stamps `Requested(peer, version)` and bumps a monotonic attempt id under the relay's lock, and a report acts only when it matches all three (`(peer, version)` alone is reusable, because a reconnect of the same peer re-sends the same version), so a dead attempt's late echo (superseded, re-routed after its peer disconnected, already resolved, or a prior try of the same version) can neither claim Established, re-point a live subscription, nor knock one back to pending; an entry sitting at pending gets a kick so a lost dispatch cannot strand it. Retryable transport failures report as `Pending` while the retry task re-attempts; a credential change re-kicks a failed leg through the normal versioned update flow, so recovery is observable rather than silent. The previous reporting structurally could not express recovery: the relay's per-query state was invisible outside a test hook, and the livequery's error signal was write-only, seven writers and no clearer (it now clears on successful activation, so `error()` and `status()` agree after a failure-then-recovery).

**Denial is a state, not a failure.** With zero eligible credentials a set-backed query constructs successfully, holds no reactor registration, serves nothing, reports `Denied`, and retains the user's intent untouched. And for EVERY query kind, a credential change that revokes a standing query's access (a re-login to a weaker subject, a logout implemented as update-to-anonymous) flips it to `Denied` and claws the rows back out of the live resultset (locally persisted rows are untouched), rather than freezing it serving the old credential's data. The intent still goes upstream for the server's own verdict, so asymmetric policies where the server grants what the client denies keep working. Revocation is enforced on BOTH sides: when a re-validation fails, the server removes the standing registration too (floored on the request's version, so a delayed older request that now fails validation cannot tear down the live newer registration), and nothing keeps streaming to a denied subscription under the credential it replaced. A tombstone against an older request re-registering after removal is follow-up work, tracked. Revocation also wins against in-flight work: the authoritative selection and denial state live under one lock that activation brackets (snapshot before, re-validate after the reactor call), so an activation that raced the denial re-asserts the claw-back instead of leaving a zombie registration; asynchronous gap fills re-check under the reactor's state lock that their query still exists at the version they fetched for before applying, so a fill that started under the old credential dies instead of repopulating a clawed-back resultset. The next credential change re-derives: local activation re-enters through the first-activation path at the CURRENT version (so waiters complete), the relay re-attempts, and both legs heal. Two loudness rules survive by design: single-credential queries fail construction loud when they never had access, and an explicit `update_selection` under a denying credential errors loud, because in both cases the caller is present to hear it.

**Re-permission re-derives, never re-sends.** The livequery retains the user's PRE-FILTER intent, and one refilter closure is the single derivation authority: policy checks and filtering run under the credentials current at derivation time, for creation, selection updates, and every re-permission alike. A credential change can therefore never re-send a filter baked under old credentials (which went permanently dark under client scope rules, the deployed policy-sync shape). The change listener lives on the livequery itself, so a DURABLE node's local queries re-filter their reactor registration, and relayed queries additionally re-send upstream through the existing versioned update flow, zero new protocol. The server's subscribe upsert re-validates whatever arrives and re-narrows the selection under the new claims.

**Version integrity.** Read-refilter-mint-store is one atomic step under the livequery's update lock, and the server's `update_query`, the relay's stored content, and the relay's status transitions all enforce version floors, so racing updates cannot regress a standing query to an older credential's selection.

**Change-gated delivery on operational identity.** `ContextData`'s `Eq` means operational identity: values compare equal only when substituting one for the other changes nothing observable, token included. (The jwt impl previously compared only the subject, an accident of serde_json hashability; equality and hash are now full-value, with the custom-claims map hashed in sorted key order.) `Session::update` gates on it, so subscribers hear exactly the updates that changed something: a token refresh carries a new token and re-permissions; an identical update is a complete no-op. Unit tests pin both directions.

**Deleted: `predicate_context`.** A node-level query-to-credential map written on subscribe, removed on unsubscribe, and read by nothing.

## Verification

Full battery 507 passed / 0 failed across 95 binaries on the main base, plus core's own unit suite (221). What the suites prove:

- **tests/tests/session_cdata.rs** drives the context surface over a real two-node pair: an equal-comparing `update_cdata` is a complete no-op that leaves the standing subscription untouched (the value-different path runs end to end under real credentials in the jwt suites); sessions extend through livequeries and cull by RAII; a mismatched ContextData type is refused.
- **extensions/jwt-auth/tests/session_refresh_tests.rs** proves visibility follows the credential, with exact-id assertions: re-login on a relayed subscription re-scopes it server-side; the same holds with scope rules mirrored onto the client; a durable node's local livequery re-filters with no relay involved; one update re-permissions every standing query under the context, each through its own version authority. `logout_claws_back_the_resultset` pins revocation end to end: logout empties the live resultset and reports `Denied`; a commit the old credential could see does not stream into the denied subscription (the server tore down its side too); re-login heals with bounded initialization and recovers both rows, the one clawed back and the one committed while denied.
- **extensions/jwt-auth/tests/system_query_tests.rs** drives the full set-backed arc against a scoped server, with exact-id assertions: denied at zero sessions (local `Denied`, the server's refusal on the remote leg), healed to alice's slice by her login (a bounded `wait_initialized` pins that healing initializes at the current version), widened to the union of alice's and bob's slices by his, narrowed back by her logout, and returned to `Denied` by his. That arc is the catalog manager's standing-query lifecycle.
- **tests/tests/query_status.rs** pins the status machinery: the remote leg establishes per version and follows selection updates; durable-local queries report no remote leg; both legs report `Pending` on a disconnected ephemeral node; and re-entrancy holds from both directions (a status subscriber AND a resultset subscriber calling `update_selection` from inside their callbacks; each deadlocked before its respective dispatch rework).
- **Unit suites**: the jwt filter union (including the exclusion of authenticated-but-unauthorized contexts); full-value credential equality with an insertion-order-independent hash (context_tests); session.rs liveness culling, change-gated notification (a refresh fires, an identical update is a no-op), composite generations, and immediate revocation (a replaced member never appears beside its successor, even while a reader's Arc keeps the replaced Session alive).

## Not in this PR

A wasm-reachable `update_cdata` surface (the generic method cannot cross wasm_bindgen; browser token refresh needs a small typed wrapper in the bindings layer). A limit-gap-across-refresh test and a reconnect-after-refresh test (named coverage gaps, recorded). The catalog PR (#425, rebuilt over this) introduces the CatalogManager as a pure consumer of the system context; the LiveQuery/Context/peer_subscription layers are final for it. Durable-side expiry enforcement against standing subscriptions is deliberately out; this PR builds its prerequisites (per-query server-side credential holders and observable status).

## Review record

Fourteen independent review rounds ran against this branch during its build. Every confirmed finding is fixed in place; the load-bearing ones are pinned by the tests above.

1. Two agent review rounds (code quality, then code placement) during the initial build, plus CodeRabbit throughout; all nine CodeRabbit threads carry disposition replies.
2. A first Codex review produced the per-credential authorization gate on the filter union, the monotonic initialization floor, the version floor on server credential refreshes, and per-entity watcher cleanup on query removal.
3. An Opus review of the accumulated delta caught a self-deadlock the dispatch rework had introduced on the denial path (reactor deregistration under a held resultset guard; two tests hung until fixed) and a stale-activation hazard in a defensive re-registration. Both fixed: deregistration now runs before any guard exists, and a registration conflict falls back to the version-floored update path instead of ever removing a possibly-newer live registration. The same round hardened stale relay reports against clobbering an established subscription, re-armed gap filling when a fill is dropped as superseded, gated the error-latch clear on version currency, and made credential replacement's revocation explicit and immediate.
4. A second Codex review drove the final round: the server-side half of the claw-back; reactor broadcasts moved outside the subscription state lock; the initialization wait registers interest before checking its condition (a wake in the gap stored no permit and could strand a waiter); an unwind-safe effects drain; establishment guards on the third relay completion site, extended to same-version duplicates from since-disconnected peers; `Active` dispatching before the reactor's changeset notification; and the error latch versioned through the same ordered dispatch as the status.
5. An Opus review of that remediation delta then caught its over-corrections: the new relay guards made Established terminal while a dead peer's late completion could still create it (a silent permanent stall), and the server claw-back lacked a version floor (a delayed older denial could tear down its live successor). The repairs replaced the guard stack with attempt-keyed acceptance (the structural half of the request-identity suggestion, built on the Requested state every send already stamps), floored the server removal, swept three more broadcast-under-lock sites (a reactor-notification subscriber revoking the credential from inside its callback deadlocked; now pinned), moved error-latch enqueueing under the currency lock, and replaced two tests that passed without the fixes they claimed to pin: the logout proof now asserts the denied-window commit is absent from client LOCAL storage, the only observation that distinguishes the server's teardown from the client's own claw-back. The same round folded the server-side holder into the `Sessions` enum as its `Held` arm (review feedback on an aliasing field pair). The tombstone half of request identity remains follow-up work, #429.
6. A paired round then ran an Opus review and a Codex review over that repair delta at once, and they converged independently on the same two blockers. First, attempt identity was still incomplete: `(peer, version)` is reusable, because a reconnect of the same peer re-sends the same version, so a dead attempt's echo could still resolve its successor's state; every send now also bumps a monotonic attempt id under the relay's lock, and completions and failures must match it exactly. Second, the deferred membership writes that `evaluate_changes` broadcasts after releasing the state lock carried no liveness check, so a subscriber revoking the credential from inside an earlier write's broadcast left a later same-batch write repopulating the denied query's clawed-back resultset; each write now carries its query id and decision-time version and re-checks, under a re-taken state lock, that the query still exists at that version before applying, the same rule the gap fills already follow. The pin for that gate was verified to fail with the gate removed. The same round released the global subscriptions mutex before per-subscription system resets (a subscriber revoking synchronously re-enters query removal, which needs that mutex), widened the server claw-back floor to cover the window between a newer subscribe's credential seed and its selection update, floored the relay's error latch on the same report sequence as its paired status, and fixed the logout pin's wrong collection id, whose absence assertion had been vacuous against an on-demand-created empty collection; a positive post-heal arm now self-validates the name. The watcher-lifecycle race both reviewers also flagged predates this branch and is tracked as #430.
7. The round-10 delta got the same paired treatment, and CI itself contributed a finding: the corrected logout assertion, no longer vacuous, exposed its own test's synchronization, which waited on the client's instant local denial while the server's re-validation was still in flight, so on a slow runner the commit streamed through the not-yet-removed registration; the test now waits for the server's refusal to land on the remote leg, which the server sends only after its claw-back completes. The Opus review found that the round-10 deferred-write gate collapsed removal and supersede into one discard verdict, and a superseded ADD has no other recovery path (the superseding update only re-adds entities from a fetch that predates the batch), so a row belonging to the current selection went silently missing, precisely in the token-refresh case where the version bumps and the selection does not; the gate is now three-way like the gap fills', re-deciding superseded writes against the current selection under the re-taken lock, with a reactor unit test pinning the interleave (verified to fail with the re-decision removed). The Codex review found the attempt nonce guarded the relay's state transition but not its side effects (both completion arms activated the livequery before the attempt check, so a dead attempt's late completion could activate the local leg and clear an error a live attempt had latched; both arms now claim the completion first, and only the claiming attempt activates), that (query id, version) is not registration-incarnation identity (all three liveness gates now also require the registration to hold the same resultset instance the decision captured), and that a revoked registration's batch still reached changeset subscribers as membership adds (the livequery now drops deliveries after its own denial, pinned by a changeset observer added to the batch test and verified discriminating). Dropped writes cancel their watcher changes with them. The in-flight-request teardown facet and the local-denial persistence window are recorded on #429.
8. Rounds 12 and 13 attempted to also fix the CONCURRENT-ACTIVATION substrate the reviews had begun mapping (a narrow denial-heal window where a stale activation can resurrect old-credential content until its successor lands, and the decision-versus-application divergences around deferred writes, watcher changes, and item claims). Both attempts were themselves found defective by the next paired review: the round-12 claw-back arm was proved, with a deterministic fetch-delaying probe, to take down the successor registration it was meant to spare, and the round-13 repair closed that while opening watcher and lifecycle corners of its own. Rather than a fourth patch round, both commits were REVERTED and the branch retreated to its round-11 waterline, where the paired verdict had been clean: the substrate work is scoped out of this PR deliberately, and everything the four review rounds established about it (the enumerated windows, the failed approaches and exactly how each failed, the lock-order constraint, and the application-derived-truth design both review tracks converged on) is consolidated in #431 for a dedicated follow-up. Two durable artifacts of those rounds stay in the tree: the deterministic delay-engine test seam and the racing-activations convergence pin (tests/tests/activation_races.rs), which passes at the waterline and guards against any future superseded-path cleanup taking down its successor.
9. The maintainer's guide-driven review (2026-08-02) produced a language ruling and a semantics redesign. The ruling: doc comments must lead with what a thing exists for, and the Session generation docs narrated their reader's protocol instead; they were rewritten purpose-first. The redesign: the maintainer challenged notify-on-every-update, and archaeology showed JwtContext's subject-only equality was an accident of hashability (serde_json::Value implements no Hash, and the workaround narrowed Eq along with Hash when only Hash needed it). Equality and hash are now full-value, ContextData documents Eq as operational identity, and Session::update gates delivery on it: a token refresh compares unequal and re-permissions, while an identical update is a complete no-op. The equality pins flipped to match (context_tests, the session unit suite, the session_cdata no-op pin); the generation counter survives on a new justification (a change-and-revert between a livequery's snapshot and its listener installation leaves the value equal while an in-window send may have shipped the interloper).
10. The maintainer's per-layer minimalism audit (2026-08-03), after the branch split into a stack: each layer justifies its own contents. The generation counter, which had landed in the base PR with no consumer there, was deleted from both layers; the livequery constructor now closes its derive-then-subscribe window by comparing session snapshots under operational-identity equality, with the accepted change-and-revert corner documented at the site. The set-backed system context constructors, consumer-less even in the composed tree, were deferred to the catalog PR that first consumes them. Sessions::subscribe_changes moved into this PR beside its listener, and policy call sites inline their snapshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live queries now support dynamic credential updates without recreating subscriptions.
  * Added live query status reporting for local and remote connection states.
  * Multi-session access now combines authorized visibility across active credentials.
  * Queries automatically recover when access is restored and show denied states when authorization is revoked.

* **Bug Fixes**
  * Improved protection against stale updates, activation races, duplicate notifications, and re-entrant subscription issues.
  * Prevented unauthorized changes from reaching client result sets.
  * Improved remote subscription retry and disconnect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
