### PR TITLE
jwt-auth: filter_predicate unions every authorized context's slice

### DIFF
--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -166,6 +166,7 @@ pub trait PolicyAgent: Clone + Send + Sync + 'static {
     where C: Iterable<Self::ContextData>;
 
     /// Filter a predicate based on the context data
+    /// An implementation may refuse a caller holding no authorized context, so callers gate on can_access_collection first.
     fn filter_predicate<C>(&self, data: &C, collection: &proto::CollectionId, predicate: Predicate) -> Result<Predicate, AccessDenied>
     where C: Iterable<Self::ContextData>;
 

--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -243,20 +243,65 @@ impl PolicyAgent for JwtAgent {
             return Ok(predicate);
         }
 
-        let claims = data
-            .iterable()
-            .find_map(|ctx| match ctx {
-                JwtContext::User { claims, .. } => Some(claims),
-                _ => None,
-            })
-            .ok_or(AccessDenied::ByPolicy("No authenticated context for row filtering"))?;
+        // A caller holding several credentials may read what any one of them
+        // may read, so the query is narrowed to the union of the per-context
+        // slices — the same any-of admission enforce_read_scope applies row by
+        // row. Narrowing by one context alone would drop rows the caller is
+        // entitled to, and a single-credential caller still gets exactly its
+        // own slice. The caller's predicate stays factored in front of the
+        // union — P AND (s1 OR s2), never (P AND s1) OR (P AND s2) — because a
+        // storage planner reads indexable terms off the top-level conjunction
+        // and treats an Or as one opaque term it can only scan. A credential
+        // whose scope cannot be constructed — its filter names a claim the
+        // token does not carry — contributes nothing, warned about rather than
+        // fatal: the union means whatever any resolvable, authorized credential
+        // admits. enforce_read_scope skips such a credential the same way, on
+        // purpose, so neither half's answer turns on the order the caller
+        // happens to present its credentials in. A caller whose every
+        // credential is skipped leaves no slice and is refused below, exactly
+        // as a caller holding nothing authorized is.
+        let mut slices = Vec::new();
+        for ctx in data.iterable() {
+            let JwtContext::User { claims, .. } = ctx else {
+                continue;
+            };
+            // Only authorized contexts contribute, matching the collection
+            // check enforce_read_scope makes before evaluating a context's
+            // scope: a credential that cannot reach the collection must not
+            // widen the query on its own account.
+            if !state.config.can_access_collection(ctx.roles(), collection) {
+                continue;
+            }
 
-        let mut result = predicate;
-        for filter in scoped_predicates(&state.config, collection.as_str(), claims, ScopeAccess::Read)? {
-            result = Predicate::And(Box::new(result), Box::new(filter));
+            let scope = match scoped_predicates(&state.config, collection.as_str(), claims, ScopeAccess::Read) {
+                Ok(scope) => scope,
+                Err(err) => {
+                    tracing::warn!("skipping credential with unresolvable read scope for {collection}: {err}");
+                    continue;
+                }
+            };
+
+            let mut filters = scope.into_iter();
+            let Some(first) = filters.next() else {
+                // No scope constrains this credential, so it may read every row
+                // the caller asked for and the union can be nothing narrower
+                // than the caller's own predicate.
+                return Ok(predicate);
+            };
+            let slice = filters.fold(first, |conjunction, filter| Predicate::And(Box::new(conjunction), Box::new(filter)));
+            // Equal-valued credentials are legal and yield equal slices;
+            // repeating one costs evaluation and index extraction without
+            // admitting a single extra row.
+            if !slices.contains(&slice) {
+                slices.push(slice);
+            }
         }
 
-        Ok(result)
+        let Some(union) = slices.into_iter().reduce(|union, next| Predicate::Or(Box::new(union), Box::new(next))) else {
+            return Err(AccessDenied::ByPolicy("No authorized context for row filtering"));
+        };
+        // Slice order is load-bearing: evaluate tries an Or's left branch first, in the order enforce_read_scope walks the same contexts.
+        Ok(Predicate::And(Box::new(predicate), Box::new(union)))
     }
 
     fn check_read<C>(
@@ -385,8 +430,21 @@ where C: Iterable<JwtContext> {
             continue;
         }
 
+        // Matching filter_predicate deliberately: a credential whose scope
+        // cannot be constructed admits no row and denies none either, so which
+        // credential the caller lists first cannot change the answer. Debug,
+        // not warn: this runs once per row, and the query-time half already
+        // warns once per query about the same credential.
+        let scope = match scoped_predicates(config, entity.collection.as_str(), claims, ScopeAccess::Read) {
+            Ok(scope) => scope,
+            Err(err) => {
+                tracing::debug!("skipping credential with unresolvable read scope for {}: {err}", entity.collection);
+                continue;
+            }
+        };
+
         let mut allowed = true;
-        for predicate in scoped_predicates(config, entity.collection.as_str(), claims, ScopeAccess::Read)? {
+        for predicate in scope {
             match evaluate_predicate(entity, &predicate) {
                 Ok(true) => {}
                 Ok(false) => {

--- a/extensions/jwt-auth/tests/filter_predicate_tests.rs
+++ b/extensions/jwt-auth/tests/filter_predicate_tests.rs
@@ -1,11 +1,18 @@
 mod common;
 
 use ankql::ast::Predicate;
-use ankurah_core::policy::PolicyAgent;
-use ankurah_jwt_auth::{JwtAgent, JwtClaims, JwtContext, JwtKeys, PolicyConfig};
-use ankurah_proto::CollectionId;
+use ankurah_core::{
+    policy::{AccessDenied, PolicyAgent},
+    property::backend::{LWWBackend, PropertyBackend},
+    selection::filter::{evaluate_predicate, Filterable},
+    util::Iterable,
+    value::Value,
+};
+use ankurah_jwt_auth::{JwtAgent, JwtClaims, JwtContext, JwtKeys, PolicyConfig, SigningKeys};
+use ankurah_proto::{self as proto, CollectionId};
 use common::{blog_config_path, make_predicate};
 use jwt_simple::prelude::Duration;
+use std::collections::BTreeMap;
 
 /// Root context returns predicate unchanged (bypasses all filtering)
 #[test]
@@ -189,4 +196,444 @@ fn test_filter_predicate_injection_payload_is_inert() {
         }
         other => panic!("Expected AND predicate, got: {:?}", other),
     }
+}
+
+// ---- multi-credential filtering ------------------------------------------
+//
+// A context set may carry several credentials, and check_read admits a row
+// that ANY authorized credential may read. These cases hold the query-time
+// narrowing to that same standard: the rows the filtered predicate admits
+// must be the rows check_read would admit, no fewer and no more.
+
+/// A post to ask the filtered predicate about. Which rows survive the filter
+/// is the contract, so these tests evaluate the result; they assert on its
+/// shape only where the claim itself is about shape — that a lone credential
+/// is not Or-wrapped, and that an unrestricted credential collapses the union
+/// back to the caller's own predicate.
+#[derive(Clone, Copy)]
+struct Post {
+    author: &'static str,
+    title: &'static str,
+}
+
+impl Filterable for Post {
+    fn collection(&self) -> &str { "post" }
+
+    fn value(&self, name: &str) -> Option<Value> {
+        match name {
+            "author" => Some(Value::String(self.author.to_string())),
+            "title" => Some(Value::String(self.title.to_string())),
+            _ => None,
+        }
+    }
+}
+
+fn admits(predicate: &Predicate, post: Post) -> bool {
+    evaluate_predicate(&post, predicate).expect("filtered predicate must be evaluable against a post")
+}
+
+/// A blog credential holding a single role, signed by `keys`.
+fn blog_context(keys: &SigningKeys, sub: &str, role: &str) -> JwtContext {
+    let claims = common::make_claims(sub, &[role], &format!("{sub}@blog.com"));
+    let token = common::sign_token(keys, &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+/// The same post as a stored row. check_read reads an entity's fields out of
+/// a serialized state, so the differential test below hands both sides one
+/// row rather than two hand-written copies of it.
+fn post_state(post: Post) -> proto::State {
+    let backend = LWWBackend::new();
+    backend.set("author".into(), Some(Value::String(post.author.to_string())));
+    backend.set("title".into(), Some(Value::String(post.title.to_string())));
+    let operations = backend.to_operations().expect("LWW diff must serialize").expect("both properties were just set");
+    // A state buffer carries only values an event committed, so the writes are
+    // handed the identity of a synthetic one.
+    backend.apply_operations_with_event(&operations, proto::EventId::from_bytes([1u8; 32])).expect("LWW diff must apply");
+    let buffer = backend.to_state_buffer().expect("committed LWW values must serialize");
+    proto::State { state_buffers: proto::StateBuffers(BTreeMap::from([("lww".to_string(), buffer)])), ..Default::default() }
+}
+
+/// check_read is the row-by-row authority the filtered predicate stands in for
+/// on the durable fetch and livequery paths, which never call it. For each
+/// row: the filter admits it exactly when the caller asked for it and
+/// check_read would hand it over.
+fn assert_agrees_with_check_read<C: Iterable<JwtContext>>(agent: &JwtAgent, contexts: &C, base: &Predicate, rows: &[Post]) {
+    let collection = CollectionId::from("post");
+    let filtered = agent.filter_predicate(contexts, &collection, base.clone()).expect("every scenario here yields a filter");
+
+    for row in rows {
+        let readable = agent.check_read(contexts, &proto::EntityId::new(), &collection, &post_state(*row)).is_ok();
+        let selected = admits(base, *row);
+        assert_eq!(
+            admits(&filtered, *row),
+            readable && selected,
+            "post {}/{}: check_read says readable={}, the caller's predicate says selected={}, filter is {}",
+            row.author,
+            row.title,
+            readable,
+            selected,
+            filtered
+        );
+    }
+}
+
+/// One credential yields exactly its own scope AND-ed onto the caller's
+/// predicate — the union must leave a single-credential query untouched.
+#[test]
+fn test_filter_predicate_single_context_parity() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+
+    let ctx = blog_context(&keys, "author-42", "Author");
+    let collection = CollectionId::from("post");
+
+    let result = agent.filter_predicate(&ctx, &collection, make_predicate("title = 'hello'")).unwrap();
+
+    assert_eq!(result, make_predicate("title = 'hello' AND author = 'author-42'"), "a lone credential's narrowing must be unwrapped");
+}
+
+/// Two credentials see the union of their slices: each author's own posts
+/// pass, and the caller's predicate still binds both branches.
+#[test]
+fn test_filter_predicate_unions_across_contexts() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+
+    let contexts = vec![blog_context(&keys, "author-1", "Author"), blog_context(&keys, "author-2", "Author")];
+    let collection = CollectionId::from("post");
+
+    let result = agent.filter_predicate(&contexts, &collection, make_predicate("title = 'hello'")).unwrap();
+
+    assert!(admits(&result, Post { author: "author-1", title: "hello" }), "the first credential's posts are readable");
+    assert!(admits(&result, Post { author: "author-2", title: "hello" }), "the second credential's posts are readable too");
+    assert!(!admits(&result, Post { author: "author-3", title: "hello" }), "a third author's posts belong to neither credential");
+    assert!(!admits(&result, Post { author: "author-1", title: "other" }), "the caller's own predicate still binds every branch");
+}
+
+/// A credential the scope rule does not constrain (Editor holds manage_posts)
+/// may read every post the caller's predicate selects, so the union collapses
+/// to that predicate: no wider than what the editor could read alone, and no
+/// narrower than the author's branch it swallows.
+#[test]
+fn test_filter_predicate_unrestricted_context_collapses_union() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+
+    let contexts = vec![blog_context(&keys, "author-42", "Author"), blog_context(&keys, "editor-1", "Editor")];
+    let collection = CollectionId::from("post");
+    let predicate = make_predicate("title = 'hello'");
+
+    let result = agent.filter_predicate(&contexts, &collection, predicate.clone()).unwrap();
+
+    assert_eq!(result, predicate, "an unrestricted credential leaves nothing to union");
+    assert!(admits(&result, Post { author: "someone-else", title: "hello" }), "the editor may read posts it did not author");
+    assert!(admits(&result, Post { author: "author-42", title: "hello" }), "the author's own posts stay readable");
+    assert!(!admits(&result, Post { author: "someone-else", title: "other" }), "the caller's own predicate still binds");
+}
+
+/// Three credentials union three ways, and every branch stays under the
+/// caller's predicate.
+#[test]
+fn test_filter_predicate_unions_three_contexts() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+
+    let contexts = vec![
+        blog_context(&keys, "author-1", "Author"),
+        blog_context(&keys, "author-2", "Author"),
+        blog_context(&keys, "author-3", "Author"),
+    ];
+    let collection = CollectionId::from("post");
+
+    let result = agent.filter_predicate(&contexts, &collection, make_predicate("title = 'hello'")).unwrap();
+
+    assert!(admits(&result, Post { author: "author-1", title: "hello" }), "the first credential's posts are readable");
+    assert!(admits(&result, Post { author: "author-2", title: "hello" }), "the second credential's posts are readable");
+    assert!(admits(&result, Post { author: "author-3", title: "hello" }), "the third credential's posts are readable");
+    assert!(!admits(&result, Post { author: "author-4", title: "hello" }), "a fourth author's posts belong to no credential in the set");
+    assert!(!admits(&result, Post { author: "author-3", title: "other" }), "the caller's own predicate still binds the last branch");
+}
+
+/// Credentials of equal value produce equal slices, and the union keeps one:
+/// the predicate a single copy would have produced.
+#[test]
+fn test_filter_predicate_deduplicates_equal_slices() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+    let collection = CollectionId::from("post");
+
+    let lone = blog_context(&keys, "author-42", "Author");
+    let single = agent.filter_predicate(&lone, &collection, make_predicate("title = 'hello'")).unwrap();
+
+    let duplicated = vec![blog_context(&keys, "author-42", "Author"), blog_context(&keys, "author-42", "Author")];
+    let result = agent.filter_predicate(&duplicated, &collection, make_predicate("title = 'hello'")).unwrap();
+
+    assert_eq!(result, single, "a repeated credential must not repeat its branch");
+}
+
+/// An empty credential set is refused on a scoped collection — there is no
+/// slice to union — but the no-scope early return runs before any credential
+/// is read, so an unscoped collection still returns the caller's predicate
+/// untouched. The refusal is narrower than "a caller with no authorized
+/// context is always denied".
+#[test]
+fn test_filter_predicate_empty_context_set() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys, blog_config_path()).unwrap();
+
+    let contexts: Vec<JwtContext> = Vec::new();
+    let predicate = make_predicate("title = 'hello'");
+
+    let scoped = agent.filter_predicate(&contexts, &CollectionId::from("post"), predicate.clone());
+    assert!(scoped.is_err(), "post is scoped, so an empty set has no authorized slice, got: {:?}", scoped);
+
+    let unscoped = agent.filter_predicate(&contexts, &CollectionId::from("comment"), predicate.clone()).unwrap();
+    assert_eq!(unscoped, predicate, "comment carries no scope rules, so the query is returned before any credential is read");
+}
+
+/// An authenticated credential that cannot reach the collection contributes
+/// no branch — its scope must not stand in for an authorized credential's,
+/// whichever order the set iterates in. Reader lacks view_posts, and listing
+/// it first is the case the old first-match narrowing got wrong outright.
+#[test]
+fn test_filter_predicate_ignores_unauthorized_context() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+
+    let contexts = vec![blog_context(&keys, "reader-1", "Reader"), blog_context(&keys, "author-42", "Author")];
+    let collection = CollectionId::from("post");
+
+    let result = agent.filter_predicate(&contexts, &collection, make_predicate("title = 'hello'")).unwrap();
+
+    assert!(admits(&result, Post { author: "author-42", title: "hello" }), "the authorized credential's posts are readable");
+    assert!(!admits(&result, Post { author: "reader-1", title: "hello" }), "the unauthorized credential opens no window of its own");
+}
+
+/// A set with no authorized credential is refused outright, the same
+/// fail-closed answer the unauthenticated case gets.
+#[test]
+fn test_filter_predicate_no_authorized_context_denied() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+
+    let ctx = blog_context(&keys, "reader-1", "Reader");
+    let collection = CollectionId::from("post");
+
+    let result = agent.filter_predicate(&ctx, &collection, make_predicate("title = 'hello'"));
+    assert!(result.is_err(), "Reader cannot read the post collection at all, got: {:?}", result);
+}
+
+/// A privileged credential anywhere in the set bypasses filtering entirely,
+/// ahead of any union.
+#[test]
+fn test_filter_predicate_privileged_precedes_union() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+
+    let contexts = vec![blog_context(&keys, "author-42", "Author"), JwtContext::Root];
+    let predicate = make_predicate("title = 'hello'");
+    let collection = CollectionId::from("post");
+
+    let result = agent.filter_predicate(&contexts, &collection, predicate.clone()).unwrap();
+    assert_eq!(result, predicate, "Root alongside a scoped credential still returns the predicate unchanged");
+}
+
+// ---- credentials whose scope cannot be constructed ------------------------
+//
+// A scope filter names claims, and a token need not carry them. Such a
+// credential is skipped by both halves with a warning: it admits no row and
+// denies none either, so a caller loses nothing by presenting it alongside a
+// credential that works. A caller holding nothing but these is refused.
+
+/// A blog whose post scope names a claim a token need not carry: the author a
+/// credential is confined to lives in a custom claim, so a token minted
+/// without it has a read scope that cannot be constructed at all. The shipped
+/// fixture cannot express that — its scope reads $jwt.sub, which every token
+/// carries — and these cases build the policy inline the way the neighbours
+/// above do.
+fn custom_author_agent(keys: &SigningKeys) -> JwtAgent {
+    let config_json = r#"{
+        "roles": {
+            "Author": ["view_posts", "create_posts"],
+            "Editor": ["view_posts", "manage_posts"]
+        },
+        "collections": {
+            "post": {
+                "read": "view_posts",
+                "write": "manage_posts",
+                "scope": [
+                    {
+                        "filter": "author = $jwt.custom.author_id",
+                        "unless_privilege": "manage_posts"
+                    }
+                ]
+            }
+        }
+    }"#;
+    let config: PolicyConfig = serde_json::from_str(config_json).unwrap();
+
+    let agent = JwtAgent::new_ephemeral();
+    agent.update_config(config);
+    agent.set_keys(JwtKeys::Signing(keys.clone()));
+    agent
+}
+
+/// An Author credential carrying the author_id claim its read scope names.
+fn resolvable_author(keys: &SigningKeys, author_id: &str) -> JwtContext {
+    let mut claims = common::make_claims(author_id, &["Author"], &format!("{author_id}@blog.com"));
+    claims.custom.insert("author_id".to_string(), serde_json::Value::String(author_id.to_string()));
+    let token = common::sign_token(keys, &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+/// An Author credential minted without that claim: authorized for the
+/// collection, but its read scope cannot be constructed.
+fn unresolvable_author(keys: &SigningKeys, sub: &str) -> JwtContext {
+    let claims = common::make_claims(sub, &["Author"], &format!("{sub}@blog.com"));
+    let token = common::sign_token(keys, &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+/// A credential whose scope cannot be constructed contributes nothing, and the
+/// query still runs: it is narrowed to what the working credential may read,
+/// exactly as if the broken credential had never been presented.
+#[test]
+fn test_filter_predicate_skips_unresolvable_credential() {
+    let keys = common::test_keys();
+    let agent = custom_author_agent(&keys);
+    let collection = CollectionId::from("post");
+    let predicate = make_predicate("title = 'hello'");
+
+    let contexts = vec![unresolvable_author(&keys, "no-claim-1"), resolvable_author(&keys, "author-42")];
+
+    let result =
+        agent.filter_predicate(&contexts, &collection, predicate.clone()).expect("one unresolvable credential must not refuse the query");
+
+    assert!(admits(&result, Post { author: "author-42", title: "hello" }), "the working credential's posts stay readable");
+    assert!(!admits(&result, Post { author: "no-claim-1", title: "hello" }), "the skipped credential opens no window of its own");
+    assert!(!admits(&result, Post { author: "author-42", title: "other" }), "the caller's own predicate still binds");
+    assert_eq!(
+        result,
+        agent.filter_predicate(&resolvable_author(&keys, "author-42"), &collection, predicate).unwrap(),
+        "the broken credential must cost the caller nothing at all"
+    );
+}
+
+/// A caller whose every credential has an unresolvable scope has no slice left
+/// to union, and is refused by the query-time half and denied by the row-time
+/// half alike — the same fail-closed answer a caller holding nothing
+/// authorized gets.
+#[test]
+fn test_filter_predicate_all_unresolvable_refused() {
+    let keys = common::test_keys();
+    let agent = custom_author_agent(&keys);
+    let collection = CollectionId::from("post");
+    let predicate = make_predicate("title = 'hello'");
+    let row = post_state(Post { author: "no-claim-1", title: "hello" });
+
+    // Naming the refusals pins where they come from: the skip must walk off the
+    // end of the loop into the union's own denial, never propagate the
+    // resolution error it swallowed.
+    let lone = unresolvable_author(&keys, "no-claim-1");
+    let filtered = agent.filter_predicate(&lone, &collection, predicate.clone());
+    assert!(
+        matches!(filtered, Err(AccessDenied::ByPolicy("No authorized context for row filtering"))),
+        "a lone unresolvable credential leaves nothing to read by, got: {:?}",
+        filtered
+    );
+    let read = agent.check_read(&lone, &proto::EntityId::new(), &collection, &row);
+    assert!(
+        matches!(read, Err(AccessDenied::ByPolicy("Read outside permitted scope"))),
+        "the row-time half must deny the caller the query-time half refused, got: {:?}",
+        read
+    );
+
+    let several = vec![unresolvable_author(&keys, "no-claim-1"), unresolvable_author(&keys, "no-claim-2")];
+    let filtered = agent.filter_predicate(&several, &collection, predicate);
+    assert!(
+        matches!(filtered, Err(AccessDenied::ByPolicy("No authorized context for row filtering"))),
+        "several unresolvable credentials are no better than one, got: {:?}",
+        filtered
+    );
+    let read = agent.check_read(&several, &proto::EntityId::new(), &collection, &row);
+    assert!(
+        matches!(read, Err(AccessDenied::ByPolicy("Read outside permitted scope"))),
+        "the row-time half must deny that caller too, got: {:?}",
+        read
+    );
+}
+
+/// Both halves skip the same credential, so the answer cannot depend on the
+/// order the caller presents its credentials in — the property the skip exists
+/// for.
+#[test]
+fn test_filter_predicate_unresolvable_order_independent() {
+    let keys = common::test_keys();
+    let agent = custom_author_agent(&keys);
+    let collection = CollectionId::from("post");
+    let predicate = make_predicate("title = 'hello'");
+
+    let broken_first = vec![unresolvable_author(&keys, "no-claim-1"), resolvable_author(&keys, "author-42")];
+    let broken_last = vec![resolvable_author(&keys, "author-42"), unresolvable_author(&keys, "no-claim-1")];
+
+    let first = agent.filter_predicate(&broken_first, &collection, predicate.clone()).unwrap();
+    let last = agent.filter_predicate(&broken_last, &collection, predicate).unwrap();
+    assert_eq!(first, last, "the filtered query must not depend on credential order");
+
+    for row in [Post { author: "author-42", title: "hello" }, Post { author: "no-claim-1", title: "hello" }] {
+        let state = post_state(row);
+        assert_eq!(
+            agent.check_read(&broken_first, &proto::EntityId::new(), &collection, &state).is_ok(),
+            agent.check_read(&broken_last, &proto::EntityId::new(), &collection, &state).is_ok(),
+            "post {}/{}: the row-time half must not depend on credential order either",
+            row.author,
+            row.title
+        );
+    }
+}
+
+/// The row-level contract this section claims, executed: over every credential
+/// set the cases above assert shape or row survival for, the filtered
+/// predicate and check_read admit the same posts.
+#[test]
+fn test_filter_predicate_agrees_with_check_read() {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), blog_config_path()).unwrap();
+    let base = make_predicate("title = 'hello'");
+    let rows = [
+        Post { author: "author-1", title: "hello" },
+        Post { author: "author-2", title: "hello" },
+        Post { author: "author-42", title: "hello" },
+        Post { author: "reader-1", title: "hello" },
+        Post { author: "someone-else", title: "hello" },
+        Post { author: "author-1", title: "other" },
+        Post { author: "someone-else", title: "other" },
+        Post { author: "no-claim-1", title: "hello" },
+        Post { author: "no-claim-1", title: "other" },
+    ];
+
+    let lone_author = blog_context(&keys, "author-42", "Author");
+    let two_authors = vec![blog_context(&keys, "author-1", "Author"), blog_context(&keys, "author-2", "Author")];
+    let author_and_editor = vec![blog_context(&keys, "author-42", "Author"), blog_context(&keys, "editor-1", "Editor")];
+    let reader_and_author = vec![blog_context(&keys, "reader-1", "Reader"), blog_context(&keys, "author-42", "Author")];
+    let author_and_root = vec![blog_context(&keys, "author-42", "Author"), JwtContext::Root];
+
+    assert_agrees_with_check_read(&agent, &lone_author, &base, &rows);
+    assert_agrees_with_check_read(&agent, &two_authors, &base, &rows);
+    assert_agrees_with_check_read(&agent, &author_and_editor, &base, &rows);
+    assert_agrees_with_check_read(&agent, &reader_and_author, &base, &rows);
+    assert_agrees_with_check_read(&agent, &author_and_root, &base, &rows);
+
+    // The broken-plus-working pair needs a scope naming a claim a token can
+    // lack, which the blog fixture's $jwt.sub never is, so the pair rides its
+    // own policy through the same oracle. A credential skipped by one half but
+    // not the other surfaces here as a row the two disagree about, in either
+    // order the caller might present them in.
+    let custom = custom_author_agent(&keys);
+    let broken_and_working = vec![unresolvable_author(&keys, "no-claim-1"), resolvable_author(&keys, "author-42")];
+    let working_and_broken = vec![resolvable_author(&keys, "author-42"), unresolvable_author(&keys, "no-claim-1")];
+
+    assert_agrees_with_check_read(&custom, &broken_and_working, &base, &rows);
+    assert_agrees_with_check_read(&custom, &working_and_broken, &base, &rows);
 }

--- a/specs/jwt-auth/spec.md
+++ b/specs/jwt-auth/spec.md
@@ -134,7 +134,7 @@ Example: with `claims.sub = "user123"`, the filter `"assigned_to = $jwt.sub"` pa
 - An empty `PolicyConfig` (no roles, no collections) denies all access.
 - Collections not listed in the config are inaccessible to non-privileged contexts.
 - Unknown roles grant no privileges.
-- Missing claim variables in scope filters cause the query to be denied.
+- A credential whose scope filter names a claim its token does not carry contributes nothing; a caller with no resolvable, authorized credential is denied.
 
 ## JwtAgent
 
@@ -193,11 +193,14 @@ Deserializes `AuthData` back into `JwtContext`:
 
 #### `filter_predicate`
 
-- `Root` context: returns the predicate unchanged.
-- Looks up scope rules for the collection. For each rule:
-  - If `unless_privilege` is set and the user holds that privilege, the rule is skipped.
-  - Otherwise, substitutes `$jwt.*` variables in the filter string and AND-s the resulting predicate with the query.
-- No scope rules: returns the predicate unchanged.
+Narrows a query so storage returns only rows the caller may read. A caller may present several credentials (its context set) and may read any row that any one of them admits, so the query narrows to the union of per-credential scope slices -- the same any-of admission `check_read` applies row by row.
+
+- `Root` anywhere in the context set: returns the predicate unchanged.
+- No scope rules for the collection: returns the predicate unchanged. This check runs first, so an unscoped collection requires no authorized credential.
+- Otherwise walks every credential in the context set. A credential contributes nothing if it is `NoUser`, if its roles cannot access the collection, or if its scope variables cannot resolve (its filter names a claim the token does not carry -- skipped with a `tracing::warn`).
+- Each surviving credential contributes one slice: its scope rules, minus any whose `unless_privilege` it holds, `$jwt.*`-substituted from its own claims and AND-ed together. Equal slices deduplicate. A credential no rule constrains may read every row the caller asked for, so the union collapses: the caller's predicate is returned unchanged.
+- The query becomes `P AND (s1 OR s2 OR ...)` -- the caller's predicate stays factored in front of the union, where a storage planner reads indexable terms off the top-level conjunction.
+- No credential contributed a slice (none authorized, or none resolvable): the query is refused with `AccessDenied`.
 
 #### `check_event` / `check_write`
 
@@ -206,9 +209,17 @@ Deserializes `AuthData` back into `JwtContext`:
 - `NoUser`: all writes denied.
 - Otherwise: checks `can_write_collection` against the user's roles and the collection's `write` privilege.
 
-#### `check_read` / `check_read_event`
+#### `check_read`
 
-Delegates to `can_access_collection`.
+The row-level half of read scoping: admits or refuses one entity by its serialized state, where `filter_predicate` narrows the query up front.
+
+- Requires `can_access_collection`. `Root` passes unconditionally.
+- No scope rules for the collection: allowed.
+- Otherwise materializes the state into a `TemporaryEntity` (a state that cannot be evaluated is refused) and walks the caller's credentials: a credential admits the row when every one of its substituted scope predicates evaluates true, and the first admitting credential allows the read. Unauthorized and unresolvable credentials are skipped exactly as in `filter_predicate` (logged at `debug` -- the query half already warned once per query), so credential order cannot change the answer. A credential no rule constrains admits every row. A scope predicate that fails to evaluate against the row refuses the read; so does running out of credentials.
+
+#### `check_read_event`
+
+`Root` passes; otherwise delegates to `can_access_collection` for the event's collection.
 
 #### `validate_received_event` / `validate_received_state` / `attest_state` / `validate_causal_assertion`
 


### PR DESCRIPTION
Fixes a live disagreement between the two halves of the jwt read policy. `filter_predicate` narrowed every query by the FIRST authenticated context's scopes (`find_map`), while `enforce_read_scope` admits a row if ANY authorized context can read it. A context carrying several sessions is constructible since the session substrate landed, and for such a caller the query filter dropped rows the row-level check would have admitted. This matters most on the durable local fetch and livequery paths, where the filter IS the enforcement and `check_read` never runs.

**The fix.** `filter_predicate` now mirrors `enforce_read_scope`'s admission structure: skip non-User contexts, skip contexts whose roles fail `can_access_collection`, build each surviving context's scope conjunction, and return the caller's predicate ANDed with the OR-union of those slices. The shape is `P AND (s1 OR s2)`, never `(P AND s1) OR (P AND s2)`, so the planner keeps reading indexable terms off the top-level conjunction instead of scanning past one opaque OR. An authorized context with no applicable scope rules collapses the whole result to the bare caller predicate (it may read everything asked for), duplicate equal-valued credentials contribute one slice, and a caller with zero authorized contexts is refused. One authorized context degenerates to an AST identical to the old behavior, pinned by an exact-equality test.

**The error semantics are ruled (maintainer, 2026-08-04): both halves skip a credential whose scope variables cannot resolve.** A skipped credential contributes nothing, exactly like an unauthorized one, so it can only narrow the union, never widen it; a caller whose credentials are ALL unresolvable is refused by both halves, the same as having no authorized credential. This makes the filter and the row check order-independent and genuinely equivalent, where previously the row check's answer could depend on which credential a caller listed first. The query-time skip warns once per query; the row-time skip logs at debug because it runs per row and the query-time warning already carries the signal. Each half's skip is independently pinned by mutation-verified tests, including the all-unresolvable refusal and an order-independence case.

**Semantic notes:** unauthorized contexts no longer influence the filter (previously the first authenticated context's scopes applied regardless of collection authorization), and the zero-authorized refusal applies only to collections carrying scope rules; unscoped collections pass the predicate through unchanged, as before, which every call site already gates with `can_access_collection`. The trait doc on `PolicyAgent::filter_predicate` now states that precondition.

**Tests.** The suite grows from 7 to 17 cases and now executes its stated contract instead of modeling it: a differential oracle test builds real entity state and asserts, across five credential sets and seven rows, that the filtered predicate admits a row exactly when `check_read` admits it and the caller's own predicate matches. The oracle was mutation-verified: reinstating first-match narrowing fails it on precisely the dropped row. Also new: empty credential vector (refused on scoped collections, pass-through on unscoped), duplicate credentials (equal to the single-credential result), three-context union, and the unrestricted-context collapse. Full workspace battery: 820 passed, 0 failed across 124 binaries.

**Provenance.** The union half of PR #426, lifted ahead and re-derived against current main per the restack plan; reviewed pre-draft by independent Codex and Opus passes (trail: ankurah-436-review-codex.md, ankurah-436-review-opus.md in the maintainer's trail directory), whose confirmed findings this revision incorporates. Known follow-up outside this PR: specs/jwt-auth/spec.md still describes the old single-context narrowing, and its `check_read` bullet was already stale on main.
