### PR TITLE
coderabbit reviews on request only

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# CodeRabbit automatic PR reviews are disabled as noise (maintainer,
+# 2026-08-04). On-demand review still works by commenting
+# "@coderabbitai review" on a PR.
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Disables CodeRabbit automatic PR reviews via .coderabbit.yaml (maintainer request: too noisy). On-demand review still works by commenting @coderabbitai review on any PR. Seven lines, config only.