### PR TITLE
sessions: the credential vocabulary, before liveness

### DIFF
--- a/ankurah/src/lib.rs
+++ b/ankurah/src/lib.rs
@@ -155,6 +155,7 @@ pub use ankurah_core::{
     property::{self, Property, Ref},
     query_value::QueryValue,
     resultset::ResultSet,
+    session::{Session, SessionSet},
     storage, transaction, value,
     value::{Value, ValueType},
 };

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,4 +1,4 @@
-use crate::retrieval::SuspenseEvents;
+use crate::retrieval::{CachedEventGetter, SuspenseEvents};
 use crate::{
     changes::EntityChange,
     entity::Entity,
@@ -17,9 +17,10 @@ use tracing::debug;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-/// Context is used to provide a local interface to fetch and subscribe to entities
-/// with a specific ContextData. Generally this means your auth token for a specific user,
-/// but ContextData is abstracted so you can use what you want.
+/// A local scope for fetching, subscribing, and transacting, backed by a
+/// live credential source: operations read the source's current state
+/// (one snapshot per operation), so a session refresh reaches every
+/// later operation without rebuilding the Context.
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct Context(Arc<dyn TContext + Send + Sync + 'static>);
@@ -33,7 +34,9 @@ where
     PA: PolicyAgent + Send + Sync + 'static,
 {
     pub node: Node<SE, PA>,
-    pub cdata: PA::ContextData,
+    /// The credential source for this context. Typically this is only one session
+    /// except for system queries, which need a node's aggregate permissions
+    pub sessions: crate::session::SessionSet<PA::ContextData>,
 }
 
 #[async_trait]
@@ -74,7 +77,8 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         &self,
         schema: &'static crate::schema::ModelStructDescriptor,
     ) -> Result<proto::ModelId, crate::schema::registration::RegistrationError> {
-        self.node.catalog.ensure_schema_for_use(&self.cdata, schema).await
+        // Registration acts as one principal, like every write path.
+        self.node.catalog.ensure_schema_for_use(&self.sessions.write_credential()?, schema).await
     }
 
     fn node_id(&self) -> proto::EntityId { self.node.id }
@@ -82,7 +86,9 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         let primary_entity = self.node.entities.create(collection);
         primary_entity.snapshot(trx_alive)
     }
-    fn check_write(&self, entity: &Entity) -> Result<(), AccessDenied> { self.node.policy_agent.check_write(&self.cdata, entity, None) }
+    fn check_write(&self, entity: &Entity) -> Result<(), AccessDenied> {
+        self.node.policy_agent.check_write(&self.sessions.write_credential()?, entity, None)
+    }
     async fn get_entity(&self, id: proto::EntityId, collection: &proto::CollectionId, cached: bool) -> Result<Entity, RetrievalError> {
         self.get_entity(collection, id, cached).await
     }
@@ -98,6 +104,10 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         if trx.alive.compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire).is_err() {
             return Err(MutationError::General("Transaction already committed or rolled back".into()));
         }
+
+        // One credential snapshot for the whole commit: a session update
+        // mid-commit must not mix credentials across its phases.
+        let cdata = self.sessions.write_credential()?;
 
         // Generate events from the transaction entities
         let trx_id = trx.id.clone();
@@ -152,7 +162,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
             event_getter.stage_event(event.clone());
             forked.apply_event(&event_getter, &event).await?;
 
-            let attestation = self.node.policy_agent.check_event(&self.node, &self.cdata, &entity_before, &forked, &event)?;
+            let attestation = self.node.policy_agent.check_event(&self.node, &cdata, &entity_before, &forked, &event)?;
             let attested = Attested::opt(event.clone(), attestation);
 
             attested_events.push(attested.clone());
@@ -171,7 +181,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
             entity.commit_head(Clock::new([attested_event.payload.id()]));
         }
         // Relay to peers and wait for confirmation
-        self.node.relay_to_required_peers(&self.cdata, trx_id, &attested_events).await?;
+        self.node.relay_to_required_peers(&cdata, trx_id, &attested_events).await?;
 
         // All peers confirmed, persist state to storage
         let mut changes: Vec<EntityChange> = Vec::new();
@@ -206,7 +216,7 @@ impl<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 
         Ok(attested_events.into_iter().map(|a| a.payload).collect())
     }
     fn query(&self, collection_id: proto::CollectionId, args: MatchArgs) -> Result<EntityLiveQuery, RetrievalError> {
-        EntityLiveQuery::new(&self.node, collection_id, args, self.cdata.clone())
+        EntityLiveQuery::new(&self.node, collection_id, args, self.sessions.clone())
     }
     async fn collection(&self, id: &proto::CollectionId) -> Result<StorageCollectionWrapper, RetrievalError> {
         self.node.system.collection(id).await
@@ -244,11 +254,17 @@ impl Context {
 }
 
 impl Context {
+    /// Type-erased query and transaction initiation context
     pub fn new<SE: StorageEngine + Send + Sync + 'static, PA: PolicyAgent + Send + Sync + 'static>(
         node: Node<SE, PA>,
-        data: PA::ContextData,
+        sessions: impl Into<crate::session::SessionSet<PA::ContextData>>,
     ) -> Self {
-        Self(Arc::new(NodeAndContext { node, cdata: data }))
+        let sessions = sessions.into();
+        // Attach the source to the node's registry: a live edge keeping
+        // it the continuous superset of every session backing a context
+        // (a no-op when the source IS the registry).
+        node.sessions.attach(&sessions);
+        Self(Arc::new(NodeAndContext { node, sessions }))
     }
 
     pub fn node_id(&self) -> proto::EntityId { self.0.node_id() }
@@ -347,10 +363,11 @@ where
         cached: bool,
     ) -> Result<Entity, RetrievalError> {
         debug!("Node({}).get_entity {:?}-{:?}", self.node.id, id, collection_id);
+        let cdata = self.sessions.current();
 
         if !self.node.durable {
             // Fetch from peers and commit first response
-            match self.node.get_from_peer(collection_id, vec![id], &self.cdata).await {
+            match self.node.get_from_peer(collection_id, vec![id], &cdata).await {
                 Ok(_) => (),
                 Err(RetrievalError::NoDurablePeers) if cached => (),
                 Err(e) => {
@@ -363,7 +380,7 @@ where
             debug!("Node({}).get_entity found local entity - returning", self.node.id);
             let state = local.to_state()?;
             let entity_id = local.id();
-            self.node.policy_agent.check_read(&self.cdata, &entity_id, collection_id, &state)?;
+            self.node.policy_agent.check_read(&cdata, &entity_id, collection_id, &state)?;
             return Ok(local);
         }
         debug!("{}.get_entity fetching from storage", self.node);
@@ -371,14 +388,9 @@ where
         let collection = self.node.collections.get(collection_id).await?;
         match collection.get_state(id).await {
             Ok(entity_state) => {
-                self.node.policy_agent.check_read(
-                    &self.cdata,
-                    &entity_state.payload.entity_id,
-                    collection_id,
-                    &entity_state.payload.state,
-                )?;
+                self.node.policy_agent.check_read(&cdata, &entity_state.payload.entity_id, collection_id, &entity_state.payload.state)?;
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection.clone());
-                let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection, &self.node, &self.cdata);
+                let event_getter = CachedEventGetter::new(collection_id.clone(), collection, &self.node, &cdata);
                 let (_changed, entity) = self
                     .node
                     .entities
@@ -391,18 +403,24 @@ where
     }
     /// Fetch a list of entities based on a selection
     pub async fn fetch_entities(&self, collection_id: &CollectionId, mut args: MatchArgs) -> Result<Vec<Entity>, RetrievalError> {
-        self.node.policy_agent.can_access_collection(&self.cdata, collection_id)?;
+        // One credential snapshot for the whole operation: the composed
+        // checks (collection gate, predicate narrowing) must come from
+        // one policy world, or a mid-operation refresh yields a
+        // composite no single credential authorized.
+        let cdata = self.sessions.current();
+        self.node.policy_agent.can_access_collection(&cdata, collection_id)?;
         // Fetch raw states from storage
 
-        args.selection.predicate = self.node.policy_agent.filter_predicate(&self.cdata, collection_id, args.selection.predicate)?;
+        args.selection.predicate = self.node.policy_agent.filter_predicate(&cdata, collection_id, args.selection.predicate)?;
 
         // Resolve types in the AST (converts literals for JSON path comparisons)
         args.selection = self.node.type_resolver.resolve_selection_types(args.selection);
 
         // TODO implement cached: true
         if !self.node.durable {
-            // Fetch from peers and commit first response
-            Ok(self.fetch_from_peer(collection_id, args.selection).await?)
+            // Fetch from peers and commit first response, under this
+            // operation's one credential snapshot.
+            Ok(self.fetch_from_peer(collection_id, args.selection, &cdata).await?)
         } else {
             let storage_collection = self.node.collections.get(collection_id).await?;
             let states = storage_collection.fetch_states(&args.selection).await?;
@@ -410,7 +428,7 @@ where
             // Convert states to entities
             let mut entities = Vec::new();
             let state_getter = crate::retrieval::LocalStateGetter::new(storage_collection.clone());
-            let event_getter = crate::retrieval::CachedEventGetter::new(collection_id.clone(), storage_collection, &self.node, &self.cdata);
+            let event_getter = CachedEventGetter::new(collection_id.clone(), storage_collection, &self.node, &cdata);
             for state in states {
                 let (_, entity) = self
                     .node
@@ -428,6 +446,7 @@ where
         &self,
         collection_id: &proto::CollectionId,
         selection: ankql::ast::Selection,
+        cdata: &Vec<PA::ContextData>,
     ) -> Result<Vec<crate::entity::Entity>, RetrievalError> {
         let peer_id = self.node.get_durable_peer_random().ok_or(RetrievalError::NoDurablePeers)?;
 
@@ -443,13 +462,12 @@ where
         let selection_clone = selection.clone();
         match self
             .node
-            .request(peer_id, &self.cdata, proto::NodeRequestBody::Fetch { collection: collection_id.clone(), selection, known_matches })
+            .request(peer_id, cdata, proto::NodeRequestBody::Fetch { collection: collection_id.clone(), selection, known_matches })
             .await?
         {
             proto::NodeResponseBody::Fetch(deltas) => {
                 let collection = self.node.collections.get(collection_id).await?;
-                let event_getter =
-                    crate::retrieval::CachedEventGetter::new(collection_id.clone(), collection.clone(), &self.node, &self.cdata);
+                let event_getter = CachedEventGetter::new(collection_id.clone(), collection.clone(), &self.node, cdata);
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection);
 
                 // 3. Apply deltas to local storage using NodeApplier

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod reactor;
 pub mod resultset;
 pub mod retrieval;
 pub mod selection;
+pub mod session;
 pub mod storage;
 pub mod system;
 pub mod task;

--- a/core/src/livequery.rs
+++ b/core/src/livequery.rs
@@ -25,6 +25,7 @@ use crate::{
         ReactorSubscription, ReactorUpdate,
     },
     resultset::{EntityResultSet, ResultSet},
+    session::SessionSet,
     storage::StorageEngine,
     Node,
 };
@@ -204,12 +205,15 @@ fn create_inner<SE, PA>(
     node_ref: Box<dyn NodeRef>,
     collection_id: CollectionId,
     mut args: MatchArgs,
-    cdata: PA::ContextData,
+    sessions: SessionSet<PA::ContextData>,
 ) -> Result<(Arc<Inner>, proto::QueryId), RetrievalError>
 where
     SE: StorageEngine + Send + Sync + 'static,
     PA: PolicyAgent + Send + Sync + 'static,
 {
+    // One credential snapshot for the whole derivation; re-derivation
+    // on change arrives with https://github.com/ankurah/ankurah/pull/426.
+    let cdata = sessions.current();
     node.policy_agent.can_access_collection(&cdata, &collection_id)?;
     args.selection.predicate = node.policy_agent.filter_predicate(&cdata, &collection_id, args.selection.predicate)?;
 
@@ -220,7 +224,7 @@ where
 
     let resultset = EntityResultSet::empty();
     let query_id = proto::QueryId::new();
-    let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(&node, cdata.clone()));
+    let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(&node, sessions));
 
     let inner = Arc::new(Inner {
         query_id,
@@ -263,14 +267,14 @@ impl EntityLiveQuery {
         node: &Node<SE, PA>,
         collection_id: CollectionId,
         args: MatchArgs,
-        cdata: PA::ContextData,
+        sessions: impl Into<SessionSet<PA::ContextData>>,
     ) -> Result<Self, RetrievalError>
     where
         SE: StorageEngine + Send + Sync + 'static,
         PA: PolicyAgent + Send + Sync + 'static,
     {
         let node_ref: Box<dyn NodeRef> = Box::new(StrongNodeRef(Arc::clone(&node.0)));
-        Self::new_with_node_ref(node, node_ref, collection_id, args, cdata)
+        Self::new_with_node_ref(node, node_ref, collection_id, args, sessions.into())
     }
 
     /// Create a LiveQuery that does NOT keep the node alive.
@@ -283,14 +287,14 @@ impl EntityLiveQuery {
         node: &Node<SE, PA>,
         collection_id: CollectionId,
         args: MatchArgs,
-        cdata: PA::ContextData,
+        sessions: impl Into<SessionSet<PA::ContextData>>,
     ) -> Result<Self, RetrievalError>
     where
         SE: StorageEngine + Send + Sync + 'static,
         PA: PolicyAgent + Send + Sync + 'static,
     {
         let node_ref: Box<dyn NodeRef> = Box::new(WeakNodeRefImpl(Arc::downgrade(&node.0)));
-        Self::new_with_node_ref(node, node_ref, collection_id, args, cdata)
+        Self::new_with_node_ref(node, node_ref, collection_id, args, sessions.into())
     }
 
     fn new_with_node_ref<SE, PA>(
@@ -298,21 +302,21 @@ impl EntityLiveQuery {
         node_ref: Box<dyn NodeRef>,
         collection_id: CollectionId,
         args: MatchArgs,
-        cdata: PA::ContextData,
+        sessions: SessionSet<PA::ContextData>,
     ) -> Result<Self, RetrievalError>
     where
         SE: StorageEngine + Send + Sync + 'static,
         PA: PolicyAgent + Send + Sync + 'static,
     {
         let has_relay = node.subscription_relay.is_some();
-        let (inner, query_id) = create_inner(node, node_ref, collection_id.clone(), args, cdata.clone())?;
+        let (inner, query_id) = create_inner(node, node_ref, collection_id.clone(), args, sessions.clone())?;
 
         let me = Self(inner.clone());
 
         // Ephemeral node: register with relay for remote subscription
         // Remote will call activate() after applying deltas via subscription_established
         if has_relay {
-            node.subscribe_remote_query(query_id, collection_id, inner.selection.value().0, cdata, 1, me.weak());
+            node.subscribe_remote_query(query_id, collection_id, inner.selection.value().0, sessions, 1, me.weak());
         }
 
         Ok(me)

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -1,5 +1,5 @@
-use crate::schema::catalog::CatalogManager;
 use crate::selection::filter::Filterable;
+use crate::{schema::catalog::CatalogManager, session::SessionSet};
 use ankurah_proto::{self as proto, Attested, CollectionId, EntityState};
 use anyhow::anyhow;
 
@@ -7,7 +7,6 @@ use rand::prelude::*;
 use rand::rngs::SmallRng;
 use std::{
     fmt,
-    hash::Hash,
     ops::Deref,
     sync::{Arc, Mutex, Weak},
 };
@@ -36,15 +35,15 @@ use tracing::instrument;
 
 use tracing::{debug, error, warn};
 
-pub struct PeerState {
+pub struct PeerState<CD: ContextData> {
     sender: Box<dyn PeerSender>,
     _durable: bool,
-    subscription_handler: SubscriptionHandler,
+    subscription_handler: SubscriptionHandler<CD>,
     pending_requests: SafeMap<proto::RequestId, oneshot::Sender<Result<proto::NodeResponseBody, RequestError>>>,
     pending_updates: SafeMap<proto::UpdateId, oneshot::Sender<Result<proto::NodeResponseBody, RequestError>>>,
 }
 
-impl PeerState {
+impl<CD: ContextData> PeerState<CD> {
     pub fn send_message(&self, message: proto::NodeMessage) -> Result<(), SendError> { self.sender.send_message(message) }
 }
 
@@ -119,9 +118,7 @@ where PA: PolicyAgent
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
-/// Represents the user session - or whatever other context the PolicyAgent
-/// Needs to perform it's evaluation.
-pub trait ContextData: Send + Sync + Clone + Hash + Eq + 'static {}
+pub use crate::session::ContextData;
 
 pub struct NodeInner<SE, PA>
 where PA: PolicyAgent
@@ -131,7 +128,7 @@ where PA: PolicyAgent
     pub collections: CollectionSet<SE>,
 
     pub(crate) entities: WeakEntitySet,
-    peer_connections: SafeMap<proto::EntityId, Arc<PeerState>>,
+    peer_connections: SafeMap<proto::EntityId, Arc<PeerState<PA::ContextData>>>,
     durable_peers: SafeSet<proto::EntityId>,
 
     /// Per-node source of randomness for peer selection. Seeded from entropy in production;
@@ -140,7 +137,11 @@ where PA: PolicyAgent
     /// RNG state and Node is shared across tasks; the lock is only ever held for a single draw.
     rng: Mutex<SmallRng>,
 
-    pub(crate) predicate_context: SafeMap<proto::QueryId, PA::ContextData>,
+    /// The continuous superset of every session backing a context on
+    /// this node: each context attaches its credential source here at
+    /// construction, so any state the node acts under is enumerable
+    /// from one place.
+    pub sessions: SessionSet<PA::ContextData>,
 
     /// The reactor for handling subscriptions
     pub(crate) reactor: Reactor,
@@ -202,7 +203,7 @@ where
             policy_agent,
             system: system_manager,
             catalog: catalog.clone(),
-            predicate_context: SafeMap::new(),
+            sessions: SessionSet::new(),
             subscription_relay,
             type_resolver: crate::TypeResolver::new(),
         }));
@@ -535,9 +536,14 @@ where
             }
             proto::NodeRequestBody::SubscribeQuery { query_id, collection, selection, version, known_matches } => {
                 let peer_state = self.peer_connections.get(&request.from).ok_or_else(|| anyhow!("Peer {} not connected", request.from))?;
-                // only one cdata is permitted for SubscribePredicate
-                use itertools::Itertools;
-                let cdata = cdata.iterable().exactly_one().map_err(|_| anyhow!("Only one cdata is permitted for SubscribePredicate"))?;
+                // Reads may act under many credentials (the union), but
+                // the per-query session substrate lands with its first
+                // plural consumer (the set-backed context) — until then a
+                // subscribe carries exactly one. The empty and union
+                // verdicts stay fenced: https://github.com/ankurah/ankurah/issues/432
+                let cdata = cdata.iterable().exactly_one().map_err(|_| {
+                    anyhow!("SubscribeQuery currently requires exactly one cdata (plural subscriptions arrive with the set-backed context)")
+                })?;
                 peer_state.subscription_handler.subscribe_query(self, query_id, collection, selection, cdata, version, known_matches).await
             }
         }
@@ -838,23 +844,28 @@ where
     /// persisted state.
     pub fn get_resident_entity(&self, id: proto::EntityId) -> Option<crate::entity::Entity> { self.entities.get(&id) }
 
-    pub fn context(&self, data: PA::ContextData) -> Result<Context, anyhow::Error> {
+    /// Build a context over its credential source: bare ContextData, an
+    /// existing session handle, or a whole [`SessionSet`] —
+    /// attached to the node's registry at construction.
+    ///
+    /// [`SessionSet`]: crate::session::SessionSet
+    pub fn context(&self, sessions: impl Into<SessionSet<PA::ContextData>>) -> Result<Context, anyhow::Error> {
         if !self.system.is_system_ready() {
             return Err(anyhow!("System is not ready"));
         }
-        Ok(Context::new(Node::clone(self), data))
+        Ok(Context::new(Node::clone(self), sessions))
     }
 
-    pub async fn context_async(&self, data: PA::ContextData) -> Context {
+    pub async fn context_async(&self, sessions: impl Into<SessionSet<PA::ContextData>>) -> Context {
         self.system.wait_system_ready().await;
-        Context::new(Node::clone(self), data)
+        Context::new(Node::clone(self), sessions)
     }
 
     pub(crate) async fn get_from_peer(
         &self,
         collection_id: &CollectionId,
         ids: Vec<proto::EntityId>,
-        cdata: &PA::ContextData,
+        cdata: &Vec<PA::ContextData>,
     ) -> Result<(), RetrievalError> {
         let peer_id = self.get_durable_peer_random().ok_or(RetrievalError::NoDurablePeers)?;
 
@@ -965,15 +976,14 @@ where
         query_id: proto::QueryId,
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
-        cdata: PA::ContextData,
+        sessions: SessionSet<PA::ContextData>,
         version: u32,
         livequery: crate::livequery::WeakEntityLiveQuery,
     ) {
         if let Some(ref relay) = self.subscription_relay {
             // Resolve types in the AST (converts literals for JSON path comparisons)
             let selection = self.type_resolver.resolve_selection_types(selection);
-            self.predicate_context.insert(query_id, cdata.clone());
-            relay.subscribe_query(query_id, collection_id, selection, cdata, version, livequery);
+            relay.subscribe_query(query_id, collection_id, selection, sessions, version, livequery);
         }
     }
 
@@ -1017,9 +1027,6 @@ where
     PA: PolicyAgent + Send + Sync + 'static,
 {
     fn unsubscribe_remote_predicate(&self, query_id: proto::QueryId) {
-        // Clean up subscription context
-        self.predicate_context.remove(&query_id);
-
         // Notify subscription relay for remote cleanup
         if let Some(ref relay) = self.subscription_relay {
             relay.unsubscribe_predicate(query_id);

--- a/core/src/peer_subscription/client_relay.rs
+++ b/core/src/peer_subscription/client_relay.rs
@@ -8,6 +8,7 @@ use tracing::{debug, warn};
 
 use crate::error::{RequestError, RetrievalError};
 use crate::node::ContextData;
+use crate::session::SessionSet;
 use crate::util::safeset::SafeSet;
 
 /// Trait for query initialization that can be driven by SubscriptionRelay
@@ -38,7 +39,10 @@ pub struct Content<CD: ContextData> {
     pub query_id: proto::QueryId,
     pub collection_id: CollectionId,
     pub selection: ankql::ast::Selection,
-    pub context_data: CD,
+    /// The live credential source, read at each attempt's start, so a
+    /// reconnect re-registration after a refresh carries the fresh
+    /// values. A set-backed query sends every live credential.
+    pub sessions: SessionSet<CD>,
     pub version: u32,
 }
 
@@ -59,33 +63,11 @@ struct SubscriptionRelayInner<CD: ContextData, Q: RemoteQuerySubscriber> {
     _shutdown_tx: tokio::sync::mpsc::Sender<()>,
 }
 
-/// Manages predicate registration on remote peer reactor subscriptions.
-///
-/// The SubscriptionRelay provides a resilient, event-driven approach to managing which predicates
-/// are registered with remote durable peers. It automatically handles:
-/// - Registering predicates on peer reactor subscriptions when peers connect
-/// - Re-registering predicates when peers disconnect and reconnect
-/// - Retrying failed predicate registration attempts
-/// - Clean teardown when predicates are removed
-/// - Storing ContextData for each predicate to enable proper authorization
-///
-/// This design separates predicate management concerns from the main Node implementation,
-/// making it easier to test and reason about predicate lifecycle management.
-///
-/// # Public API (for Node integration)
-///
-/// - `subscribe_predicate()` - Call when local subscriptions are created (parallel to reactor.subscribe)
-/// - `unsubscribe_predicate()` - Call when local subscriptions are removed (parallel to reactor.unsubscribe)
-/// - `notify_peer_connected()` - Call when durable peers connect (triggers automatic predicate registration)
-/// - `notify_peer_disconnected()` - Call when durable peers disconnect (orphans predicate registrations)
-/// - `get_status()` - Query current state of a predicate registration
-///
-/// # Internal/Testing API
-///
-/// - `setup_remote_subscriptions()` - Internal method for triggering predicate registration with specific peers
-///   (called automatically by notify_peer_connected, but exposed for testing)
-///
-/// The relay will automatically handle predicate registration/teardown asynchronously.
+/// Keeps this node's queries registered on remote durable peers across
+/// peer availability: it registers on connect, re-registers on
+/// reconnect, retries failures, and tears down removals — each attempt
+/// reading the query's live credential source, so re-registrations
+/// carry refreshed values.
 #[derive(Clone)]
 pub struct SubscriptionRelay<CD: ContextData, Q: RemoteQuerySubscriber> {
     inner: Arc<SubscriptionRelayInner<CD, Q>>,
@@ -129,7 +111,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         query_id: proto::QueryId,
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
-        context_data: CD,
+        sessions: SessionSet<CD>,
         version: u32,
         livequery: Q,
     ) {
@@ -138,7 +120,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             self.inner.subscriptions.lock().expect("poisoned lock").insert(
                 query_id,
                 RemoteQueryState {
-                    content: Arc::new(Content { collection_id, selection, context_data, query_id, version }),
+                    content: Arc::new(Content { collection_id, selection, sessions, query_id, version }),
                     status: Status::PendingRemote,
                     livequery,
                 },
@@ -162,7 +144,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
                     state.content = Arc::new(Content {
                         collection_id: old_content.collection_id.clone(),
                         selection: selection.clone(),
-                        context_data: old_content.context_data.clone(),
+                        sessions: old_content.sessions.clone(),
                         query_id: old_content.query_id,
                         version,
                     });
@@ -171,7 +153,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
                         Status::Established(peer_id, _old_version) => {
                             // Update to new version, mark as requested for this peer
                             state.status = Status::Requested(peer_id, version);
-                            Some((peer_id, state.content.collection_id.clone(), state.content.context_data.clone()))
+                            Some((peer_id, state.content.collection_id.clone(), state.content.sessions.clone()))
                             // Return the peer_id to send update to
                         }
                         _ => {
@@ -186,8 +168,8 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         };
 
         match update {
-            Some((peer_id, collection_id, context_data)) => {
-                self.update_query_on_peer(peer_id, query_id, collection_id, selection, version, context_data);
+            Some((peer_id, collection_id, sessions)) => {
+                self.update_query_on_peer(peer_id, query_id, collection_id, selection, version, sessions);
             }
             None => {
                 // Not established yet - use setup_remote_subscriptions for initial setup
@@ -205,7 +187,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
         version: u32,
-        context_data: CD,
+        sessions: SessionSet<CD>,
     ) {
         let me = self.clone();
         crate::task::spawn(async move {
@@ -215,8 +197,9 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
                     me.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner()).get(&query_id).map(|state| state.livequery.clone())
                 };
 
-                // Send the updated predicate to the peer
-                match node.remote_subscribe(peer_id, query_id, collection_id, selection, &context_data, version).await {
+                // Send the updated predicate to the peer, under the
+                // credentials current at send time.
+                match node.remote_subscribe(peer_id, query_id, collection_id, selection, sessions.current(), version).await {
                     Ok(()) => {
                         // Deltas applied successfully, now activate the livequery
                         if let Some(lq) = livequery {
@@ -323,7 +306,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             match &state.status {
                 Status::Established(established_peer, _) | Status::Requested(established_peer, _) => {
                     if established_peer == peer_id {
-                        contexts.insert(state.content.context_data.clone());
+                        contexts.extend(state.content.sessions.current());
                     }
                 }
                 _ => {}
@@ -384,7 +367,8 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
     async fn attempt_subscribe(self, node: Arc<dyn TNode<CD>>, target_peer: proto::EntityId, content: Arc<Content<CD>>) {
         let query_id = content.query_id;
         let predicate = content.selection.clone();
-        let context_data = content.context_data.clone();
+        // Credentials read at send time from the live source.
+        let cdatas = content.sessions.current();
         let version = content.version;
 
         // Get the livequery for error handling
@@ -392,7 +376,7 @@ impl<CD: ContextData, Q: RemoteQuerySubscriber> SubscriptionRelay<CD, Q> {
             { self.inner.subscriptions.lock().unwrap_or_else(|e| e.into_inner()).get(&query_id).map(|state| state.livequery.clone()) };
 
         // Call remote_subscribe which fetches known matches, subscribes, applies deltas, and stores events
-        match node.remote_subscribe(target_peer, query_id, content.collection_id.clone(), predicate, &context_data, version).await {
+        match node.remote_subscribe(target_peer, query_id, content.collection_id.clone(), predicate, cdatas, version).await {
             Ok(()) => {
                 // Deltas applied successfully, now activate the livequery
                 // The livequery handles its own errors internally
@@ -487,7 +471,7 @@ pub trait TNode<CD: ContextData>: Send + Sync {
         query_id: proto::QueryId,
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
-        context_data: &CD,
+        context_data: Vec<CD>,
         version: u32,
     ) -> Result<(), RetrievalError>;
 
@@ -509,7 +493,7 @@ where
         query_id: proto::QueryId,
         collection_id: CollectionId,
         selection: ankql::ast::Selection,
-        context_data: &PA::ContextData,
+        context_data: Vec<PA::ContextData>,
         version: u32,
     ) -> Result<(), RetrievalError> {
         let node = self.upgrade().ok_or_else(|| RetrievalError::Other("Node has been dropped".to_string()))?;
@@ -526,7 +510,7 @@ where
         let deltas = match node
             .request(
                 peer_id,
-                context_data,
+                &context_data,
                 ankurah_proto::NodeRequestBody::SubscribeQuery {
                     query_id,
                     collection: collection_id.clone(),
@@ -551,7 +535,7 @@ where
         );
         // 3. Apply deltas to local node using NodeApplier
         let collection = node.collections.get(&collection_id).await?;
-        let event_getter = crate::retrieval::CachedEventGetter::new(collection_id, collection.clone(), &node, context_data);
+        let event_getter = crate::retrieval::CachedEventGetter::new(collection_id, collection.clone(), &node, &context_data);
         let state_getter = crate::retrieval::LocalStateGetter::new(collection);
         crate::node_applier::NodeApplier::apply_deltas(&node, &peer_id, deltas, &event_getter, &state_getter).await?;
 
@@ -622,7 +606,7 @@ mod tests {
             query_id: proto::QueryId,
             collection_id: CollectionId,
             selection: ankql::ast::Selection,
-            _context_data: &CD,
+            _context_data: Vec<CD>,
             _version: u32,
         ) -> Result<(), RetrievalError> {
             self.sent_requests.lock().unwrap().push((peer_id, query_id, collection_id.clone(), selection.clone()));
@@ -690,7 +674,7 @@ mod tests {
         relay.notify_peer_connected(peer_id);
 
         // Notify of new subscription
-        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone().into(), 0, MockLiveQuery);
 
         // Check initial state - subscription should immediately go to Requested state since peer is connected
         assert!(matches!(relay.get_status(query_id), Some(Status::Requested(_, _))));
@@ -725,7 +709,7 @@ mod tests {
         relay.notify_peer_connected(peer_id);
 
         // Setup established subscription by going through the full flow
-        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone().into(), 0, MockLiveQuery);
 
         // Give async task time to complete
         futures_timer::Delay::new(std::time::Duration::from_millis(10)).await;
@@ -751,7 +735,7 @@ mod tests {
         let peer_id = EntityId::new();
 
         // Add pending subscription (no peers connected yet)
-        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone().into(), 0, MockLiveQuery);
         assert!(matches!(relay.get_status(query_id), Some(Status::PendingRemote)));
 
         // Clear any previous requests
@@ -786,7 +770,7 @@ mod tests {
 
         // Connect peer and add subscription (should succeed initially)
         relay.notify_peer_connected(peer_id);
-        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone().into(), 0, MockLiveQuery);
 
         // Give async task time to complete
         futures_timer::Delay::new(std::time::Duration::from_millis(10)).await;
@@ -832,8 +816,15 @@ mod tests {
         let peer_id = EntityId::new();
 
         // Add subscriptions
-        relay.subscribe_query(retryable_query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
-        relay.subscribe_query(non_retryable_query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(retryable_query_id, collection_id.clone(), predicate.clone(), collection_id.clone().into(), 0, MockLiveQuery);
+        relay.subscribe_query(
+            non_retryable_query_id,
+            collection_id.clone(),
+            predicate.clone(),
+            collection_id.clone().into(),
+            0,
+            MockLiveQuery,
+        );
 
         // Manually set different failure types - retryable goes back to pending, non-retryable stays failed
         {
@@ -877,7 +868,7 @@ mod tests {
 
         // Connect peer and setup established subscription
         relay.notify_peer_connected(peer_id);
-        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone().into(), 0, MockLiveQuery);
 
         // Give async task time to complete
         futures_timer::Delay::new(std::time::Duration::from_millis(10)).await;
@@ -914,7 +905,7 @@ mod tests {
         let peer_id = EntityId::new();
 
         // Test setup without message sender - should not crash
-        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(query_id, collection_id.clone(), predicate.clone(), collection_id.clone().into(), 0, MockLiveQuery);
         futures_timer::Delay::new(std::time::Duration::from_millis(10)).await;
 
         // Should still be pending since no sender
@@ -950,7 +941,7 @@ mod tests {
         let predicate = create_test_selection();
 
         // Add subscription but don't establish it
-        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone(), 0, MockLiveQuery);
+        relay.subscribe_query(query_id, collection_id.clone(), predicate, collection_id.clone().into(), 0, MockLiveQuery);
         assert!(matches!(relay.get_status(query_id), Some(Status::PendingRemote)));
 
         // Unsubscribe from pending subscription

--- a/core/src/peer_subscription/server.rs
+++ b/core/src/peer_subscription/server.rs
@@ -2,29 +2,42 @@ use ankurah_proto::{self as proto, Attested};
 use tracing::warn;
 
 use crate::{
+    entity::Entity,
     error::SubscriptionError,
     node::Node,
     policy::PolicyAgent,
-    reactor::{ReactorSubscription, ReactorUpdate},
+    reactor::{
+        fetch_gap::{GapFetcher, QueryGapFetcher},
+        ReactorSubscription, ReactorUpdate,
+    },
+    session::{ContextData, SessionSet},
     storage::StorageEngine,
 };
 use ankurah_signals::{Subscribe, SubscriptionGuard};
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 /// Manages a peer's subscription to this node's reactor.
 ///
 /// This handler owns both the ReactorSubscription and the SubscriptionGuard
-/// for listening to changes on that subscription.
-pub struct SubscriptionHandler {
+/// for listening to changes on that subscription — and each standing
+/// query's subscriber session, the typed owner of credential state the
+/// reactor reads but does not manage.
+pub struct SubscriptionHandler<CD: ContextData> {
     _peer_id: proto::EntityId,
     subscription: ReactorSubscription,
     _guard: SubscriptionGuard,
+    /// Each standing query's credential source, shared with its gap
+    /// fetcher and dropped with the handler, so a disconnect releases
+    /// them all.
+    queries: Mutex<HashMap<proto::QueryId, SessionSet<CD>>>,
 }
 
-impl SubscriptionHandler {
+impl<CD: ContextData> SubscriptionHandler<CD> {
     pub fn new<SE, PA>(peer_id: proto::EntityId, node: &Node<SE, PA>) -> Self
     where
         SE: StorageEngine + Send + Sync + 'static,
-        PA: PolicyAgent + Send + Sync + 'static,
+        PA: PolicyAgent<ContextData = CD> + Send + Sync + 'static,
     {
         let subscription = node.reactor.subscribe();
         let weak_node = node.weak();
@@ -44,7 +57,7 @@ impl SubscriptionHandler {
             }
         });
 
-        Self { _peer_id: peer_id, subscription, _guard: guard }
+        Self { _peer_id: peer_id, subscription, _guard: guard, queries: Mutex::new(HashMap::new()) }
     }
 
     /// Get the subscription ID for this peer.
@@ -53,9 +66,11 @@ impl SubscriptionHandler {
     /// Get a reference to the subscription for adding/removing predicates.
     pub fn subscription(&self) -> &ReactorSubscription { &self.subscription }
 
-    /// Remove a predicate from this peer's subscription.
+    /// Remove a predicate from this peer's subscription, releasing the
+    /// query's session with it.
     pub fn remove_predicate(&self, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
         self.subscription.remove_predicate(query_id)?;
+        self.queries.lock().unwrap_or_else(|e| e.into_inner()).remove(&query_id);
         Ok(())
     }
 
@@ -72,19 +87,51 @@ impl SubscriptionHandler {
     ) -> anyhow::Result<proto::NodeResponseBody>
     where
         SE: StorageEngine + Send + Sync + 'static,
-        PA: PolicyAgent + Send + Sync + 'static,
+        PA: PolicyAgent<ContextData = CD> + Send + Sync + 'static,
     {
         if version == 0 {
             return Err(anyhow::anyhow!("Invalid version 0 for subscription"));
         }
+        // Re-subscribes re-validate under the peer's current credentials
+        // and refresh the query's standing session below. Denial does
+        // not yet tear down a standing registration — the claw-back
+        // arrives with the re-permission PR:
+        // https://github.com/ankurah/ankurah/pull/426
         node.policy_agent.can_access_collection(cdata, &collection_id)?;
         selection.predicate = node.policy_agent.filter_predicate(cdata, &collection_id, selection.predicate)?;
         let storage_collection = node.collections.get(&collection_id).await?;
 
+        // TODO: consider separating session updating from SubscribeQuery,
+        // reserving that request for actual subscription (selection)
+        // updates and carrying credential refresh on its own wire
+        // message once the protocol grows a session-update vocabulary.
+        //
+        // The query's credential source: minted at first subscribe,
+        // shared with the gap fetcher, refreshed with the re-validated
+        // credentials on re-subscribe (the equality gate makes an
+        // identical credential a no-op).
+        let sessions: SessionSet<CD> = {
+            use std::collections::hash_map::Entry;
+            let mut queries = self.queries.lock().unwrap_or_else(|e| e.into_inner());
+            match queries.entry(query_id) {
+                Entry::Occupied(o) => {
+                    let sessions = o.get().clone();
+                    for session in sessions.sessions() {
+                        session.update(cdata.clone());
+                    }
+                    sessions
+                }
+                Entry::Vacant(v) => v.insert(cdata.clone().into()).clone(),
+            }
+        };
+
+        let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(node, sessions));
+
         // Add or update the query - idempotent, works whether query exists or not
-        let matching_entities = node
-            .reactor
-            .upsert_query(self.subscription.id(), query_id, collection_id.clone(), selection.clone(), node, cdata, version)
+        let included_entities = node.fetch_entities_from_local(&collection_id, &selection).await?;
+        let matching_entities = self
+            .subscription
+            .upsert_query(query_id, collection_id.clone(), selection.clone(), included_entities, gap_fetcher, version)
             .await?;
 
         // TASK: Audit SubscriptionUpdate vs QuerySubscribed sequencing https://github.com/ankurah/ankurah/issues/147

--- a/core/src/reactor.rs
+++ b/core/src/reactor.rs
@@ -140,15 +140,23 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
 
         // Remove the query from the subscription
         let query_state = subscription.remove_query(query_id).ok_or(SubscriptionError::PredicateNotFound)?;
+        self.cleanup_removed_query(subscription_id, query_id, &query_state);
+        Ok(())
+    }
 
+    /// Watcher teardown shared by the removal paths.
+    fn cleanup_removed_query(
+        &self,
+        subscription_id: ReactorSubscriptionId,
+        query_id: proto::QueryId,
+        query_state: &subscription_state::QueryState<E>,
+    ) {
         // Remove from watchers (only if selection was set)
         if let Some(selection) = &query_state.selection {
             let mut watcher_set = self.0.watcher_set.lock().unwrap();
             let watcher_id = (subscription_id, query_id);
             watcher_set.recurse_predicate_watchers(&query_state.collection_id, &selection.predicate, watcher_id, WatcherOp::Remove);
         }
-
-        Ok(())
     }
 
     /// Add entity subscriptions to a subscription
@@ -384,53 +392,6 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         for subscription in subscriptions.values() {
             subscription.system_reset();
         }
-    }
-}
-
-// Entity-specific methods for remote subscriptions
-impl Reactor<Entity, ankurah_proto::Attested<ankurah_proto::Event>> {
-    /// Add or update a query for remote subscriptions (server-side)
-    /// This method is idempotent - it works whether the query exists or not
-    /// Constructs gap_fetcher internally using the provided Node and ContextData
-    /// Returns all entities that currently match the selection (for delta generation)
-    pub async fn upsert_query<SE, PA>(
-        &self,
-        subscription_id: ReactorSubscriptionId,
-        query_id: proto::QueryId,
-        collection_id: proto::CollectionId,
-        selection: ankql::ast::Selection,
-        node: &crate::node::Node<SE, PA>,
-        cdata: &PA::ContextData,
-        version: u32,
-    ) -> anyhow::Result<Vec<Entity>>
-    where
-        SE: crate::storage::StorageEngine + Send + Sync + 'static,
-        PA: crate::policy::PolicyAgent + Send + Sync + 'static,
-    {
-        let subscription = {
-            let subscriptions = self.0.subscriptions.lock().unwrap();
-            subscriptions.get(&subscription_id).cloned().ok_or_else(|| anyhow::anyhow!("Subscription {:?} not found", subscription_id))?
-        };
-
-        let included_entities = node.fetch_entities_from_local(&collection_id, &selection).await?;
-
-        // Upsert query - register if new or get existing resultset
-        // Gap fetcher is only created if query doesn't exist yet
-        let resultset = subscription.upsert_query(query_id, collection_id.clone(), node, cdata);
-
-        // Update query - watcher management is handled internally
-        let mut all_entities =
-            subscription.update_query(query_id, collection_id.clone(), selection.clone(), included_entities, version, &mut ())?;
-
-        // Fill gaps if needed for this specific query (also registers entity watchers)
-        // FIXME: Same follow-up — we should confirm whether edit-driven gaps can occur between the
-        // storage fetch and notify_change handling, which would make this gap fill mandatory.
-        subscription.fill_gaps_for_query_entities(query_id, &mut all_entities).await;
-
-        resultset.set_loaded(true);
-
-        // Return all entities (newly added + gap-filled)
-        Ok(all_entities)
     }
 }
 

--- a/core/src/reactor/fetch_gap.rs
+++ b/core/src/reactor/fetch_gap.rs
@@ -33,15 +33,19 @@ pub trait GapFetcher<E: AbstractEntity>: Send + Sync + 'static {
     ) -> Result<Vec<E>, RetrievalError>;
 }
 
-/// Concrete implementation of GapFetcher using a WeakNode and typed ContextData
-#[derive(Clone)]
+/// Concrete implementation of GapFetcher using a WeakNode and a live
+/// credential source, read at fetch time so a refreshed credential is
+/// used without rebuilding the fetcher.
 pub struct QueryGapFetcher<SE, PA>
 where
     SE: StorageEngine,
     PA: PolicyAgent,
 {
     weak_node: Weak<NodeInner<SE, PA>>,
-    cdata: PA::ContextData,
+    /// A context's set on the client side; on the server side a private
+    /// set owning the per-query session the peer subscription server
+    /// writes on each re-validated subscribe.
+    sessions: crate::session::SessionSet<PA::ContextData>,
 }
 
 impl<SE, PA> QueryGapFetcher<SE, PA>
@@ -49,7 +53,9 @@ where
     SE: StorageEngine,
     PA: PolicyAgent,
 {
-    pub fn new(node: &Node<SE, PA>, cdata: PA::ContextData) -> Self { Self { weak_node: Arc::downgrade(&node.0), cdata } }
+    pub fn new(node: &Node<SE, PA>, sessions: crate::session::SessionSet<PA::ContextData>) -> Self {
+        Self { weak_node: Arc::downgrade(&node.0), sessions }
+    }
 }
 
 #[async_trait]
@@ -73,7 +79,7 @@ where
 
         // Create a Node wrapper and NodeAndContext
         let node = Node(node_inner);
-        let node_context = NodeAndContext { node, cdata: self.cdata.clone() };
+        let node_context = NodeAndContext { node, sessions: self.sessions.clone() };
 
         // Build gap predicate if we have a last entity
         let gap_selection = if let Some(last) = last_entity {

--- a/core/src/reactor/subscription.rs
+++ b/core/src/reactor/subscription.rs
@@ -57,10 +57,6 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
     /// Get the subscription ID
     pub fn id(&self) -> ReactorSubscriptionId { self.0.subscription_id }
 
-    /// Add a predicate to this subscription
-    // TODO: REMOVE this method - predicates should ONLY be added via set_predicate
-    // This creates an inactive predicate that does nothing until initialize() is called
-
     /// Remove a predicate from this subscription
     pub fn remove_predicate(&self, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
         self.0.reactor.remove_query(self.0.subscription_id, query_id)?;
@@ -77,6 +73,50 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
     pub fn remove_entity_subscriptions(&self, entity_ids: impl IntoIterator<Item = proto::EntityId>) {
         let entity_ids: Vec<_> = entity_ids.into_iter().collect();
         self.0.reactor.remove_entity_subscriptions(self.0.subscription_id, entity_ids);
+    }
+}
+
+// Entity-specific methods for remote subscriptions
+impl ReactorSubscription<crate::entity::Entity, ankurah_proto::Attested<ankurah_proto::Event>> {
+    /// Add or update a query for a remote subscriber (server-side):
+    /// register if new, installing the caller's gap fetcher, then run
+    /// the caller-fetched entities through the versioned update flow
+    /// and fill gaps. Idempotent per query id. The reactor holds no
+    /// node or credential access here: fetching current matches and
+    /// wiring a fetcher to a session source are the caller's jobs.
+    pub async fn upsert_query(
+        &self,
+        query_id: proto::QueryId,
+        collection_id: proto::CollectionId,
+        selection: ankql::ast::Selection,
+        included_entities: Vec<crate::entity::Entity>,
+        gap_fetcher: std::sync::Arc<dyn crate::reactor::fetch_gap::GapFetcher<crate::entity::Entity>>,
+        version: u32,
+    ) -> anyhow::Result<Vec<crate::entity::Entity>> {
+        let subscription = {
+            let subscriptions = self.0.reactor.0.subscriptions.lock().unwrap();
+            subscriptions
+                .get(&self.0.subscription_id)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Subscription {:?} not found", self.0.subscription_id))?
+        };
+
+        // Register if new or get the existing resultset.
+        let resultset = subscription.register_or_get_query(query_id, collection_id.clone(), gap_fetcher);
+
+        // Update query - watcher management is handled internally
+        let mut all_entities =
+            subscription.update_query(query_id, collection_id.clone(), selection.clone(), included_entities, version, &mut ())?;
+
+        // Fill gaps if needed for this specific query (also registers entity watchers)
+        // FIXME: Same follow-up — we should confirm whether edit-driven gaps can occur between the
+        // storage fetch and notify_change handling, which would make this gap fill mandatory.
+        subscription.fill_gaps_for_query_entities(query_id, &mut all_entities).await;
+
+        resultset.set_loaded(true);
+
+        // Return all entities (newly added + gap-filled)
+        Ok(all_entities)
     }
 }
 

--- a/core/src/reactor/subscription_state.rs
+++ b/core/src/reactor/subscription_state.rs
@@ -683,28 +683,22 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
 
 // Entity-specific methods for remote subscriptions
 impl Subscription<crate::entity::Entity, ankurah_proto::Attested<ankurah_proto::Event>> {
-    /// Upsert a query - register if it doesn't exist, or return the existing resultset
-    /// Idempotent - safe to call multiple times with the same query_id
-    /// Constructs gap_fetcher lazily (only if query doesn't exist)
-    pub fn upsert_query<SE, PA>(
+    /// Register a query if absent, installing the caller's gap fetcher,
+    /// or return the already-registered query's resultset. Idempotent
+    /// per query id: for an existing query every argument except the id
+    /// is ignored and the provided fetcher is dropped.
+    pub fn register_or_get_query(
         &self,
         query_id: proto::QueryId,
         collection_id: proto::CollectionId,
-        node: &crate::node::Node<SE, PA>,
-        cdata: &PA::ContextData,
-    ) -> EntityResultSet<crate::entity::Entity>
-    where
-        SE: crate::storage::StorageEngine + Send + Sync + 'static,
-        PA: crate::policy::PolicyAgent + Send + Sync + 'static,
-    {
+        gap_fetcher: std::sync::Arc<dyn crate::reactor::fetch_gap::GapFetcher<crate::entity::Entity>>,
+    ) -> EntityResultSet<crate::entity::Entity> {
         let mut state = self.state.lock().unwrap();
 
         use std::collections::hash_map::Entry;
         match state.queries.entry(query_id) {
             Entry::Vacant(v) => {
                 let resultset = EntityResultSet::empty();
-                // Only create gap fetcher if query doesn't exist
-                let gap_fetcher = std::sync::Arc::new(crate::reactor::fetch_gap::QueryGapFetcher::new(node, cdata.clone()));
                 v.insert(QueryState {
                     collection_id,
                     selection: None,

--- a/core/src/schema/registration.rs
+++ b/core/src/schema/registration.rs
@@ -139,7 +139,8 @@ pub enum RegistrationError {
         /// The value type declared by the requester.
         value_type: String,
     },
-    /// The policy agent denied the resolved registration plan.
+    /// The policy agent denied the resolved registration plan, or the
+    /// context could not act as a single principal.
     #[error("registration refused by policy: {0}")]
     PolicyDenied(
         /// The policy agent's denial.

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -1,0 +1,514 @@
+//! Represents one or more sessions: the state each principal acts
+//! under — one [`Session`] per ordinary Context, enumerable through the
+//! node's [`SessionSet`].
+//!
+//! A Session wraps its current ContextData in a signal, so a long-lived
+//! handle's state can change (a token refresh, a re-login) without
+//! rebuilding the Context or the livequeries under it: holders keep the
+//! session and read the current value at use time, and change
+//! subscribers hear each effective update (standing queries re-permission
+//! on it in https://github.com/ankurah/ankurah/pull/426). What a session
+//! holds is whatever its PolicyAgent evaluates — a bearer token today; a
+//! session id, challenge state, or anything else as ContextData
+//! generalizes. The SessionSet tracks sessions, undeduplicated: two
+//! sessions whose states compare equal today are still independent and
+//! may diverge tomorrow, so any deduplication happens at the point of
+//! consumption, over current values.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex, Weak,
+};
+
+use ankurah_signals::{
+    broadcast::{Broadcast, BroadcastId},
+    signal::{Listener, ListenerGuard},
+    subscribe::IntoSubscribeListener,
+    Get, Mut, Peek, Signal, Subscribe, SubscriptionGuard,
+};
+
+/// Represents the user session - or whatever other context the PolicyAgent
+/// needs to perform its evaluation. The credential vocabulary lives here
+/// beside its live holder; node.rs re-exports it for path compatibility.
+///
+/// `Eq` is operational identity: values compare equal only when
+/// substituting one for the other changes nothing observable (for a
+/// token credential, the token included), and `Hash` agrees with it.
+/// [`Session::update`] delivery gates on this — an update comparing
+/// equal to the current value is a no-op.
+///
+/// `Clone` is assumed cheap: sessions, snapshots, and sends clone
+/// values freely — wrap heavy payloads in `Arc`.
+pub trait ContextData: Send + Sync + Clone + std::hash::Hash + Eq + 'static {}
+
+/// One live credential: the value a single principal acts under,
+/// replaceable in place. An ordinary context owns exactly one in its
+/// private set, attached to the node's [`SessionSet`]. Queries and
+/// their machinery (livequeries, gap fetchers, the relay) hold their
+/// context's set and read its current values once per operation.
+/// Cloning shares the one session: handles alias the same cell.
+pub struct Session<CD: ContextData>(Arc<SessionInner<CD>>);
+
+impl<CD: ContextData> Clone for Session<CD> {
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+struct SessionInner<CD: ContextData> {
+    /// The current data for this Session
+    current: Mut<CD>,
+}
+
+impl<CD: ContextData> Session<CD> {
+    /// Begin a session holding `cdata` as its current credential. In no
+    /// set until something owns it (a context's source owns its session;
+    /// the source is attached to the node's registry at construction).
+    pub fn new(cdata: CD) -> Self { Self(Arc::new(SessionInner { current: Mut::new(cdata) })) }
+
+    /// A snapshot of the current credential. Take one per logical
+    /// operation, so a mid-operation update cannot mix credentials. (Named
+    /// snapshot, not get: the signals lexicon's `get` is an
+    /// observer-tracked read, and this is deliberately untracked.)
+    pub fn snapshot(&self) -> CD { self.0.current.value() }
+
+    /// Replace the credential. A value comparing equal to the current one
+    /// is a complete no-op, no store and no notification: `Eq` is
+    /// operational identity per [`ContextData`], so
+    /// equal means nothing observable changed and there is nothing to
+    /// re-permission. A token refresh carries a new token, compares
+    /// unequal, and notifies holders and change subscribers.
+    pub fn update(&self, cdata: CD) {
+        // The compare and the store take the lock separately; a racing
+        // update can only make this comparison stale in ways that
+        // linearize legally (a suppressed call was a no-op against SOME
+        // current value, and the racing update's own notification covers
+        // the change).
+        if self.0.current.value() == cdata {
+            return;
+        }
+        self.0.current.set(cdata);
+    }
+}
+
+// A Session IS a signal over its credential, so it implements the standard
+// signals vocabulary by delegation (beside the inherent, doc-carrying
+// `snapshot`, the same coexistence `Mut::value` has with its trait impls).
+impl<CD: ContextData> Signal for Session<CD> {
+    fn listen(&self, listener: Listener) -> ListenerGuard { self.0.current.listen(listener) }
+    fn broadcast_id(&self) -> BroadcastId { self.0.current.broadcast_id() }
+}
+
+impl<CD: ContextData> Get<CD> for Session<CD> {
+    fn get(&self) -> CD { self.0.current.get() }
+}
+
+impl<CD: ContextData> Peek<CD> for Session<CD> {
+    fn peek(&self) -> CD { self.0.current.value() }
+}
+
+impl<CD: ContextData> Subscribe<CD> for Session<CD> {
+    fn subscribe<F>(&self, listener: F) -> SubscriptionGuard
+    where F: IntoSubscribeListener<CD> {
+        self.0.current.subscribe(listener)
+    }
+}
+
+impl<CD: ContextData> std::fmt::Debug for Session<CD> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The credential is deliberately omitted: CDs can carry tokens,
+        // and Debug output reaches logs.
+        f.debug_struct("Session").finish_non_exhaustive()
+    }
+}
+
+/// A set of sessions — the universal credential-source shape. An
+/// ordinary context's source is one (owning exactly the session it
+/// acts as); the node's registry is another, made the continuous
+/// superset of every session backing a context by each context
+/// attaching its source at construction: attached sets join the union
+/// through live edges, so their additions, removals, and value changes
+/// are reflected as they happen.
+pub struct SessionSet<CD: ContextData>(Arc<SessionSetInner<CD>>);
+
+impl<CD: ContextData> Clone for SessionSet<CD> {
+    fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+impl<CD: ContextData> std::fmt::Debug for SessionSet<CD> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Member values are deliberately omitted (CDs can carry tokens,
+        // and Debug reaches logs); counts only, so a Debug line does not
+        // walk the recursive union.
+        let members = self.0.sessions.lock().unwrap_or_else(|e| e.into_inner()).len();
+        let attached = self.0.attached.lock().unwrap_or_else(|e| e.into_inner()).len();
+        f.debug_struct("SessionSet").field("members", &members).field("attached", &attached).finish()
+    }
+}
+
+struct SessionSetInner<CD: ContextData> {
+    sessions: Mutex<HashMap<u64, SessionSlot<CD>>>,
+    next_slot: AtomicU64,
+    /// Fires on any membership change (own, attach, an attached source
+    /// dropping) and on any member's value change (each slot and each
+    /// attached set forwards its signal).
+    changed: Broadcast<()>,
+    /// Attached sets, unioned into this one through live edges: reads
+    /// recurse through the edge, so additions and removals in an
+    /// attached set are reflected here as they happen. Edges are weak —
+    /// a dead set is skipped on read.
+    attached: Mutex<Vec<AttachedSet<CD>>>,
+    /// Parents holding an edge to this set, notified when it drops so a
+    /// watcher of the parent hears this set's members leave.
+    parents: Mutex<Vec<Weak<SessionSetInner<CD>>>>,
+}
+
+struct AttachedSet<CD: ContextData> {
+    set: Weak<SessionSetInner<CD>>,
+    /// Forwards the attached set's change signal into `changed`;
+    /// dropped with the edge.
+    _forward: ListenerGuard,
+}
+
+impl<CD: ContextData> Drop for SessionSetInner<CD> {
+    fn drop(&mut self) {
+        // A dying set's members leave every parent's union; fire so
+        // watchers hear the departure (the dead edge itself is skipped
+        // on the next read).
+        for parent in self.parents.lock().unwrap_or_else(|e| e.into_inner()).drain(..) {
+            if let Some(parent) = parent.upgrade() {
+                parent.changed.send(());
+            }
+        }
+    }
+}
+
+struct SessionSlot<CD: ContextData> {
+    /// The set is this member's liveness: it lives as long as the set
+    /// (a context's own session, a server query's subscriber session).
+    session: Session<CD>,
+    /// Forwards the member's change signal into `changed`; dropped with
+    /// the slot.
+    _forward: ListenerGuard,
+}
+
+impl<CD: ContextData> SessionSet<CD> {
+    pub fn new() -> Self {
+        Self(Arc::new(SessionSetInner {
+            sessions: Mutex::new(HashMap::new()),
+            next_slot: AtomicU64::new(0),
+            changed: Broadcast::new(),
+            attached: Mutex::new(Vec::new()),
+            parents: Mutex::new(Vec::new()),
+        }))
+    }
+
+    /// Attach another set: its members join this set's union through a
+    /// live edge — additions, removals, and value changes over there
+    /// are reflected here as they happen, because reads recurse through
+    /// the edge and its change signal forwards into this set's. This is
+    /// how the node's registry stays the continuous superset of every
+    /// session backing a context. A no-op for self-attachment (the
+    /// registry backing a context is its own source); an attach
+    /// that would form a cycle is refused, warned and ignored.
+    pub fn attach(&self, other: &SessionSet<CD>) {
+        if Arc::ptr_eq(&self.0, &other.0) {
+            return;
+        }
+        if other.reaches(self) {
+            tracing::warn!("refusing attach: it would form a cycle");
+            return;
+        }
+        {
+            let mut attached = self.0.attached.lock().unwrap_or_else(|e| e.into_inner());
+            // Dead edges are skipped on read; prune them here so
+            // re-attachment churn cannot grow the list without bound.
+            attached.retain(|edge| edge.set.strong_count() > 0);
+            let other_weak = Arc::downgrade(&other.0);
+            if attached.iter().any(|edge| edge.set.ptr_eq(&other_weak)) {
+                return;
+            }
+            let forward = {
+                let changed = self.0.changed.clone();
+                // listen, not subscribe: this edge only needs the change
+                // notification — subscribe would recompute the attached
+                // set's whole recursive union on every fire just to
+                // discard it.
+                other.listen(Arc::new(move |_| changed.send(())))
+            };
+            attached.push(AttachedSet { set: other_weak, _forward: forward });
+        }
+        other.0.parents.lock().unwrap_or_else(|e| e.into_inner()).push(Arc::downgrade(&self.0));
+        // Fire outside the locks: subscribers read the set back.
+        self.0.changed.send(());
+    }
+
+    /// Take ownership of a session: the set becomes the member's
+    /// liveness, holding it strong until the set drops. This is how a
+    /// context holds the principal it acts as. A no-op when this set
+    /// already owns it.
+    pub fn own(&self, session: &Session<CD>) {
+        let mut slots = self.0.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        if slots.values().any(|slot| Arc::ptr_eq(&slot.session.0, &session.0)) {
+            return;
+        }
+        let slot = self.0.next_slot.fetch_add(1, Ordering::Relaxed);
+        let forward = {
+            let changed = self.0.changed.clone();
+            // listen, not subscribe: this slot only needs the change
+            // notification — subscribe would clone the credential value
+            // on every fire just to discard it.
+            session.listen(Arc::new(move |_| changed.send(())))
+        };
+        slots.insert(slot, SessionSlot { session: session.clone(), _forward: forward });
+        drop(slots);
+        // Fire outside the lock: subscribers read the set back.
+        self.0.changed.send(());
+    }
+
+    /// Every currently live session — owned members in slot order, then
+    /// each attached set's, depth-first. A set union, not a path
+    /// expansion: each set is visited once (a diamond's shared source
+    /// contributes once) and each session listed once by handle identity
+    /// (distinct sessions whose values compare equal stay distinct).
+    pub fn sessions(&self) -> Vec<Session<CD>> {
+        let mut visited = HashSet::new();
+        let mut seen = HashSet::new();
+        let mut out = Vec::new();
+        self.collect_sessions(&mut visited, &mut seen, &mut out);
+        out
+    }
+
+    fn collect_sessions(&self, visited: &mut HashSet<*const ()>, seen: &mut HashSet<*const ()>, out: &mut Vec<Session<CD>>) {
+        if !visited.insert(Arc::as_ptr(&self.0) as *const ()) {
+            return;
+        }
+        let own: Vec<Session<CD>> = {
+            let map = self.0.sessions.lock().unwrap_or_else(|e| e.into_inner());
+            let mut live: Vec<_> = map.iter().map(|(slot, entry)| (*slot, entry.session.clone())).collect();
+            live.sort_by_key(|(slot, _)| *slot);
+            live.into_iter().map(|(_, session)| session).collect()
+        };
+        for session in own {
+            if seen.insert(Arc::as_ptr(&session.0) as *const ()) {
+                out.push(session);
+            }
+        }
+        // Snapshot the edges, then recurse with no lock held.
+        let edges: Vec<_> = self.0.attached.lock().unwrap_or_else(|e| e.into_inner()).iter().map(|edge| edge.set.clone()).collect();
+        for edge in edges {
+            if let Some(inner) = edge.upgrade() {
+                SessionSet(inner).collect_sessions(visited, seen, out);
+            }
+        }
+    }
+
+    /// Whether `target` is reachable from this set through attached
+    /// edges (including being this set). Attach refuses cycle-forming
+    /// edges, so the walk terminates.
+    fn reaches(&self, target: &SessionSet<CD>) -> bool {
+        if Arc::ptr_eq(&self.0, &target.0) {
+            return true;
+        }
+        let edges: Vec<_> = self.0.attached.lock().unwrap_or_else(|e| e.into_inner()).iter().map(|edge| edge.set.clone()).collect();
+        edges.into_iter().filter_map(|edge| edge.upgrade()).any(|inner| SessionSet(inner).reaches(target))
+    }
+
+    /// The current value of every live session, in slot order.
+    pub fn current(&self) -> Vec<CD> { self.sessions().iter().map(|session| session.snapshot()).collect() }
+
+    /// The single credential write paths act as. A write is one
+    /// principal's act — the wire enforces the same rule, exactly one
+    /// cdata per CommitTransaction / RegisterSchema request — so a
+    /// source with zero or several current sessions refuses. Read paths
+    /// use every member (the union) instead.
+    pub fn write_credential(&self) -> Result<CD, crate::policy::AccessDenied> {
+        let mut sessions = self.sessions().into_iter();
+        match (sessions.next(), sessions.next()) {
+            (Some(session), None) => Ok(session.snapshot()),
+            (None, _) => Err(crate::policy::AccessDenied::ByPolicy("write operations require a session; this context's source has none")),
+            _ => Err(crate::policy::AccessDenied::ByPolicy(
+                "write operations act as one principal; this context's source has several sessions",
+            )),
+        }
+    }
+}
+
+impl<CD: ContextData> From<CD> for SessionSet<CD> {
+    /// Bare state becomes a private set owning one freshly minted
+    /// session — the shape of an ordinary context's source.
+    fn from(cdata: CD) -> Self {
+        let set = SessionSet::new();
+        set.own(&Session::new(cdata));
+        set
+    }
+}
+
+impl<CD: ContextData> From<Session<CD>> for SessionSet<CD> {
+    /// An existing session becomes a private set owning it; the
+    /// caller's handle keeps working (clones share the one session).
+    fn from(session: Session<CD>) -> Self {
+        let set = SessionSet::new();
+        set.own(&session);
+        set
+    }
+}
+
+// The SessionSet is a signal over the union of its members' current
+// credentials: it fires on membership changes and on any member's value
+// change, and reads compute the union fresh (consumers recompute from the
+// full current set; diffs would buy them nothing).
+impl<CD: ContextData> Signal for SessionSet<CD> {
+    fn listen(&self, listener: Listener) -> ListenerGuard { ListenerGuard::new(self.0.changed.reference().listen(listener)) }
+    fn broadcast_id(&self) -> BroadcastId { self.0.changed.id() }
+}
+
+impl<CD: ContextData> Get<Vec<CD>> for SessionSet<CD> {
+    fn get(&self) -> Vec<CD> {
+        ankurah_signals::CurrentObserver::track(self);
+        self.current()
+    }
+}
+
+impl<CD: ContextData> Peek<Vec<CD>> for SessionSet<CD> {
+    fn peek(&self) -> Vec<CD> { self.current() }
+}
+
+impl<CD: ContextData> Subscribe<Vec<CD>> for SessionSet<CD> {
+    fn subscribe<F>(&self, listener: F) -> SubscriptionGuard
+    where F: IntoSubscribeListener<Vec<CD>> {
+        let listener = listener.into_subscribe_listener();
+        // A weak inner breaks the cycle set -> broadcast -> listener -> set.
+        let weak = Arc::downgrade(&self.0);
+        let subscription = self.listen(Arc::new(move |_| {
+            if let Some(inner) = weak.upgrade() {
+                listener(SessionSet(inner).current());
+            }
+        }));
+        SubscriptionGuard::new(subscription)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A value-carrying test credential. Equality is full-value
+    /// (operational identity per the [`ContextData`] contract), so a
+    /// token refresh — same subject, new token — compares unequal and an
+    /// identical update compares equal.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    struct TestCd {
+        subject: u8,
+        token: u8,
+    }
+    impl ContextData for TestCd {}
+
+    /// A context-shaped source — a private set owning its session,
+    /// attached to a registry — joins the registry's union while it
+    /// lives, and its members leave when it drops.
+    #[test]
+    fn attached_set_liveness() {
+        let registry: SessionSet<TestCd> = SessionSet::new();
+        let source: SessionSet<TestCd> = TestCd { subject: 1, token: 0 }.into();
+        registry.attach(&source);
+        assert_eq!(registry.sessions().len(), 1, "attached members join the union");
+
+        let second: SessionSet<TestCd> = TestCd { subject: 2, token: 0 }.into();
+        registry.attach(&second);
+        assert_eq!(registry.sessions().len(), 2);
+
+        drop(second);
+        assert_eq!(registry.sessions().len(), 1, "a dropped source's members leave the union");
+        drop(source);
+        assert!(registry.sessions().is_empty());
+    }
+
+    /// Updates are visible to every holder and fire change subscribers
+    /// with the new value.
+    #[test]
+    fn update_is_shared_and_reactive() {
+        let session = Session::new(TestCd { subject: 1, token: 1 });
+        let holder = session.clone();
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let _guard = session.subscribe(move |value: TestCd| {
+            sink.lock().unwrap().push(value.token);
+        });
+
+        session.update(TestCd { subject: 2, token: 2 });
+        assert_eq!(holder.snapshot().token, 2, "holders read the new value");
+        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "subscriber fired with the new value");
+    }
+
+    /// A token refresh — same subject, new token — is a real change: it
+    /// compares unequal and fires the subscriber. An identical update is
+    /// a complete no-op: no notification.
+    #[test]
+    fn refresh_notifies_and_identical_update_is_a_noop() {
+        let session = Session::new(TestCd { subject: 1, token: 1 });
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let _guard = session.subscribe(move |value: TestCd| {
+            sink.lock().unwrap().push(value.token);
+        });
+
+        let refreshed = TestCd { subject: 1, token: 2 };
+        assert_ne!(session.snapshot(), refreshed, "a refresh carries a new token, so it compares unequal");
+        session.update(refreshed);
+        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "the refresh fires the subscriber");
+
+        session.update(TestCd { subject: 1, token: 2 });
+        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "an identical update does not notify");
+        assert_eq!(session.snapshot().token, 2, "the stored value is unchanged");
+    }
+
+    /// A new session belongs to no set until something owns it.
+    #[test]
+    fn new_sessions_belong_to_no_set() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let _infra = Session::new(TestCd { subject: 1, token: 0 });
+        assert!(set.sessions().is_empty());
+    }
+
+    /// The set is a signal over the union of current values: it fires on
+    /// own, on any member's update, on attach, and when an attached
+    /// source drops.
+    #[test]
+    fn set_fires_on_membership_and_member_updates() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let fired = Arc::new(Mutex::new(Vec::new()));
+        let sink = fired.clone();
+        let _guard = set.subscribe(move |current: Vec<TestCd>| {
+            sink.lock().unwrap().push(current.iter().map(|cd| cd.token).collect::<Vec<_>>());
+        });
+
+        let a = Session::new(TestCd { subject: 1, token: 10 });
+        set.own(&a);
+        assert_eq!(fired.lock().unwrap().last(), Some(&vec![10]), "owning fires with the new union");
+
+        a.update(TestCd { subject: 1, token: 11 });
+        assert_eq!(fired.lock().unwrap().last(), Some(&vec![11]), "a member's update fires with its new value");
+
+        let child: SessionSet<TestCd> = TestCd { subject: 2, token: 20 }.into();
+        set.attach(&child);
+        assert_eq!(fired.lock().unwrap().last(), Some(&vec![11, 20]), "attaching fires with the joined union");
+
+        let count = fired.lock().unwrap().len();
+        drop(child);
+        assert_eq!(fired.lock().unwrap().last(), Some(&vec![11]), "a dropped source fires the shrunken union");
+        assert_eq!(fired.lock().unwrap().len(), count + 1, "exactly the drop notification fired");
+    }
+
+    /// Peek reads the union without tracking; the porcelain and the
+    /// inherent accessors agree.
+    #[test]
+    fn porcelain_and_inherent_accessors_agree() {
+        let set: SessionSet<TestCd> = SessionSet::new();
+        let session = Session::new(TestCd { subject: 1, token: 1 });
+        set.own(&session);
+        assert_eq!(session.peek(), session.snapshot());
+        assert_eq!(set.peek(), set.current());
+        assert_eq!(set.peek(), vec![TestCd { subject: 1, token: 1 }]);
+    }
+}

--- a/core/src/util/iterable.rs
+++ b/core/src/util/iterable.rs
@@ -2,6 +2,9 @@ use std::{collections::HashSet, hash::BuildHasher};
 
 /// Trait for types that can provide an iterator over their contents without consuming self.
 /// This allows uniform iteration over both single items (`&T`) and collections (`&HashSet<T>`).
+/// (No `[T]` impl: consumers' generic `C` params carry an implicit `Sized`
+/// bound, so slice support means threading `?Sized` through the policy
+/// trait — take `&Vec<T>` until that is worth doing.)
 pub trait Iterable<T> {
     type Iter<'a>: Iterator<Item = &'a T>
     where

--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -112,6 +112,10 @@ impl PolicyAgent for JwtAgent {
     {
         debug!("JwtAgent sign_request");
         let mut auth_data = Vec::new();
+        // All-or-nothing: one unsignable member (Root's auth_data errors
+        // by design) fails the whole request even when other members
+        // could serve. Skip-vs-fail is an open decision:
+        // https://github.com/ankurah/ankurah/issues/432
         for ctx in cdata.iterable() {
             auth_data.push(ctx.auth_data()?);
         }

--- a/extensions/jwt-auth/src/claims.rs
+++ b/extensions/jwt-auth/src/claims.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 /// Note: `sub` is stored in the standard JWT `subject` field (not in custom claims)
 /// to avoid serde conflicts with `jwt_simple`'s `#[serde(flatten)]` on custom claims.
 /// The `sub` field here is populated by `SigningKeys::verify()` from the standard claim.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// Eq and Hash ride serde_json's own total impls (`Value` derives both;
+// its Number hash normalizes the +/-0.0 case), so full-value equality
+// needs no hand-rolled walk.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct JwtClaims {
     /// User entity ID (ankurah EntityId serialized as string).
     /// When signing, this is placed in the standard JWT `sub` claim.

--- a/extensions/jwt-auth/src/context.rs
+++ b/extensions/jwt-auth/src/context.rs
@@ -2,13 +2,16 @@ use crate::claims::JwtClaims;
 use ankurah_core::node::ContextData;
 use ankurah_core::policy::AccessDenied;
 use ankurah_proto as proto;
-use async_trait::async_trait;
-use std::hash::{Hash, Hasher};
 
 /// The context data extracted from a validated JWT, used for all policy checks.
 /// `Root` represents a privileged system context that bypasses all RBAC checks.
 /// `NoUser` represents an unauthenticated context (e.g. for reading the policy collection).
-#[derive(Debug, Clone)]
+///
+/// Equality and hash are full-value — claims and token — because
+/// `ContextData`'s contract is operational identity and `Session` update
+/// delivery gates on it: a token refresh compares unequal and
+/// propagates; an identical update is a no-op.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum JwtContext {
     User { claims: JwtClaims, token: String },
     Root,
@@ -68,28 +71,4 @@ impl JwtContext {
     }
 }
 
-impl PartialEq for JwtContext {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (JwtContext::User { claims: a, .. }, JwtContext::User { claims: b, .. }) => a.sub == b.sub,
-            (JwtContext::Root, JwtContext::Root) => true,
-            (JwtContext::NoUser, JwtContext::NoUser) => true,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for JwtContext {}
-
-impl Hash for JwtContext {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(self).hash(state);
-        match self {
-            JwtContext::User { claims, .. } => claims.sub.hash(state),
-            JwtContext::Root | JwtContext::NoUser => {}
-        }
-    }
-}
-
-#[async_trait]
 impl ContextData for JwtContext {}

--- a/extensions/jwt-auth/tests/context_tests.rs
+++ b/extensions/jwt-auth/tests/context_tests.rs
@@ -25,8 +25,13 @@ fn test_jwt_context_accessors() {
     assert_eq!(ctx.token_bytes(), Some(b"fake-token".as_slice()));
 }
 
+/// Equality is full-value (operational identity per the ContextData
+/// contract): same subject with different claims or token compares
+/// UNEQUAL — Session update delivery gates on this, and a token refresh
+/// must register as a change — and only an identical value compares
+/// equal, with the hash agreeing.
 #[test]
-fn test_jwt_context_equality_by_sub() {
+fn test_jwt_context_equality_is_full_value() {
     let ctx1 = JwtContext::from_claims(
         JwtClaims {
             sub: "user-1".into(),
@@ -37,6 +42,7 @@ fn test_jwt_context_equality_by_sub() {
         },
         "token-1".into(),
     );
+    // Same subject, different claims and token: a re-login or refresh.
     let ctx2 = JwtContext::from_claims(
         JwtClaims {
             sub: "user-1".into(),
@@ -57,8 +63,43 @@ fn test_jwt_context_equality_by_sub() {
         },
         "token-3".into(),
     );
-    assert_eq!(ctx1, ctx2);
+    assert_ne!(ctx1, ctx2, "same subject with different claims or token is a different credential");
     assert_ne!(ctx1, ctx3);
+    let identical = ctx1.clone();
+    assert_eq!(ctx1, identical, "only an identical value compares equal");
+
+    let mut set = std::collections::HashSet::new();
+    set.insert(ctx1);
+    assert!(set.contains(&identical), "hash agrees with eq");
+    assert!(!set.contains(&ctx2));
+}
+
+/// Hash agrees with Eq over custom claims regardless of map insertion
+/// order: json map equality is order-independent, so the hash walks
+/// objects in sorted key order.
+#[test]
+fn test_jwt_context_hash_ignores_custom_claim_insertion_order() {
+    let mut ab = serde_json::Map::new();
+    ab.insert("a".into(), serde_json::json!({"n": 1, "s": ["x", 2.5, null]}));
+    ab.insert("b".into(), serde_json::json!(true));
+    let mut ba = serde_json::Map::new();
+    ba.insert("b".into(), serde_json::json!(true));
+    ba.insert("a".into(), serde_json::json!({"n": 1, "s": ["x", 2.5, null]}));
+
+    let claims = |custom: serde_json::Map<String, serde_json::Value>| JwtClaims {
+        sub: "user-1".into(),
+        roles: vec![],
+        email: "a@b.com".into(),
+        name: None,
+        custom,
+    };
+    let c1 = JwtContext::from_claims(claims(ab), "t".into());
+    let c2 = JwtContext::from_claims(claims(ba), "t".into());
+    assert_eq!(c1, c2, "map equality is insertion-order independent");
+
+    let mut set = std::collections::HashSet::new();
+    set.insert(c1);
+    assert!(set.contains(&c2), "the hash must agree");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tests/session_cdata.rs
+++ b/tests/tests/session_cdata.rs
@@ -1,0 +1,31 @@
+//! Live credential sessions, the vocabulary layer: a Context owns its
+//! Session in a private set attached to the node's registry, whose
+//! union reflects the source's members for as long as they live.
+
+mod common;
+use common::*;
+
+/// The SessionSet tracks context liveness, extended through livequeries:
+/// a query keeps its credential session live after the user drops the
+/// Context handle, and the last drop culls the slot.
+#[tokio::test]
+async fn sessions_extend_through_livequeries() -> anyhow::Result<()> {
+    let node = durable_sled_setup().await?;
+    assert!(node.sessions.sessions().is_empty());
+
+    let ctx = node.context(DEFAULT_CONTEXT)?;
+    assert_eq!(node.sessions.sessions().len(), 1, "context construction attaches its source to the registry");
+
+    let second = node.context(DEFAULT_CONTEXT)?;
+    assert_eq!(node.sessions.sessions().len(), 2, "sessions are per-context, never deduplicated");
+    drop(second);
+    assert_eq!(node.sessions.sessions().len(), 1);
+
+    ctx.register_model::<Album>().await?;
+    let lq = ctx.query_wait::<AlbumView>("true").await?;
+    drop(ctx);
+    assert_eq!(node.sessions.sessions().len(), 1, "a live query extends its session past the context drop");
+    drop(lq);
+    assert!(node.sessions.sessions().is_empty(), "the last holder's drop removes the source from the union");
+    Ok(())
+}


### PR DESCRIPTION
The first layer of the live-credential-sessions stack: the session vocabulary and the live-source structure, landable on its own because the reactions to credential change (re-permission, teardown) stay in the next layer.

**The vocabulary.** `Session` is a reactive cell holding the context data one principal acts under: cloning shares it, `update` replaces it in place, and an update comparing equal to the current value is a complete no-op (`ContextData`'s `Eq` is operational identity, documented on the trait). `SessionSet` is the one credential source everywhere a credential used to be baked in: contexts, livequeries, gap fetchers, the relay's pending content, and the server's standing queries. A set owns its member sessions, and sets attach to sets as live union edges: additions, removals, and member updates propagate to attached parents, cycle-forming edges are refused, and a dropped set detaches from its parents. `Node::context` accepts anything convertible into a set (a bare credential, a session, a set), and every context's source attaches to the node's registry set, which stays a continuous superset of the sessions in use on the node.

**Reads and writes.** Read operations pin one credential snapshot per operation, so the composed checks (collection gate, predicate narrowing) come from one policy world. Write operations require the source to hold exactly one current session, because one write cannot be attributed to two credentials; an empty source and a several-session source are refused with distinct messages.

**The server side.** The peer subscription server owns each standing query's session set, minting it at first subscribe and sharing it with the query's gap fetcher, which reads it at fetch time. A re-subscribe re-validates under the peer's current credentials and refreshes the standing session in place; the equality gate makes an identical credential a no-op. The reactor takes no node or credential arguments for any of this: the subscription handler fetches the included entities and constructs the gap fetcher beside the session mint, and the reactor pipeline registers the query, runs the versioned update flow, and fills gaps using what it is handed.

**Equality.** JwtContext drops its hand-rolled subject-only equality and hash (a 22-line impl in extensions/jwt-auth/src/context.rs comparing only `claims.sub`) for derived full-value `Eq` and `Hash`, with JwtClaims deriving both so serde_json's total implementations carry the value comparison.

**Deliberately not here, arriving with the re-permission layer (#426):** tearing down a standing query when re-validation denies it (the claw-back and the version floor that guards out-of-order re-subscribes), re-deriving live query selections on credential change, and the jwt union that narrows a predicate once per authorized context. Multi-credential subscribes stay fenced as an open decision (#432): the wire arm requires exactly one credential for now.

**Proofs:** the session.rs unit suite (set liveness, attached-set propagation, the equality-gated update, membership and member-update notification), the jwt context tests (full-value equality; hash independent of custom-claim insertion order), and tests/tests/session_cdata.rs (sessions extend through livequeries and are culled by RAII). Full workspace battery: 810 tests green across 124 binaries.

**Review provenance:** built and reviewed inside the #426 process (fourteen review rounds), re-cut per the maintainer's layering ruling into structure here and reactions there, then redesigned end-to-end with the maintainer in-session (the enum of credential sources and the holder types collapsed into the one set type; registration became live attachment edges; the reactor lost its credential arguments) and re-reviewed by two independent read-only passes. #426 will be restacked over this branch and absorbs everything in the deliberately-not-here list.
