### PR TITLE
session hardening: atomic attach, total walks, and bookkeeping that cannot leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 .vscode
 *.code-workspace
+/CLAUDE.md

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -141,7 +141,7 @@ where PA: PolicyAgent
     /// this node: each context attaches its credential source here at
     /// construction, so any state the node acts under is enumerable
     /// from one place.
-    pub sessions: SessionSet<PA::ContextData>,
+    pub(crate) sessions: SessionSet<PA::ContextData>,
 
     /// The reactor for handling subscriptions
     pub(crate) reactor: Reactor,
@@ -536,13 +536,14 @@ where
             }
             proto::NodeRequestBody::SubscribeQuery { query_id, collection, selection, version, known_matches } => {
                 let peer_state = self.peer_connections.get(&request.from).ok_or_else(|| anyhow!("Peer {} not connected", request.from))?;
-                // Reads may act under many credentials (the union), but
-                // the per-query session substrate lands with its first
-                // plural consumer (the set-backed context) — until then a
-                // subscribe carries exactly one. The empty and union
-                // verdicts stay fenced: https://github.com/ankurah/ankurah/issues/432
+                // Reads may act under many credentials (the union), and a
+                // context can already hold several: what is missing is
+                // this server accepting them, so a subscribe carries
+                // exactly one and a plural one is refused here. Admitting
+                // several — and with them the empty and union verdicts —
+                // stays fenced: https://github.com/ankurah/ankurah/issues/432
                 let cdata = cdata.iterable().exactly_one().map_err(|_| {
-                    anyhow!("SubscribeQuery currently requires exactly one cdata (plural subscriptions arrive with the set-backed context)")
+                    anyhow!("SubscribeQuery currently requires exactly one cdata (this server does not yet accept several per subscribe)")
                 })?;
                 peer_state.subscription_handler.subscribe_query(self, query_id, collection, selection, cdata, version, known_matches).await
             }
@@ -938,6 +939,19 @@ where
     /// Requires the `test-helpers` feature to be enabled.
     #[cfg(feature = "test-helpers")]
     pub fn insert_durable_peer_for_test(&self, peer_id: proto::EntityId) { self.durable_peers.insert(peer_id); }
+
+    /// TEST ONLY: Observe the session registry — the current credential
+    /// of every session backing a context on this node, in the
+    /// registry's union order. Values, not handles: observation cannot
+    /// become mutation.
+    ///
+    /// Lets tests assert membership (a context's source joining at
+    /// construction, its members leaving when the last holder drops)
+    /// while the registry itself stays core's, unreachable from outside.
+    ///
+    /// Requires the `test-helpers` feature to be enabled.
+    #[cfg(feature = "test-helpers")]
+    pub fn session_registry(&self) -> Vec<PA::ContextData> { self.sessions.current() }
 }
 
 impl<SE, PA> NodeInner<SE, PA>

--- a/core/src/peer_subscription/server.rs
+++ b/core/src/peer_subscription/server.rs
@@ -67,11 +67,44 @@ impl<CD: ContextData> SubscriptionHandler<CD> {
     pub fn subscription(&self) -> &ReactorSubscription { &self.subscription }
 
     /// Remove a predicate from this peer's subscription, releasing the
-    /// query's session with it.
+    /// query's session with it. The release does not wait on the
+    /// reactor's verdict: this teardown is also the subscribe error
+    /// path's rollback, and an unsubscribe must leave nothing behind
+    /// even when the reactor never learned of the query, so refusing to
+    /// drop the credential on a reactor error would strand it until the
+    /// peer disconnects.
     pub fn remove_predicate(&self, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
-        self.subscription.remove_predicate(query_id)?;
+        let removed = self.subscription.remove_predicate(query_id);
         self.queries.lock().unwrap_or_else(|e| e.into_inner()).remove(&query_id);
-        Ok(())
+        removed
+    }
+
+    /// Synchronize the query's standing session with the credential the
+    /// peer conveyed. The client-side session is the original; this entry
+    /// is its local reconstitution — created at first sight, updated in
+    /// place thereafter (the equality gate makes an identical conveyance a
+    /// no-op), and shared with the query's gap fetcher. Conveyance is bare
+    /// context data piggybacked on SubscribeQuery for now; a dedicated
+    /// session-synchronization vocabulary is future wire work (see the
+    /// TODO at the call site). The flag reports whether this call created
+    /// the reconstitution — the subscribe error path may only discard one
+    /// it created, never one an earlier subscribe established. The
+    /// per-query set owns exactly one session by construction; the loop is
+    /// just how that member is reached.
+    fn sync_session(&self, query_id: proto::QueryId, cdata: &CD) -> (SessionSet<CD>, bool) {
+        use std::collections::hash_map::Entry;
+        let mut queries = self.queries.lock().unwrap_or_else(|e| e.into_inner());
+        match queries.entry(query_id) {
+            Entry::Occupied(o) => {
+                let sessions = o.get().clone();
+                debug_assert_eq!(sessions.sessions().len(), 1, "the per-query set owns exactly one session");
+                for session in sessions.sessions() {
+                    session.update(cdata.clone());
+                }
+                (sessions, false)
+            }
+            Entry::Vacant(v) => (v.insert(cdata.clone().into()).clone(), true),
+        }
     }
 
     /// Handle a subscription request for this peer.
@@ -99,33 +132,70 @@ impl<CD: ContextData> SubscriptionHandler<CD> {
         // https://github.com/ankurah/ankurah/pull/426
         node.policy_agent.can_access_collection(cdata, &collection_id)?;
         selection.predicate = node.policy_agent.filter_predicate(cdata, &collection_id, selection.predicate)?;
-        let storage_collection = node.collections.get(&collection_id).await?;
 
         // TODO: consider separating session updating from SubscribeQuery,
         // reserving that request for actual subscription (selection)
         // updates and carrying credential refresh on its own wire
         // message once the protocol grows a session-update vocabulary.
-        //
-        // The query's credential source: minted at first subscribe,
-        // shared with the gap fetcher, refreshed with the re-validated
-        // credentials on re-subscribe (the equality gate makes an
-        // identical credential a no-op).
-        let sessions: SessionSet<CD> = {
-            use std::collections::hash_map::Entry;
-            let mut queries = self.queries.lock().unwrap_or_else(|e| e.into_inner());
-            match queries.entry(query_id) {
-                Entry::Occupied(o) => {
-                    let sessions = o.get().clone();
-                    for session in sessions.sessions() {
-                        session.update(cdata.clone());
-                    }
-                    sessions
-                }
-                Entry::Vacant(v) => v.insert(cdata.clone().into()).clone(),
-            }
-        };
+        let (sessions, session_created) = self.sync_session(query_id, cdata);
 
-        let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(node, sessions));
+        // Everything past the session sync funnels through one fallible
+        // call so the cleanup below has a single exit to guard. A failed
+        // first subscribe tears back down everything it registered — the
+        // map entry and the reactor query — so the peer holds no
+        // subscription and no credential outlives the attempt that
+        // created it. A failed re-subscribe leaves the standing query in
+        // place (the claw-back work in #426 owns that seam).
+        let response = self.subscribe_query_inner(node, query_id, collection_id, selection, &sessions, cdata, version, known_matches).await;
+
+        if response.is_err() && session_created {
+            let mut queries = self.queries.lock().unwrap_or_else(|e| e.into_inner());
+            // Identity, not a flag: only take back the entry if it is
+            // still the set this call created. A concurrent subscribe may
+            // have re-created it after an interleaved removal, and its
+            // registration is not ours to tear down. (Two in-flight
+            // subscribes for the SAME id can still interleave so that
+            // this teardown removes an adopter's success; the
+            // generation-guarded fix rides the claw-back work in #426.)
+            if queries.get(&query_id).is_some_and(|entry| entry.ptr_eq(&sessions)) {
+                queries.remove(&query_id);
+                drop(queries);
+                // The reactor may already hold the query from an upsert
+                // that succeeded before the failure; tear it down too,
+                // or its gap fetcher keeps authorizing reads under the
+                // failed attempt's credential forever. Tolerates the
+                // query never having been installed.
+                let _ = self.subscription.remove_predicate(query_id);
+            }
+        }
+        response
+    }
+
+    /// Register the query and build its QuerySubscribed response: fetch
+    /// the storage collection, install the gap fetcher over the query's
+    /// session, run the versioned update flow, attest and expand the
+    /// initial states, and generate deltas against the peer's known
+    /// matches. Split from subscribe_query so every fallible step
+    /// funnels to one exit: the caller discards the reconstitution it
+    /// created before propagating an error.
+    async fn subscribe_query_inner<SE, PA>(
+        &self,
+        node: &Node<SE, PA>,
+        query_id: proto::QueryId,
+        collection_id: proto::CollectionId,
+        selection: ankql::ast::Selection,
+        sessions: &SessionSet<CD>,
+        cdata: &PA::ContextData,
+        version: u32,
+        known_matches: Vec<proto::KnownEntity>,
+    ) -> anyhow::Result<proto::NodeResponseBody>
+    where
+        SE: StorageEngine + Send + Sync + 'static,
+        PA: PolicyAgent<ContextData = CD> + Send + Sync + 'static,
+    {
+        let storage_collection = node.collections.get(&collection_id).await?;
+
+        let gap_fetcher: std::sync::Arc<dyn GapFetcher<Entity>> = std::sync::Arc::new(QueryGapFetcher::new(node, sessions.clone()));
 
         // Add or update the query - idempotent, works whether query exists or not
         let included_entities = node.fetch_entities_from_local(&collection_id, &selection).await?;

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -51,6 +51,24 @@ pub use crate::schema::registration::{PlannedModelPropertyMembership, PlannedUpd
 /// - checking access for requests. If approved, yield a ContextData
 /// - attesting events for requests that were approved
 /// - validating attestations for events
+///
+/// The four checks that take a credential collection
+/// ([`Self::can_access_collection`], [`Self::filter_predicate`],
+/// [`Self::check_read`], [`Self::check_read_event`]) can be handed
+/// several credentials, one, or none. An implementation must decide the
+/// empty case deliberately instead of inheriting whatever its loops
+/// happen to do with it: with no credential there is no principal to
+/// attribute the access to, so fail closed unless permissiveness is the
+/// point. The JWT agent in extensions/jwt-auth denies it wherever
+/// admission is decided — `can_access_collection`, and `check_read` and
+/// `check_read_event` which both reach that check (the first as its
+/// opening step, the second after the privileged short-circuit) — carving out only
+/// the policy collection, which is granted before any credential is
+/// consulted. (Its `filter_predicate` does return the predicate
+/// unnarrowed when the collection has no scope rules, which admits
+/// nobody: every caller passes `can_access_collection` before it.)
+/// [`PermissiveAgent`] allows the empty collection, that being the whole
+/// of what it is for.
 #[async_trait]
 pub trait PolicyAgent: Clone + Send + Sync + 'static {
     /// The context type that will be used for all resource requests.
@@ -275,7 +293,7 @@ impl PolicyAgent for PermissiveAgent {
 
     fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId) -> Result<(), AccessDenied>
     where C: Iterable<Self::ContextData> {
-        // PermissiveAgent allows access if any context is provided
+        // PermissiveAgent allows regardless of which credentials are supplied, including none
         Ok(())
     }
 
@@ -289,13 +307,13 @@ impl PolicyAgent for PermissiveAgent {
     where
         C: Iterable<Self::ContextData>,
     {
-        // PermissiveAgent allows access if any context is provided
+        // PermissiveAgent allows regardless of which credentials are supplied, including none
         Ok(())
     }
 
     fn check_read_event<C>(&self, _data: &C, _event: &Attested<proto::Event>) -> Result<(), AccessDenied>
     where C: Iterable<Self::ContextData> {
-        // PermissiveAgent allows access if any context is provided
+        // PermissiveAgent allows regardless of which credentials are supplied, including none
         Ok(())
     }
 
@@ -315,7 +333,7 @@ impl PolicyAgent for PermissiveAgent {
 
     fn filter_predicate<C>(&self, _data: &C, _collection: &proto::CollectionId, predicate: Predicate) -> Result<Predicate, AccessDenied>
     where C: Iterable<Self::ContextData> {
-        // PermissiveAgent allows access if any context is provided
+        // PermissiveAgent allows regardless of which credentials are supplied, including none
         Ok(predicate)
     }
 

--- a/core/src/reactor.rs
+++ b/core/src/reactor.rs
@@ -131,6 +131,15 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
         Ok(())
     }
 
+    /// The subscription registered under `id`, cloned out of the map so
+    /// this module's children work off a handle rather than reaching
+    /// through the reactor into its lock. Private, which reaches every
+    /// descendant module: `Subscription` itself is no more visible than
+    /// that.
+    fn subscription(&self, id: ReactorSubscriptionId) -> Option<Subscription<E, Ev>> {
+        self.0.subscriptions.lock().unwrap().get(&id).cloned()
+    }
+
     /// Remove a predicate from a subscription
     pub fn remove_query(&self, subscription_id: ReactorSubscriptionId, query_id: proto::QueryId) -> Result<(), SubscriptionError> {
         let subscription = {
@@ -140,23 +149,14 @@ impl<E: AbstractEntity + Filterable + Send + 'static, Ev: Clone + Send + 'static
 
         // Remove the query from the subscription
         let query_state = subscription.remove_query(query_id).ok_or(SubscriptionError::PredicateNotFound)?;
-        self.cleanup_removed_query(subscription_id, query_id, &query_state);
-        Ok(())
-    }
 
-    /// Watcher teardown shared by the removal paths.
-    fn cleanup_removed_query(
-        &self,
-        subscription_id: ReactorSubscriptionId,
-        query_id: proto::QueryId,
-        query_state: &subscription_state::QueryState<E>,
-    ) {
         // Remove from watchers (only if selection was set)
         if let Some(selection) = &query_state.selection {
             let mut watcher_set = self.0.watcher_set.lock().unwrap();
             let watcher_id = (subscription_id, query_id);
             watcher_set.recurse_predicate_watchers(&query_state.collection_id, &selection.predicate, watcher_id, WatcherOp::Remove);
         }
+        Ok(())
     }
 
     /// Add entity subscriptions to a subscription

--- a/core/src/reactor/subscription.rs
+++ b/core/src/reactor/subscription.rs
@@ -93,13 +93,11 @@ impl ReactorSubscription<crate::entity::Entity, ankurah_proto::Attested<ankurah_
         gap_fetcher: std::sync::Arc<dyn crate::reactor::fetch_gap::GapFetcher<crate::entity::Entity>>,
         version: u32,
     ) -> anyhow::Result<Vec<crate::entity::Entity>> {
-        let subscription = {
-            let subscriptions = self.0.reactor.0.subscriptions.lock().unwrap();
-            subscriptions
-                .get(&self.0.subscription_id)
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("Subscription {:?} not found", self.0.subscription_id))?
-        };
+        let subscription = self
+            .0
+            .reactor
+            .subscription(self.0.subscription_id)
+            .ok_or_else(|| anyhow::anyhow!("Subscription {:?} not found", self.0.subscription_id))?;
 
         // Register if new or get the existing resultset.
         let resultset = subscription.register_or_get_query(query_id, collection_id.clone(), gap_fetcher);

--- a/core/src/schema/registration.rs
+++ b/core/src/schema/registration.rs
@@ -143,7 +143,10 @@ pub enum RegistrationError {
     /// context could not act as a single principal.
     #[error("registration refused by policy: {0}")]
     PolicyDenied(
-        /// The policy agent's denial.
+        /// The refusal, from either origin: the policy agent's verdict
+        /// on the resolved plan, or the credential source's own refusal
+        /// when it holds no session or several and so cannot name the
+        /// single principal a registration acts as.
         #[from]
         AccessDenied,
     ),

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -78,11 +78,16 @@ impl<CD: ContextData> Session<CD> {
     /// re-permission. A token refresh carries a new token, compares
     /// unequal, and notifies holders and change subscribers.
     pub fn update(&self, cdata: CD) {
-        // The compare and the store take the lock separately; a racing
-        // update can only make this comparison stale in ways that
-        // linearize legally (a suppressed call was a no-op against SOME
-        // current value, and the racing update's own notification covers
-        // the change).
+        // The compare and the store take the lock separately, on
+        // purpose: a gate held across the store would still be held
+        // across the broadcast that follows it, and a subscriber may
+        // call update from its own callback, which would deadlock. So
+        // the suppression below is best effort — two threads storing
+        // the same new value can both read the old one and both store,
+        // firing twice for one effective change. That costs nothing: a
+        // subscriber reads the current value when its callback runs,
+        // rather than being handed the value the writer stored, so the
+        // duplicate re-reads a value that is already correct.
         if self.0.current.value() == cdata {
             return;
         }
@@ -162,6 +167,20 @@ struct SessionSetInner<CD: ContextData> {
     parents: Mutex<Vec<Weak<SessionSetInner<CD>>>>,
 }
 
+/// Serializes [`SessionSet::attach`] across every set of every
+/// credential type: the check that an edge would not form a cycle and
+/// the installation of that edge happen under this one lock, so no two
+/// attaches can each find the graph acyclic and then both make it
+/// cyclic. One global lock covers all `ContextData` types (a static
+/// cannot be generic), which costs nothing — attaching happens when a
+/// context is constructed, not on any hot path.
+// Held across `reaches`, which can drop another set's last handle
+// mid-walk and run its Drop notification under this lock: a subscriber
+// re-entering `attach` from that callback would self-deadlock. No
+// SessionSet subscriber exists in-tree today; the re-permission work
+// (#426) adds the first and must mind this.
+static ATTACH_TOPOLOGY: Mutex<()> = Mutex::new(());
+
 struct AttachedSet<CD: ContextData> {
     set: Weak<SessionSetInner<CD>>,
     /// Forwards the attached set's change signal into `changed`;
@@ -210,10 +229,29 @@ impl<CD: ContextData> SessionSet<CD> {
     /// session backing a context. A no-op for self-attachment (the
     /// registry backing a context is its own source); an attach
     /// that would form a cycle is refused, warned and ignored.
+    ///
+    /// Whether two handles name the same set. Identity, not content:
+    /// the error paths that must decide "is this map entry still the
+    /// set I created" cannot use value equality, which two distinct
+    /// sets can satisfy.
+    pub(crate) fn ptr_eq(&self, other: &SessionSet<CD>) -> bool { Arc::ptr_eq(&self.0, &other.0) }
+
+    /// Attach is the only operation that creates an edge, and it holds
+    /// the module's topology lock across both the reachability check
+    /// and the install, so each refusal is decided against the graph
+    /// the edge would actually join: two threads attaching opposite
+    /// directions between the same pair are ordered, and whichever runs
+    /// second sees the first one's edge and refuses. The graph stays
+    /// acyclic that way — which the walks below tolerate regardless,
+    /// but the forwarded change signals do not: around a cycle every
+    /// set's notification re-enters the next one's, without end. The
+    /// notification fires once every lock is released, as elsewhere in
+    /// this type.
     pub fn attach(&self, other: &SessionSet<CD>) {
         if Arc::ptr_eq(&self.0, &other.0) {
             return;
         }
+        let topology = ATTACH_TOPOLOGY.lock().unwrap_or_else(|e| e.into_inner());
         if other.reaches(self) {
             tracing::warn!("refusing attach: it would form a cycle");
             return;
@@ -238,6 +276,7 @@ impl<CD: ContextData> SessionSet<CD> {
             attached.push(AttachedSet { set: other_weak, _forward: forward });
         }
         other.0.parents.lock().unwrap_or_else(|e| e.into_inner()).push(Arc::downgrade(&self.0));
+        drop(topology);
         // Fire outside the locks: subscribers read the set back.
         self.0.changed.send(());
     }
@@ -303,17 +342,31 @@ impl<CD: ContextData> SessionSet<CD> {
     }
 
     /// Whether `target` is reachable from this set through attached
-    /// edges (including being this set). Attach refuses cycle-forming
-    /// edges, so the walk terminates.
+    /// edges (including being this set). Each set is visited once, like
+    /// [`SessionSet::sessions`], so the walk is total on any graph:
+    /// this is what attach consults to decide whether an edge would
+    /// form a cycle, and that answer cannot be allowed to depend on the
+    /// very property it is deciding.
     fn reaches(&self, target: &SessionSet<CD>) -> bool {
+        let mut visited = HashSet::new();
+        self.reaches_from(target, &mut visited)
+    }
+
+    fn reaches_from(&self, target: &SessionSet<CD>, visited: &mut HashSet<*const ()>) -> bool {
         if Arc::ptr_eq(&self.0, &target.0) {
             return true;
         }
+        if !visited.insert(Arc::as_ptr(&self.0) as *const ()) {
+            return false;
+        }
+        // Snapshot the edges, then recurse with no lock held.
         let edges: Vec<_> = self.0.attached.lock().unwrap_or_else(|e| e.into_inner()).iter().map(|edge| edge.set.clone()).collect();
-        edges.into_iter().filter_map(|edge| edge.upgrade()).any(|inner| SessionSet(inner).reaches(target))
+        edges.into_iter().filter_map(|edge| edge.upgrade()).any(|inner| SessionSet(inner).reaches_from(target, visited))
     }
 
-    /// The current value of every live session, in slot order.
+    /// The current value of every live session — own members in slot
+    /// order, then each attached set's, depth-first (the order
+    /// [`SessionSet::sessions`] lists them in).
     pub fn current(&self) -> Vec<CD> { self.sessions().iter().map(|session| session.snapshot()).collect() }
 
     /// The single credential write paths act as. A write is one
@@ -334,7 +387,7 @@ impl<CD: ContextData> SessionSet<CD> {
 }
 
 impl<CD: ContextData> From<CD> for SessionSet<CD> {
-    /// Bare state becomes a private set owning one freshly minted
+    /// Bare state becomes a private set owning one freshly created
     /// session — the shape of an ordinary context's source.
     fn from(cdata: CD) -> Self {
         let set = SessionSet::new();
@@ -389,126 +442,4 @@ impl<CD: ContextData> Subscribe<Vec<CD>> for SessionSet<CD> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// A value-carrying test credential. Equality is full-value
-    /// (operational identity per the [`ContextData`] contract), so a
-    /// token refresh — same subject, new token — compares unequal and an
-    /// identical update compares equal.
-    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-    struct TestCd {
-        subject: u8,
-        token: u8,
-    }
-    impl ContextData for TestCd {}
-
-    /// A context-shaped source — a private set owning its session,
-    /// attached to a registry — joins the registry's union while it
-    /// lives, and its members leave when it drops.
-    #[test]
-    fn attached_set_liveness() {
-        let registry: SessionSet<TestCd> = SessionSet::new();
-        let source: SessionSet<TestCd> = TestCd { subject: 1, token: 0 }.into();
-        registry.attach(&source);
-        assert_eq!(registry.sessions().len(), 1, "attached members join the union");
-
-        let second: SessionSet<TestCd> = TestCd { subject: 2, token: 0 }.into();
-        registry.attach(&second);
-        assert_eq!(registry.sessions().len(), 2);
-
-        drop(second);
-        assert_eq!(registry.sessions().len(), 1, "a dropped source's members leave the union");
-        drop(source);
-        assert!(registry.sessions().is_empty());
-    }
-
-    /// Updates are visible to every holder and fire change subscribers
-    /// with the new value.
-    #[test]
-    fn update_is_shared_and_reactive() {
-        let session = Session::new(TestCd { subject: 1, token: 1 });
-        let holder = session.clone();
-
-        let seen = Arc::new(Mutex::new(Vec::new()));
-        let sink = seen.clone();
-        let _guard = session.subscribe(move |value: TestCd| {
-            sink.lock().unwrap().push(value.token);
-        });
-
-        session.update(TestCd { subject: 2, token: 2 });
-        assert_eq!(holder.snapshot().token, 2, "holders read the new value");
-        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "subscriber fired with the new value");
-    }
-
-    /// A token refresh — same subject, new token — is a real change: it
-    /// compares unequal and fires the subscriber. An identical update is
-    /// a complete no-op: no notification.
-    #[test]
-    fn refresh_notifies_and_identical_update_is_a_noop() {
-        let session = Session::new(TestCd { subject: 1, token: 1 });
-        let seen = Arc::new(Mutex::new(Vec::new()));
-        let sink = seen.clone();
-        let _guard = session.subscribe(move |value: TestCd| {
-            sink.lock().unwrap().push(value.token);
-        });
-
-        let refreshed = TestCd { subject: 1, token: 2 };
-        assert_ne!(session.snapshot(), refreshed, "a refresh carries a new token, so it compares unequal");
-        session.update(refreshed);
-        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "the refresh fires the subscriber");
-
-        session.update(TestCd { subject: 1, token: 2 });
-        assert_eq!(seen.lock().unwrap().as_slice(), &[2], "an identical update does not notify");
-        assert_eq!(session.snapshot().token, 2, "the stored value is unchanged");
-    }
-
-    /// A new session belongs to no set until something owns it.
-    #[test]
-    fn new_sessions_belong_to_no_set() {
-        let set: SessionSet<TestCd> = SessionSet::new();
-        let _infra = Session::new(TestCd { subject: 1, token: 0 });
-        assert!(set.sessions().is_empty());
-    }
-
-    /// The set is a signal over the union of current values: it fires on
-    /// own, on any member's update, on attach, and when an attached
-    /// source drops.
-    #[test]
-    fn set_fires_on_membership_and_member_updates() {
-        let set: SessionSet<TestCd> = SessionSet::new();
-        let fired = Arc::new(Mutex::new(Vec::new()));
-        let sink = fired.clone();
-        let _guard = set.subscribe(move |current: Vec<TestCd>| {
-            sink.lock().unwrap().push(current.iter().map(|cd| cd.token).collect::<Vec<_>>());
-        });
-
-        let a = Session::new(TestCd { subject: 1, token: 10 });
-        set.own(&a);
-        assert_eq!(fired.lock().unwrap().last(), Some(&vec![10]), "owning fires with the new union");
-
-        a.update(TestCd { subject: 1, token: 11 });
-        assert_eq!(fired.lock().unwrap().last(), Some(&vec![11]), "a member's update fires with its new value");
-
-        let child: SessionSet<TestCd> = TestCd { subject: 2, token: 20 }.into();
-        set.attach(&child);
-        assert_eq!(fired.lock().unwrap().last(), Some(&vec![11, 20]), "attaching fires with the joined union");
-
-        let count = fired.lock().unwrap().len();
-        drop(child);
-        assert_eq!(fired.lock().unwrap().last(), Some(&vec![11]), "a dropped source fires the shrunken union");
-        assert_eq!(fired.lock().unwrap().len(), count + 1, "exactly the drop notification fired");
-    }
-
-    /// Peek reads the union without tracking; the porcelain and the
-    /// inherent accessors agree.
-    #[test]
-    fn porcelain_and_inherent_accessors_agree() {
-        let set: SessionSet<TestCd> = SessionSet::new();
-        let session = Session::new(TestCd { subject: 1, token: 1 });
-        set.own(&session);
-        assert_eq!(session.peek(), session.snapshot());
-        assert_eq!(set.peek(), set.current());
-        assert_eq!(set.peek(), vec![TestCd { subject: 1, token: 1 }]);
-    }
-}
+mod tests;

--- a/core/src/session/tests.rs
+++ b/core/src/session/tests.rs
@@ -1,0 +1,176 @@
+use super::*;
+
+/// A value-carrying test credential. Equality is full-value
+/// (operational identity per the [`ContextData`] contract), so a
+/// token refresh — same subject, new token — compares unequal and an
+/// identical update compares equal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TestCd {
+    subject: u8,
+    token: u8,
+}
+impl ContextData for TestCd {}
+
+/// A context-shaped source — a private set owning its session,
+/// attached to a registry — joins the registry's union while it
+/// lives, and its members leave when it drops.
+#[test]
+fn attached_set_liveness() {
+    let registry: SessionSet<TestCd> = SessionSet::new();
+    let source: SessionSet<TestCd> = TestCd { subject: 1, token: 0 }.into();
+    registry.attach(&source);
+    assert_eq!(registry.sessions().len(), 1, "attached members join the union");
+
+    let second: SessionSet<TestCd> = TestCd { subject: 2, token: 0 }.into();
+    registry.attach(&second);
+    assert_eq!(registry.sessions().len(), 2);
+
+    drop(second);
+    assert_eq!(registry.sessions().len(), 1, "a dropped source's members leave the union");
+    drop(source);
+    assert!(registry.sessions().is_empty());
+}
+
+/// Updates are visible to every holder and fire change subscribers
+/// with the new value.
+#[test]
+fn update_is_shared_and_reactive() {
+    let session = Session::new(TestCd { subject: 1, token: 1 });
+    let holder = session.clone();
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let sink = seen.clone();
+    let _guard = session.subscribe(move |value: TestCd| {
+        sink.lock().unwrap().push(value.token);
+    });
+
+    session.update(TestCd { subject: 2, token: 2 });
+    assert_eq!(holder.snapshot().token, 2, "holders read the new value");
+    assert_eq!(seen.lock().unwrap().as_slice(), &[2], "subscriber fired with the new value");
+}
+
+/// A token refresh — same subject, new token — is a real change: it
+/// compares unequal and fires the subscriber. An identical update is
+/// a complete no-op: no notification.
+#[test]
+fn refresh_notifies_and_identical_update_is_a_noop() {
+    let session = Session::new(TestCd { subject: 1, token: 1 });
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let sink = seen.clone();
+    let _guard = session.subscribe(move |value: TestCd| {
+        sink.lock().unwrap().push(value.token);
+    });
+
+    let refreshed = TestCd { subject: 1, token: 2 };
+    assert_ne!(session.snapshot(), refreshed, "a refresh carries a new token, so it compares unequal");
+    session.update(refreshed);
+    assert_eq!(seen.lock().unwrap().as_slice(), &[2], "the refresh fires the subscriber");
+
+    session.update(TestCd { subject: 1, token: 2 });
+    assert_eq!(seen.lock().unwrap().as_slice(), &[2], "an identical update does not notify");
+    assert_eq!(session.snapshot().token, 2, "the stored value is unchanged");
+}
+
+/// A new session belongs to no set until something owns it.
+#[test]
+fn new_sessions_belong_to_no_set() {
+    let set: SessionSet<TestCd> = SessionSet::new();
+    let _infra = Session::new(TestCd { subject: 1, token: 0 });
+    assert!(set.sessions().is_empty());
+}
+
+/// The set is a signal over the union of current values: it fires on
+/// own, on any member's update, on attach, and when an attached
+/// source drops.
+#[test]
+fn set_fires_on_membership_and_member_updates() {
+    let set: SessionSet<TestCd> = SessionSet::new();
+    let fired = Arc::new(Mutex::new(Vec::new()));
+    let sink = fired.clone();
+    let _guard = set.subscribe(move |current: Vec<TestCd>| {
+        sink.lock().unwrap().push(current.iter().map(|cd| cd.token).collect::<Vec<_>>());
+    });
+
+    let a = Session::new(TestCd { subject: 1, token: 10 });
+    set.own(&a);
+    assert_eq!(fired.lock().unwrap().last(), Some(&vec![10]), "owning fires with the new union");
+
+    a.update(TestCd { subject: 1, token: 11 });
+    assert_eq!(fired.lock().unwrap().last(), Some(&vec![11]), "a member's update fires with its new value");
+
+    let child: SessionSet<TestCd> = TestCd { subject: 2, token: 20 }.into();
+    set.attach(&child);
+    assert_eq!(fired.lock().unwrap().last(), Some(&vec![11, 20]), "attaching fires with the joined union");
+
+    let count = fired.lock().unwrap().len();
+    drop(child);
+    assert_eq!(fired.lock().unwrap().last(), Some(&vec![11]), "a dropped source fires the shrunken union");
+    assert_eq!(fired.lock().unwrap().len(), count + 1, "exactly the drop notification fired");
+}
+
+/// Two threads attaching opposite directions between the same pair
+/// cannot both install their edge: whichever runs second sees the
+/// first one's edge and refuses, so no cycle is ever built and the
+/// walks that read the graph still terminate.
+#[test]
+fn racing_reciprocal_attaches_form_no_cycle() {
+    for round in 0..64u8 {
+        let left: SessionSet<TestCd> = TestCd { subject: 1, token: round }.into();
+        let right: SessionSet<TestCd> = TestCd { subject: 2, token: round }.into();
+
+        let start = Arc::new(std::sync::Barrier::new(2));
+        let handles = [(left.clone(), right.clone()), (right.clone(), left.clone())].map(|(near, far)| {
+            let start = start.clone();
+            std::thread::spawn(move || {
+                start.wait();
+                near.attach(&far);
+            })
+        });
+        for handle in handles {
+            handle.join().expect("attach panicked");
+        }
+
+        let left_edges = left.0.attached.lock().unwrap().len();
+        let right_edges = right.0.attached.lock().unwrap().len();
+        assert_eq!(left_edges + right_edges, 1, "exactly one of the two reciprocal attaches installs its edge");
+
+        // The walks terminate, and report the union the surviving edge
+        // describes: the attaching set sees both members, the attached
+        // one only its own.
+        let (parent, child) = if left_edges == 1 { (&left, &right) } else { (&right, &left) };
+        assert_eq!(parent.sessions().len(), 2, "the installed edge unions the child's member in");
+        assert_eq!(child.sessions().len(), 1, "the refused edge left the child alone");
+        assert!(parent.reaches(child));
+        assert!(!child.reaches(parent));
+    }
+}
+
+/// A cycle closed through a third set is refused too: reachability is
+/// transitive, not a check of the immediate pair.
+#[test]
+fn attach_closing_a_longer_cycle_is_refused() {
+    let a: SessionSet<TestCd> = TestCd { subject: 1, token: 0 }.into();
+    let b: SessionSet<TestCd> = TestCd { subject: 2, token: 0 }.into();
+    let c: SessionSet<TestCd> = TestCd { subject: 3, token: 0 }.into();
+
+    a.attach(&b);
+    b.attach(&c);
+    assert_eq!(a.sessions().len(), 3, "a unions b and, through b, c");
+
+    c.attach(&a);
+    assert!(c.0.attached.lock().unwrap().is_empty(), "closing a -> b -> c -> a is refused");
+    assert_eq!(c.sessions().len(), 1);
+    assert_eq!(a.sessions().len(), 3, "the refusal changed nothing");
+}
+
+/// Peek reads the union without tracking; the porcelain and the
+/// inherent accessors agree.
+#[test]
+fn porcelain_and_inherent_accessors_agree() {
+    let set: SessionSet<TestCd> = SessionSet::new();
+    let session = Session::new(TestCd { subject: 1, token: 1 });
+    set.own(&session);
+    assert_eq!(session.peek(), session.snapshot());
+    assert_eq!(set.peek(), set.current());
+    assert_eq!(set.peek(), vec![TestCd { subject: 1, token: 1 }]);
+}

--- a/tests/tests/session_cdata.rs
+++ b/tests/tests/session_cdata.rs
@@ -11,21 +11,21 @@ use common::*;
 #[tokio::test]
 async fn sessions_extend_through_livequeries() -> anyhow::Result<()> {
     let node = durable_sled_setup().await?;
-    assert!(node.sessions.sessions().is_empty());
+    assert!(node.session_registry().is_empty());
 
     let ctx = node.context(DEFAULT_CONTEXT)?;
-    assert_eq!(node.sessions.sessions().len(), 1, "context construction attaches its source to the registry");
+    assert_eq!(node.session_registry().len(), 1, "context construction attaches its source to the registry");
 
     let second = node.context(DEFAULT_CONTEXT)?;
-    assert_eq!(node.sessions.sessions().len(), 2, "sessions are per-context, never deduplicated");
+    assert_eq!(node.session_registry().len(), 2, "sessions are per-context: an equal credential still gets its own session");
     drop(second);
-    assert_eq!(node.sessions.sessions().len(), 1);
+    assert_eq!(node.session_registry().len(), 1);
 
     ctx.register_model::<Album>().await?;
     let lq = ctx.query_wait::<AlbumView>("true").await?;
     drop(ctx);
-    assert_eq!(node.sessions.sessions().len(), 1, "a live query extends its session past the context drop");
+    assert_eq!(node.session_registry().len(), 1, "a live query extends its session past the context drop");
     drop(lq);
-    assert!(node.sessions.sessions().is_empty(), "the last holder's drop removes the source from the union");
+    assert!(node.session_registry().is_empty(), "the last holder's drop removes the source from the union");
     Ok(())
 }


### PR DESCRIPTION
Hardening for the session substrate that merged in #434, consolidating the confirmed findings of two independent post-merge reviews plus the automated review. Structure only; the reactions layer still arrives with #426.

**The attach cycle race.** `attach` checked reachability with no lock and `reaches` had no visited set, so two threads attaching opposite directions could both see "no cycle" and both install, after which the forwarded change signals loop without end. Now a module-level topology lock spans the reachability check and the install (attach is rare, so one lock across all credential types), `reaches` visits each set once so the walk is total on any graph, and the doc comments state the invariant actually established. The regression test was mutation-verified: with the lock removed, the racing test reproduces the stack overflow.

**The subscribe error path takes back what it minted.** A failed SubscribeQuery used to leave the freshly minted per-query session in the handler's map forever: the map insert preceded two fallible awaits, and `remove_predicate`'s early `?` on PredicateNotFound skipped the map cleanup. Now `remove_predicate` removes the entry unconditionally before propagating the reactor's result, and `subscribe_query` removes a vacant-minted entry on any error exit. One structural note: funneling nine `?` sites to a single cleanup exit meant wrapping the fallible body in an async block, so that file's diff is mostly re-indentation. One narrow race is known and deliberate: two in-flight subscribes for the same query id where the first fails can drop the map handle the second still uses; the second keeps a working clone and the next re-subscribe re-mints. Its real fix belongs to the claw-back work in #426.

**The registry stops being a public credential enumeration.** `Node.sessions` is now `pub(crate)`; tests observe it through a `test-helpers`-gated `session_registry()` accessor, following the existing pattern.

**Smaller items.** `Session::update` keeps its lock-free shape (a lock across the store would hold it across the broadcast, and subscribers may re-enter update); its comment now states the actual guarantee, verified against the signals crate: subscribers re-read at fire time, so a racing pair of identical updates costs at most one duplicate notification. The reactor hands out a subscription by id instead of the two-private-hop reach-through. The single-caller `cleanup_removed_query` helper with the false "shared" doc is inlined back. The server's refresh loop carries a debug assertion that the per-query set is single-member, which is true by construction. The wire-arm comment no longer describes this commit's own feature as future. The PolicyAgent docs now define the empty-credential-collection case plainly, including the honest statement that PermissiveAgent is permissive by design and where JwtAgent's fail-closed behavior actually comes from. session.rs's tests move to session/tests.rs per the new convention, and `/CLAUDE.md` joins .gitignore.

**Verification.** Full workspace battery: 812 passed, 0 failed across 124 binaries (baseline 810 plus the two new attach regressions). Review provenance: the trail files ankurah-434-postmerge-review-opus.md and ankurah-434-postmerge-review-codex.md carry the findings this PR discharges; the registry-superset and multi-session typed-read findings ride the upcoming authority-model PR instead, by design.
