### PR TITLE
jwt-auth: events answer to the same row scopes as state

### DIFF
--- a/core/src/lazy_entity_getter.rs
+++ b/core/src/lazy_entity_getter.rs
@@ -1,0 +1,60 @@
+//! Lazy, single-entity lookup for policy checks: a check receives a getter
+//! bound to one entity and fetches the row only if its verdict turns on row
+//! content, so verdicts that never look at the row never pay a read.
+
+use crate::{
+    entity::Entity,
+    error::RetrievalError,
+    node::Node,
+    policy::PolicyAgent,
+    retrieval::{LocalEventGetter, LocalStateGetter},
+    storage::StorageEngine,
+};
+use ankurah_proto::{CollectionId, EntityId};
+
+/// Fetches one preordained entity, on demand. Which entity is fixed at
+/// construction; [`Self::get`] takes nothing and fetches it, so a check that
+/// is handed one of these cannot be pointed at any other row, and a check
+/// that never calls `get` costs nothing. Construct via
+/// [`Node::entity_getter`](crate::node::Node::entity_getter).
+pub struct EntityGetter<'a, SE, PA>
+where PA: PolicyAgent
+{
+    entity_id: EntityId,
+    collection: CollectionId,
+    node: &'a Node<SE, PA>,
+}
+
+impl<'a, SE, PA> EntityGetter<'a, SE, PA>
+where
+    SE: StorageEngine + Send + Sync + 'static,
+    PA: PolicyAgent + Send + Sync + 'static,
+{
+    pub(crate) fn new(node: &'a Node<SE, PA>, entity_id: EntityId, collection: CollectionId) -> Self {
+        Self { entity_id, collection, node }
+    }
+
+    /// The entity this getter is bound to.
+    pub fn id(&self) -> EntityId { self.entity_id }
+
+    /// The entity as it currently stands, or `None` when nothing current
+    /// exists for it. The resident entity when the node holds one, otherwise
+    /// materialized from stored state into the node's entity set, which is
+    /// what makes repeated calls not repeat the lookup.
+    pub async fn get(&self) -> Result<Option<Entity>, RetrievalError> {
+        let collection = self.node.collections.get(&self.collection).await?;
+        let state_getter = LocalStateGetter::new(collection.clone());
+        let event_getter = LocalEventGetter::new(collection, self.node.durable);
+        let Some(entity) = self.node.entities.get_or_retrieve(&state_getter, &event_getter, &self.collection, &self.entity_id).await?
+        else {
+            return Ok(None);
+        };
+        // An id can only name one entity, but nothing above checked which
+        // collection that entity belongs to; a row from another collection is
+        // not this getter's row.
+        if entity.collection() != &self.collection {
+            return Ok(None);
+        }
+        Ok(Some(entity))
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod event_dag;
 #[cfg(feature = "bench-internals")]
 pub mod bench_support;
 pub mod indexing;
+pub mod lazy_entity_getter;
 pub mod livequery;
 pub mod model;
 pub mod node;

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -1,6 +1,6 @@
 use crate::selection::filter::Filterable;
 use crate::{schema::catalog::CatalogManager, session::SessionSet};
-use ankurah_proto::{self as proto, Attested, CollectionId, EntityState};
+use ankurah_proto::{self as proto, Attested, CollectionId, EntityId, EntityState};
 use anyhow::anyhow;
 
 use rand::prelude::*;
@@ -20,6 +20,7 @@ use crate::{
     context::Context,
     entity::{Entity, WeakEntitySet},
     error::{MutationError, RequestError, RetrievalError},
+    lazy_entity_getter::EntityGetter,
     notice_info,
     peer_subscription::{SubscriptionHandler, SubscriptionRelay},
     policy::{AccessDenied, PolicyAgent},
@@ -436,7 +437,7 @@ where
 
     #[cfg_attr(feature = "instrument", instrument(level = "debug", skip_all, fields(request = %request)))]
     async fn handle_request<C>(&self, cdata: &C, request: proto::NodeRequest) -> anyhow::Result<proto::NodeResponseBody>
-    where C: Iterable<PA::ContextData> {
+    where C: Iterable<PA::ContextData> + Sync {
         match request.body {
             proto::NodeRequestBody::CommitTransaction { id, events } => {
                 // Protected collections (the system collection and the
@@ -524,7 +525,8 @@ where
                 // filter out any that the policy agent says we don't have access to
                 let mut events = Vec::new();
                 for event in storage_collection.get_events(event_ids).await? {
-                    match self.policy_agent.check_read_event(cdata, &event) {
+    
+                    match self.policy_agent.check_read_event(cdata, &event, &self.entity_getter(event.payload.entity_id, collection.clone())).await {
                         Ok(_) => events.push(event),
                         Err(AccessDenied::ByPolicy(_)) => {}
                         // TODO: we need to have a cleaner delineation between actual access denied versus processing errors
@@ -588,6 +590,12 @@ where
             }
         }
         Ok(())
+    }
+
+    /// An [`EntityGetter`] bound to one entity of one collection, for handing
+    /// to policy checks.
+    pub fn entity_getter(&self, entity_id: EntityId, collection: CollectionId) -> EntityGetter<'_, SE, PA> {
+        EntityGetter::new(self, entity_id, collection)
     }
 
     /// Does all the things necessary to commit a remote transaction
@@ -712,28 +720,30 @@ where
     where
         SE: StorageEngine + Send + Sync + 'static,
         PA: PolicyAgent + Send + Sync + 'static,
-        C: crate::util::Iterable<PA::ContextData>,
+        C: crate::util::Iterable<PA::ContextData> + Sync,
     {
-        // Destructure to take ownership and avoid clones
-        let proto::Attested { payload: proto::EntityState { entity_id, collection, state }, attestations } = entity_state;
-        let current_head = &state.head;
+        // Destructure to take ownership and avoid clones. The entity state stays
+        // whole until the snapshot is built: the bridge walk needs the entity id
+        // alongside the head to keep the window on one entity.
+        let proto::Attested { payload: entity_state, attestations } = entity_state;
+        let current_head = &entity_state.state.head;
 
         // Entity is in known_matches - try to optimize the response
-        if let Some(known_head) = known_map.get(&entity_id) {
+        if let Some(known_head) = known_map.get(&entity_state.entity_id) {
             // Case 1: Heads equal → return None (omit entity, client already has current state) ✓
             if known_head == current_head {
                 return Ok(None);
             }
 
             // Case 2: Heads differ → try to build EventBridge (cheaper than full state) ✓
-            match self.collect_event_bridge(storage_collection, known_head, current_head, cdata).await {
+            match self.collect_event_bridge(storage_collection, known_head, &entity_state, cdata).await {
                 Ok(attested_events) if !attested_events.is_empty() => {
                     // Convert Attested<Event> to EventFragments (strips entity_id and collection)
                     let event_fragments: Vec<proto::EventFragment> = attested_events.into_iter().map(|e| e.into()).collect();
 
                     return Ok(Some(proto::EntityDelta {
-                        entity_id,
-                        collection,
+                        entity_id: entity_state.entity_id,
+                        collection: entity_state.collection,
                         content: proto::DeltaContent::EventBridge { events: event_fragments },
                     }));
                 }
@@ -744,28 +754,34 @@ where
         }
 
         // Case 3: Entity not in known_matches OR bridge building failed → send full StateSnapshot ✓
+        let proto::EntityState { entity_id, collection, state } = entity_state;
         let state_fragment = proto::StateFragment { state, attestations };
         Ok(Some(proto::EntityDelta { entity_id, collection, content: proto::DeltaContent::StateSnapshot { state: state_fragment } }))
     }
 
-    /// Collect events between known_head and current_head using event_dag comparison.
-    /// Returns events needed to advance from known_head to current_head.
+    /// Collect events between known_head and the entity's current head using
+    /// event_dag comparison. Returns events needed to advance from known_head to
+    /// that head. The walk keeps to `current_state`'s own entity: a parent
+    /// pointer that leaves it abandons the bridge, because that state is what
+    /// the read check evaluates every event in the window against, and it is
+    /// evidence about no other row.
     pub(crate) async fn collect_event_bridge<C>(
         &self,
         storage_collection: &crate::storage::StorageCollectionWrapper,
         known_head: &proto::Clock,
-        current_head: &proto::Clock,
+        current_state: &proto::EntityState,
         cdata: &C,
     ) -> anyhow::Result<Vec<proto::Attested<proto::Event>>>
     where
         SE: StorageEngine + Send + Sync + 'static,
         PA: PolicyAgent + Send + Sync + 'static,
-        C: crate::util::Iterable<PA::ContextData>,
+        C: crate::util::Iterable<PA::ContextData> + Sync,
     {
         use crate::event_dag::{compare, AbstractCausalRelation};
         use crate::retrieval::LocalEventGetter;
         use std::collections::HashSet;
 
+        let current_head = &current_state.state.head;
         let event_getter = LocalEventGetter::new(storage_collection.clone(), self.durable);
 
         // First check the causal relationship
@@ -789,6 +805,21 @@ where
                     let fetched = storage_collection.get_events(batch).await?;
 
                     for event in fetched {
+                        // Parent pointers are event ids, and an event of another
+                        // entity can be reached through one (a graft, whether a
+                        // bug or a forged event). Serving it here would check it
+                        // against this entity's state, which says nothing about
+                        // the row it actually belongs to, so give up the bridge
+                        // and let the caller send a state snapshot instead.
+                        if event.payload.entity_id != current_state.entity_id {
+                            warn!(
+                                "Event {} belongs to entity {} but was reached walking entity {}'s history; abandoning the event bridge",
+                                event.payload.id(),
+                                event.payload.entity_id,
+                                current_state.entity_id
+                            );
+                            return Ok(vec![]);
+                        }
                         let id = event.payload.id();
                         if visited.insert(id.clone()) && !known_set.contains(&id) {
                             // Add parents to frontier (walking backward)
@@ -806,9 +837,15 @@ where
                 // One unreadable event makes the whole bridge unusable (a
                 // chain with a hole loses operations downstream), so give up
                 // entirely and let the caller fall back to a state snapshot,
-                // which passes its own read check.
+                // which passes its own read check. The walk kept every event
+                // on `current_state`'s own entity, so its getter is the one
+                // to judge by.
                 for event in &events {
-                    match self.policy_agent.check_read_event(cdata, event) {
+                    match self
+                        .policy_agent
+                        .check_read_event(cdata, event, &self.entity_getter(current_state.entity_id, current_state.collection.clone()))
+                        .await
+                    {
                         Ok(()) => {}
                         Err(AccessDenied::ByPolicy(_)) => return Ok(vec![]),
                         Err(e) => return Err(anyhow!("check_read_event failed while building event bridge: {}", e)),
@@ -939,6 +976,30 @@ where
     /// Requires the `test-helpers` feature to be enabled.
     #[cfg(feature = "test-helpers")]
     pub fn insert_durable_peer_for_test(&self, peer_id: proto::EntityId) { self.durable_peers.insert(peer_id); }
+
+    /// TEST ONLY: Run the event-bridge walk over a caller-supplied head and
+    /// state, returning the window it would put on the wire.
+    ///
+    /// The walk's guards (unreadable events, events belonging to another
+    /// entity) all express themselves as an empty window, which the delta
+    /// builder turns into a state snapshot. Reaching the walk directly lets a
+    /// test tell "the guard refused" from "the causal comparison never reached
+    /// the walk", which the delta on the wire cannot.
+    ///
+    /// Requires the `test-helpers` feature to be enabled.
+    #[cfg(feature = "test-helpers")]
+    pub async fn collect_event_bridge_for_test<C>(
+        &self,
+        storage_collection: &crate::storage::StorageCollectionWrapper,
+        known_head: &proto::Clock,
+        current_state: &proto::EntityState,
+        cdata: &C,
+    ) -> anyhow::Result<Vec<proto::Attested<proto::Event>>>
+    where
+        C: crate::util::Iterable<PA::ContextData> + Sync,
+    {
+        self.collect_event_bridge(storage_collection, known_head, current_state, cdata).await
+    }
 
     /// TEST ONLY: Observe the session registry — the current credential
     /// of every session backing a context on this node, in the

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -525,22 +525,48 @@ where
 
                 // An event carries its entity's content, so the read check needs
                 // the same thing the state path gives it: the entity's current
-                // state. Fetch one state per distinct entity in the batch;
-                // entities with no stored state are absent from the map, and the
-                // policy agent decides what an absent state means.
+                // state. Fetch one state per distinct entity the batch touches --
+                // the default `get_states` walks its argument one `get_state` at a
+                // time, so K distinct entities cost K sequential reads until an
+                // engine overrides it with a real multi-key read. Entities with no
+                // state anywhere are absent from the map, and the policy agent
+                // decides what an absent state means.
                 let entity_ids: Vec<proto::EntityId> =
                     stored_events.iter().map(|e| e.payload.entity_id).collect::<std::collections::HashSet<_>>().into_iter().collect();
-                let states: std::collections::HashMap<proto::EntityId, proto::State> = storage_collection
-                    .get_states(entity_ids)
+                let mut states: std::collections::HashMap<proto::EntityId, proto::EntityState> = storage_collection
+                    .get_states(entity_ids.clone())
                     .await?
                     .into_iter()
-                    .map(|state| (state.payload.entity_id, state.payload.state))
+                    .map(|state| (state.payload.entity_id, state.payload))
                     .collect();
+
+                // A resident entity outranks the stored state: the EventOnly apply
+                // path advances the in-memory entity and leaves the state buffer
+                // behind, so storage alone can authorize an event against a row
+                // several events out of date.
+                for id in entity_ids {
+                    let Some(entity) = self.get_resident_entity(id) else { continue };
+                    if entity.collection() != &collection {
+                        continue;
+                    }
+                    states.insert(id, proto::EntityState { entity_id: id, collection: collection.clone(), state: entity.to_state()? });
+                }
 
                 // filter out any that the policy agent says we don't have access to
                 let mut events = Vec::new();
                 for event in stored_events {
-                    match self.policy_agent.check_read_event(cdata, &event, states.get(&event.payload.entity_id)) {
+                    let current_state = states.get(&event.payload.entity_id);
+                    // A commit publishes its event before it persists the state,
+                    // so the state paired above can predate the event -- including
+                    // an event that moves the row out of the caller's scope, whose
+                    // own effect the authorizing state then does not show. Serve
+                    // only what that state causally accounts for.
+                    if let Some(state) = current_state {
+                        if !self.head_covers_event(&storage_collection, &state.state.head, &event.payload.id()).await? {
+                            continue;
+                        }
+                    }
+                    match self.policy_agent.check_read_event(cdata, &event, current_state) {
                         Ok(_) => events.push(event),
                         Err(AccessDenied::ByPolicy(_)) => {}
                         // TODO: we need to have a cleaner delineation between actual access denied versus processing errors
@@ -730,26 +756,28 @@ where
         PA: PolicyAgent + Send + Sync + 'static,
         C: crate::util::Iterable<PA::ContextData>,
     {
-        // Destructure to take ownership and avoid clones
-        let proto::Attested { payload: proto::EntityState { entity_id, collection, state }, attestations } = entity_state;
-        let current_head = &state.head;
+        // Destructure to take ownership and avoid clones. The entity state stays
+        // whole until the snapshot is built: the bridge walk needs the entity id
+        // alongside the head to keep the window on one entity.
+        let proto::Attested { payload: entity_state, attestations } = entity_state;
+        let current_head = &entity_state.state.head;
 
         // Entity is in known_matches - try to optimize the response
-        if let Some(known_head) = known_map.get(&entity_id) {
+        if let Some(known_head) = known_map.get(&entity_state.entity_id) {
             // Case 1: Heads equal → return None (omit entity, client already has current state) ✓
             if known_head == current_head {
                 return Ok(None);
             }
 
             // Case 2: Heads differ → try to build EventBridge (cheaper than full state) ✓
-            match self.collect_event_bridge(storage_collection, known_head, &state, cdata).await {
+            match self.collect_event_bridge(storage_collection, known_head, &entity_state, cdata).await {
                 Ok(attested_events) if !attested_events.is_empty() => {
                     // Convert Attested<Event> to EventFragments (strips entity_id and collection)
                     let event_fragments: Vec<proto::EventFragment> = attested_events.into_iter().map(|e| e.into()).collect();
 
                     return Ok(Some(proto::EntityDelta {
-                        entity_id,
-                        collection,
+                        entity_id: entity_state.entity_id,
+                        collection: entity_state.collection,
                         content: proto::DeltaContent::EventBridge { events: event_fragments },
                     }));
                 }
@@ -760,20 +788,22 @@ where
         }
 
         // Case 3: Entity not in known_matches OR bridge building failed → send full StateSnapshot ✓
+        let proto::EntityState { entity_id, collection, state } = entity_state;
         let state_fragment = proto::StateFragment { state, attestations };
         Ok(Some(proto::EntityDelta { entity_id, collection, content: proto::DeltaContent::StateSnapshot { state: state_fragment } }))
     }
 
     /// Collect events between known_head and the entity's current head using
     /// event_dag comparison. Returns events needed to advance from known_head to
-    /// that head. Every event in the window belongs to `current_state`'s entity
-    /// (the walk starts at its head and follows parents), so that state is what
-    /// the read check evaluates each of them against.
+    /// that head. The walk keeps to `current_state`'s own entity: a parent
+    /// pointer that leaves it abandons the bridge, because that state is what
+    /// the read check evaluates every event in the window against, and it is
+    /// evidence about no other row.
     pub(crate) async fn collect_event_bridge<C>(
         &self,
         storage_collection: &crate::storage::StorageCollectionWrapper,
         known_head: &proto::Clock,
-        current_state: &proto::State,
+        current_state: &proto::EntityState,
         cdata: &C,
     ) -> anyhow::Result<Vec<proto::Attested<proto::Event>>>
     where
@@ -785,7 +815,7 @@ where
         use crate::retrieval::LocalEventGetter;
         use std::collections::HashSet;
 
-        let current_head = &current_state.head;
+        let current_head = &current_state.state.head;
         let event_getter = LocalEventGetter::new(storage_collection.clone(), self.durable);
 
         // First check the causal relationship
@@ -809,6 +839,21 @@ where
                     let fetched = storage_collection.get_events(batch).await?;
 
                     for event in fetched {
+                        // Parent pointers are event ids, and an event of another
+                        // entity can be reached through one (a graft, whether a
+                        // bug or a forged event). Serving it here would check it
+                        // against this entity's state, which says nothing about
+                        // the row it actually belongs to, so give up the bridge
+                        // and let the caller send a state snapshot instead.
+                        if event.payload.entity_id != current_state.entity_id {
+                            warn!(
+                                "Event {} belongs to entity {} but was reached walking entity {}'s history; abandoning the event bridge",
+                                event.payload.id(),
+                                event.payload.entity_id,
+                                current_state.entity_id
+                            );
+                            return Ok(vec![]);
+                        }
                         let id = event.payload.id();
                         if visited.insert(id.clone()) && !known_set.contains(&id) {
                             // Add parents to frontier (walking backward)
@@ -847,6 +892,36 @@ where
                 Ok(vec![])
             }
         }
+    }
+
+    /// Is `event_id` in `head`'s past, or in `head` itself?
+    ///
+    /// This is what makes a state usable as authorization for an event: a state
+    /// speaks for the events its head accounts for and for no others. An event
+    /// the head does not cover may be the very event that changes who may read
+    /// the row, and the state cannot show that change.
+    ///
+    /// An event named in `head` itself answers immediately; any other costs a
+    /// DAG comparison, which walks back from `head` until it reaches the event.
+    /// That is proportional to the distance between the two, so a peer
+    /// backfilling deep history one event per request pays the depth each time.
+    async fn head_covers_event(
+        &self,
+        storage_collection: &crate::storage::StorageCollectionWrapper,
+        head: &proto::Clock,
+        event_id: &proto::EventId,
+    ) -> anyhow::Result<bool> {
+        use crate::event_dag::{compare, AbstractCausalRelation};
+
+        if head.as_slice().contains(event_id) {
+            return Ok(true);
+        }
+        let event_getter = LocalEventGetter::new(storage_collection.clone(), self.durable);
+        let comparison = compare(&event_getter, head, &proto::Clock::from(event_id.clone()), 100000).await?;
+        // Anything else -- the event ahead of the head, concurrent with it, or
+        // undecided within the budget -- leaves the state unable to speak for
+        // the event, so it is not covered.
+        Ok(matches!(comparison.relation, AbstractCausalRelation::Equal | AbstractCausalRelation::StrictDescends { .. }))
     }
 
     pub fn next_entity_id(&self) -> proto::EntityId { proto::EntityId::new() }
@@ -959,6 +1034,30 @@ where
     /// Requires the `test-helpers` feature to be enabled.
     #[cfg(feature = "test-helpers")]
     pub fn insert_durable_peer_for_test(&self, peer_id: proto::EntityId) { self.durable_peers.insert(peer_id); }
+
+    /// TEST ONLY: Run the event-bridge walk over a caller-supplied head and
+    /// state, returning the window it would put on the wire.
+    ///
+    /// The walk's guards (unreadable events, events belonging to another
+    /// entity) all express themselves as an empty window, which the delta
+    /// builder turns into a state snapshot. Reaching the walk directly lets a
+    /// test tell "the guard refused" from "the causal comparison never reached
+    /// the walk", which the delta on the wire cannot.
+    ///
+    /// Requires the `test-helpers` feature to be enabled.
+    #[cfg(feature = "test-helpers")]
+    pub async fn collect_event_bridge_for_test<C>(
+        &self,
+        storage_collection: &crate::storage::StorageCollectionWrapper,
+        known_head: &proto::Clock,
+        current_state: &proto::EntityState,
+        cdata: &C,
+    ) -> anyhow::Result<Vec<proto::Attested<proto::Event>>>
+    where
+        C: crate::util::Iterable<PA::ContextData>,
+    {
+        self.collect_event_bridge(storage_collection, known_head, current_state, cdata).await
+    }
 
     /// TEST ONLY: Observe the session registry — the current credential
     /// of every session backing a context on this node, in the

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -521,10 +521,26 @@ where
                 self.policy_agent.can_access_collection(cdata, &collection)?;
                 let storage_collection = self.collections.get(&collection).await?;
 
+                let stored_events = storage_collection.get_events(event_ids).await?;
+
+                // An event carries its entity's content, so the read check needs
+                // the same thing the state path gives it: the entity's current
+                // state. Fetch one state per distinct entity in the batch;
+                // entities with no stored state are absent from the map, and the
+                // policy agent decides what an absent state means.
+                let entity_ids: Vec<proto::EntityId> =
+                    stored_events.iter().map(|e| e.payload.entity_id).collect::<std::collections::HashSet<_>>().into_iter().collect();
+                let states: std::collections::HashMap<proto::EntityId, proto::State> = storage_collection
+                    .get_states(entity_ids)
+                    .await?
+                    .into_iter()
+                    .map(|state| (state.payload.entity_id, state.payload.state))
+                    .collect();
+
                 // filter out any that the policy agent says we don't have access to
                 let mut events = Vec::new();
-                for event in storage_collection.get_events(event_ids).await? {
-                    match self.policy_agent.check_read_event(cdata, &event) {
+                for event in stored_events {
+                    match self.policy_agent.check_read_event(cdata, &event, states.get(&event.payload.entity_id)) {
                         Ok(_) => events.push(event),
                         Err(AccessDenied::ByPolicy(_)) => {}
                         // TODO: we need to have a cleaner delineation between actual access denied versus processing errors
@@ -726,7 +742,7 @@ where
             }
 
             // Case 2: Heads differ → try to build EventBridge (cheaper than full state) ✓
-            match self.collect_event_bridge(storage_collection, known_head, current_head, cdata).await {
+            match self.collect_event_bridge(storage_collection, known_head, &state, cdata).await {
                 Ok(attested_events) if !attested_events.is_empty() => {
                     // Convert Attested<Event> to EventFragments (strips entity_id and collection)
                     let event_fragments: Vec<proto::EventFragment> = attested_events.into_iter().map(|e| e.into()).collect();
@@ -748,13 +764,16 @@ where
         Ok(Some(proto::EntityDelta { entity_id, collection, content: proto::DeltaContent::StateSnapshot { state: state_fragment } }))
     }
 
-    /// Collect events between known_head and current_head using event_dag comparison.
-    /// Returns events needed to advance from known_head to current_head.
+    /// Collect events between known_head and the entity's current head using
+    /// event_dag comparison. Returns events needed to advance from known_head to
+    /// that head. Every event in the window belongs to `current_state`'s entity
+    /// (the walk starts at its head and follows parents), so that state is what
+    /// the read check evaluates each of them against.
     pub(crate) async fn collect_event_bridge<C>(
         &self,
         storage_collection: &crate::storage::StorageCollectionWrapper,
         known_head: &proto::Clock,
-        current_head: &proto::Clock,
+        current_state: &proto::State,
         cdata: &C,
     ) -> anyhow::Result<Vec<proto::Attested<proto::Event>>>
     where
@@ -766,6 +785,7 @@ where
         use crate::retrieval::LocalEventGetter;
         use std::collections::HashSet;
 
+        let current_head = &current_state.head;
         let event_getter = LocalEventGetter::new(storage_collection.clone(), self.durable);
 
         // First check the causal relationship
@@ -808,7 +828,7 @@ where
                 // entirely and let the caller fall back to a state snapshot,
                 // which passes its own read check.
                 for event in &events {
-                    match self.policy_agent.check_read_event(cdata, event) {
+                    match self.policy_agent.check_read_event(cdata, event, Some(current_state)) {
                         Ok(()) => {}
                         Err(AccessDenied::ByPolicy(_)) => return Ok(vec![]),
                         Err(e) => return Err(anyhow!("check_read_event failed while building event bridge: {}", e)),

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -184,8 +184,22 @@ pub trait PolicyAgent: Clone + Send + Sync + 'static {
         C: Iterable<Self::ContextData>;
 
     /// Check if a context can read an event
-    fn check_read_event<C>(&self, data: &C, event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData>;
+    ///
+    /// An event replays the same entity content a state carries, so an agent
+    /// that admits entities row by row in [`Self::check_read`] must apply the
+    /// same rule here or the row filter is only as strong as the collection
+    /// gate. `current_state` is the state the serving node currently holds for
+    /// the event's entity, giving that rule something to evaluate; it is `None`
+    /// when the node holds no state for the entity, and an agent whose decision
+    /// depends on state should refuse rather than guess.
+    fn check_read_event<C>(
+        &self,
+        data: &C,
+        event: &Attested<proto::Event>,
+        current_state: Option<&proto::State>,
+    ) -> Result<(), AccessDenied>
+    where
+        C: Iterable<Self::ContextData>;
 
     /// Check if a context can edit an entity
     fn check_write(&self, data: &Self::ContextData, entity: &Entity, event: Option<&proto::Event>) -> Result<(), AccessDenied>;
@@ -311,8 +325,15 @@ impl PolicyAgent for PermissiveAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, _event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
+    fn check_read_event<C>(
+        &self,
+        _data: &C,
+        _event: &Attested<proto::Event>,
+        _current_state: Option<&proto::State>,
+    ) -> Result<(), AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
         // PermissiveAgent allows regardless of which credentials are supplied, including none
         Ok(())
     }

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -2,6 +2,7 @@ use crate::util::Iterable;
 use crate::{
     entity::Entity,
     error::ValidationError,
+    lazy_entity_getter::EntityGetter,
     node::{ContextData, Node, NodeInner, WeakNode},
     property::PropertyError,
     proto::{self},
@@ -25,6 +26,11 @@ pub enum AccessDenied {
     ParseError(ParseError),
     #[error("Insufficient attestation")]
     InsufficientAttestation,
+    /// A check needed the current row and its resolver failed (a storage
+    /// error, not a verdict). Request handling reports this as an error
+    /// instead of quietly withholding the data a refusal would.
+    #[error("Access check could not resolve the entity to evaluate: {0}")]
+    ResolutionFailed(String),
 }
 
 impl From<PropertyError> for AccessDenied {
@@ -61,8 +67,8 @@ pub use crate::schema::registration::{PlannedModelPropertyMembership, PlannedUpd
 /// attribute the access to, so fail closed unless permissiveness is the
 /// point. The JWT agent in extensions/jwt-auth denies it wherever
 /// admission is decided — `can_access_collection`, and `check_read` and
-/// `check_read_event` which both reach that check (the first as its
-/// opening step, the second after the privileged short-circuit) — carving out only
+/// `check_read_event` which both open on that check (they share one
+/// row-level helper, whose first step it is) — carving out only
 /// the policy collection, which is granted before any credential is
 /// consulted. (Its `filter_predicate` does return the predicate
 /// unnarrowed when the collection has no scope rules, which admits
@@ -185,8 +191,35 @@ pub trait PolicyAgent: Clone + Send + Sync + 'static {
         C: Iterable<Self::ContextData>;
 
     /// Check if a context can read an event
-    fn check_read_event<C>(&self, data: &C, event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData>;
+    ///
+    /// An event replays the same entity content a state carries, so an agent
+    /// that admits entities row by row in [`Self::check_read`] must apply the
+    /// same rule here or the row filter is only as strong as the collection
+    /// gate. `getter` is bound to the event's own entity and resolves it
+    /// lazily: an agent that settles the verdict without row content
+    /// (privileged caller, unscoped collection, permissive policy) must
+    /// decide before calling `get`, and those paths cost no read.
+    ///
+    /// `get` yields `None` when nothing current exists for the entity, and an
+    /// agent whose decision depends on the row should refuse rather than
+    /// guess. A lookup failure is neither verdict — surface it as
+    /// [`AccessDenied::ResolutionFailed`], which request handling reports as
+    /// an error instead of a refusal.
+    ///
+    /// The verdict is about the row as it stands now, not as it stood when the
+    /// event was written: a caller who can read a row today may read that row's
+    /// whole history, including the part written while the row sat outside its
+    /// scope. Per-event historical evaluation is tracked in
+    /// <https://github.com/ankurah/ankurah/issues/445>.
+    async fn check_read_event<SE, C>(
+        &self,
+        data: &C,
+        event: &Attested<proto::Event>,
+        getter: &EntityGetter<'_, SE, Self>,
+    ) -> Result<(), AccessDenied>
+    where
+        SE: StorageEngine + Send + Sync + 'static,
+        C: Iterable<Self::ContextData> + Sync;
 
     /// Check if a context can edit an entity
     fn check_write(&self, data: &Self::ContextData, entity: &Entity, event: Option<&proto::Event>) -> Result<(), AccessDenied>;
@@ -312,9 +345,18 @@ impl PolicyAgent for PermissiveAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, _event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
-        // PermissiveAgent allows regardless of which credentials are supplied, including none
+    async fn check_read_event<SE, C>(
+        &self,
+        _data: &C,
+        _event: &Attested<proto::Event>,
+        _getter: &EntityGetter<'_, SE, Self>,
+    ) -> Result<(), AccessDenied>
+    where
+        SE: StorageEngine + Send + Sync + 'static,
+        C: Iterable<Self::ContextData> + Sync,
+    {
+        // PermissiveAgent allows regardless of which credentials are supplied,
+        // including none — and never fetches the row it is not going to judge.
         Ok(())
     }
 

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -61,8 +61,8 @@ pub use crate::schema::registration::{PlannedModelPropertyMembership, PlannedUpd
 /// attribute the access to, so fail closed unless permissiveness is the
 /// point. The JWT agent in extensions/jwt-auth denies it wherever
 /// admission is decided — `can_access_collection`, and `check_read` and
-/// `check_read_event` which both reach that check (the first as its
-/// opening step, the second after the privileged short-circuit) — carving out only
+/// `check_read_event` which both open on that check (they share one
+/// row-level helper, whose first step it is) — carving out only
 /// the policy collection, which is granted before any credential is
 /// consulted. (Its `filter_predicate` does return the predicate
 /// unnarrowed when the collection has no scope rules, which admits
@@ -192,11 +192,26 @@ pub trait PolicyAgent: Clone + Send + Sync + 'static {
     /// the event's entity, giving that rule something to evaluate; it is `None`
     /// when the node holds no state for the entity, and an agent whose decision
     /// depends on state should refuse rather than guess.
+    ///
+    /// Contract for callers: `current_state` MUST be the state of the event's
+    /// own entity — `current_state.entity_id == event.payload.entity_id`. An
+    /// agent evaluates a row rule against whatever state it is handed, so
+    /// pairing an event with a different entity's state authorizes the event
+    /// against a row the caller may read instead of the row the event belongs
+    /// to. The state travels as a whole [`proto::EntityState`] so the agent can
+    /// see that pairing and refuse a mismatched one; the JWT agent in
+    /// extensions/jwt-auth does.
+    ///
+    /// The verdict is about the row as it stands now, not as it stood when the
+    /// event was written: a caller who can read a row today may read that row's
+    /// whole history, including the part written while the row sat outside its
+    /// scope. Per-event historical evaluation is tracked in
+    /// <https://github.com/ankurah/ankurah/issues/445>.
     fn check_read_event<C>(
         &self,
         data: &C,
         event: &Attested<proto::Event>,
-        current_state: Option<&proto::State>,
+        current_state: Option<&proto::EntityState>,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>;
@@ -329,7 +344,7 @@ impl PolicyAgent for PermissiveAgent {
         &self,
         _data: &C,
         _event: &Attested<proto::Event>,
-        _current_state: Option<&proto::State>,
+        _current_state: Option<&proto::EntityState>,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,

--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -79,6 +79,47 @@ impl JwtAgent {
 
     /// Replaces the in-memory config with a new one.
     pub fn update_config(&self, new_config: PolicyConfig) { self.state.write().unwrap_or_else(|e| e.into_inner()).config = new_config; }
+
+    /// Row-level read authorization for one entity, evaluated against the state
+    /// the caller holds for it. Both read paths land here -- `check_read` for an
+    /// entity's state and `check_read_event` for its events -- so a caller that
+    /// cannot read a row cannot read that row's events either, which would
+    /// otherwise hand it the same content in replayable form.
+    ///
+    /// `state` is `None` when the caller has no state for the entity. A
+    /// collection carrying scope rules then has nothing to evaluate them
+    /// against and is refused; a collection without scope rules was already
+    /// settled by the collection gate above.
+    fn check_read_entity<C>(
+        &self,
+        data: &C,
+        id: &proto::EntityId,
+        collection: &proto::CollectionId,
+        state: Option<&proto::State>,
+    ) -> Result<(), AccessDenied>
+    where
+        C: Iterable<JwtContext>,
+    {
+        self.can_access_collection(data, collection)?;
+
+        for ctx in data.iterable() {
+            if ctx.is_privileged() {
+                return Ok(());
+            }
+        }
+
+        let guard = self.state.read().unwrap_or_else(|e| e.into_inner());
+        if guard.config.scope_rules_for_collection(collection.as_str()).is_empty() {
+            return Ok(());
+        }
+
+        let Some(state) = state else {
+            return Err(AccessDenied::ByPolicy("Read scope has no current entity state to evaluate"));
+        };
+        let entity = TemporaryEntity::new(*id, collection.clone(), state)
+            .map_err(|_| AccessDenied::ByPolicy("Read scope entity state could not be evaluated"))?;
+        enforce_read_scope(&guard.config, data, &entity)
+    }
 }
 
 #[async_trait]
@@ -269,32 +310,19 @@ impl PolicyAgent for JwtAgent {
     where
         C: Iterable<Self::ContextData>,
     {
-        self.can_access_collection(data, collection)?;
-
-        for ctx in data.iterable() {
-            if ctx.is_privileged() {
-                return Ok(());
-            }
-        }
-
-        let guard = self.state.read().unwrap_or_else(|e| e.into_inner());
-        if guard.config.scope_rules_for_collection(collection.as_str()).is_empty() {
-            return Ok(());
-        }
-
-        let entity = TemporaryEntity::new(*id, collection.clone(), state)
-            .map_err(|_| AccessDenied::ByPolicy("Read scope entity state could not be evaluated"))?;
-        enforce_read_scope(&guard.config, data, &entity)
+        self.check_read_entity(data, id, collection, Some(state))
     }
 
-    fn check_read_event<C>(&self, data: &C, event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
-        for ctx in data.iterable() {
-            if ctx.is_privileged() {
-                return Ok(());
-            }
-        }
-        self.can_access_collection(data, &event.payload.collection)
+    fn check_read_event<C>(
+        &self,
+        data: &C,
+        event: &Attested<proto::Event>,
+        current_state: Option<&proto::State>,
+    ) -> Result<(), AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
+        self.check_read_entity(data, &event.payload.entity_id, &event.payload.collection, current_state)
     }
 
     fn check_write(&self, cdata: &Self::ContextData, entity: &Entity, _event: Option<&proto::Event>) -> Result<(), AccessDenied> {

--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -89,7 +89,9 @@ impl JwtAgent {
     /// `state` is `None` when the caller has no state for the entity. A
     /// collection carrying scope rules then has nothing to evaluate them
     /// against and is refused; a collection without scope rules was already
-    /// settled by the collection gate above.
+    /// settled by the collection gate above. A `state` that is present must be
+    /// `id`'s own state -- `check_read_event`, whose caller supplies the two
+    /// separately, refuses a mismatched pair before it gets here.
     fn check_read_entity<C>(
         &self,
         data: &C,
@@ -317,11 +319,22 @@ impl PolicyAgent for JwtAgent {
         &self,
         data: &C,
         event: &Attested<proto::Event>,
-        current_state: Option<&proto::State>,
+        current_state: Option<&proto::EntityState>,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,
     {
+        // The state is only evidence about the row the event belongs to. Handed
+        // another entity's state, the scope rule would be evaluated against a row
+        // the caller may well read, and admit an event from a row it may not --
+        // so a mispaired state is refused outright rather than evaluated.
+        let current_state = match current_state {
+            Some(state) if state.entity_id != event.payload.entity_id => {
+                return Err(AccessDenied::ByPolicy("Read scope state belongs to a different entity than the event"))
+            }
+            Some(state) => Some(&state.state),
+            None => None,
+        };
         self.check_read_entity(data, &event.payload.entity_id, &event.payload.collection, current_state)
     }
 

--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -5,6 +5,9 @@ use ankql::ast::Predicate;
 use ankurah_core::{
     entity::{Entity, TemporaryEntity},
     error::ValidationError,
+    entity::EntityInner,
+    lazy_entity_getter::EntityGetter,
+    selection::filter::Filterable,
     livequery::EntityLiveQuery,
     node::{Node, NodeInner, WeakNode},
     policy::{AccessDenied, PolicyAgent},
@@ -79,6 +82,41 @@ impl JwtAgent {
 
     /// Replaces the in-memory config with a new one.
     pub fn update_config(&self, new_config: PolicyConfig) { self.state.write().unwrap_or_else(|e| e.into_inner()).config = new_config; }
+
+    /// The verdict both read paths share before any row is examined:
+    /// collection access, then the privileged bypass, then whether the
+    /// collection carries scope rules at all. `Ok(false)` means the caller is
+    /// admitted outright; `Ok(true)` means admission depends on the row, which
+    /// the caller of this helper must then produce and evaluate. Splitting the
+    /// decision this way is what lets `check_read_event` leave the row
+    /// unresolved on every path that never needed it.
+    fn read_needs_row<C>(&self, data: &C, collection: &proto::CollectionId) -> Result<bool, AccessDenied>
+    where C: Iterable<JwtContext> {
+        self.can_access_collection(data, collection)?;
+
+        for ctx in data.iterable() {
+            if ctx.is_privileged() {
+                return Ok(false);
+            }
+        }
+
+        let guard = self.state.read().unwrap_or_else(|e| e.into_inner());
+        Ok(!guard.config.scope_rules_for_collection(collection.as_str()).is_empty())
+    }
+
+    /// The row-level half both read paths share: evaluates the collection's
+    /// scope rules against the row, so a caller that cannot read a row cannot
+    /// read that row's events either, which would otherwise hand it the same
+    /// content in replayable form. Only called once [`Self::read_needs_row`]
+    /// said the verdict depends on the row.
+    fn enforce_row_scope<C, E>(&self, data: &C, entity: &E) -> Result<(), AccessDenied>
+    where
+        C: Iterable<JwtContext>,
+        E: Filterable + std::ops::Deref<Target = EntityInner>,
+    {
+        let guard = self.state.read().unwrap_or_else(|e| e.into_inner());
+        enforce_read_scope(&guard.config, data, entity)
+    }
 }
 
 #[async_trait]
@@ -344,32 +382,35 @@ impl PolicyAgent for JwtAgent {
     where
         C: Iterable<Self::ContextData>,
     {
-        self.can_access_collection(data, collection)?;
-
-        for ctx in data.iterable() {
-            if ctx.is_privileged() {
-                return Ok(());
-            }
-        }
-
-        let guard = self.state.read().unwrap_or_else(|e| e.into_inner());
-        if guard.config.scope_rules_for_collection(collection.as_str()).is_empty() {
+        if !self.read_needs_row(data, collection)? {
             return Ok(());
         }
-
         let entity = TemporaryEntity::new(*id, collection.clone(), state)
             .map_err(|_| AccessDenied::ByPolicy("Read scope entity state could not be evaluated"))?;
-        enforce_read_scope(&guard.config, data, &entity)
+        self.enforce_row_scope(data, &entity)
     }
 
-    fn check_read_event<C>(&self, data: &C, event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
-        for ctx in data.iterable() {
-            if ctx.is_privileged() {
-                return Ok(());
-            }
+    async fn check_read_event<SE, C>(
+        &self,
+        data: &C,
+        event: &Attested<proto::Event>,
+        getter: &EntityGetter<'_, SE, Self>,
+    ) -> Result<(), AccessDenied>
+    where
+        SE: StorageEngine + Send + Sync + 'static,
+        C: Iterable<Self::ContextData> + Sync,
+    {
+        if !self.read_needs_row(data, &event.payload.collection)? {
+            return Ok(());
         }
-        self.can_access_collection(data, &event.payload.collection)
+        // Only now does the row's cost exist: every verdict above fetched
+        // nothing. A lookup failure is a fault, not a refusal, and is
+        // surfaced as such.
+        let row = getter.get().await.map_err(|e| AccessDenied::ResolutionFailed(e.to_string()))?;
+        let Some(entity) = row else {
+            return Err(AccessDenied::ByPolicy("Read scope has no current entity state to evaluate"));
+        };
+        self.enforce_row_scope(data, &entity)
     }
 
     fn check_write(&self, cdata: &Self::ContextData, entity: &Entity, _event: Option<&proto::Event>) -> Result<(), AccessDenied> {
@@ -450,8 +491,11 @@ fn enforce_write_scope(config: &PolicyConfig, cdata: &JwtContext, entity: &Entit
     Ok(())
 }
 
-fn enforce_read_scope<C>(config: &PolicyConfig, data: &C, entity: &TemporaryEntity) -> Result<(), AccessDenied>
-where C: Iterable<JwtContext> {
+fn enforce_read_scope<C, E>(config: &PolicyConfig, data: &C, entity: &E) -> Result<(), AccessDenied>
+where
+    C: Iterable<JwtContext>,
+    E: Filterable + std::ops::Deref<Target = EntityInner>,
+{
     for ctx in data.iterable() {
         let JwtContext::User { claims, .. } = ctx else {
             continue;

--- a/extensions/jwt-auth/tests/event_read_scope_tests.rs
+++ b/extensions/jwt-auth/tests/event_read_scope_tests.rs
@@ -1,0 +1,481 @@
+//! Row-level read scopes must gate an entity's events, not only its state.
+//!
+//! A scope rule narrows which rows a token may read. The state path applies it
+//! per row, but events replay the same CRDT content, so a token that is refused
+//! a row and then granted that row's events reads the row anyway. These tests
+//! hold the two paths to the same verdict on one fixture, and pin the rest of
+//! what the event path owes that verdict: a privileged caller still reads
+//! everything, several credentials read their union, and the state the rule is
+//! evaluated against must be the event's own entity's, must actually account
+//! for the event, and comes from the resident entity when one is held.
+
+mod common;
+
+use ankurah::{Model, Node, Ref};
+use ankurah_connector_local_process::LocalProcessConnection;
+use ankurah_core::policy::PolicyAgent;
+use ankurah_jwt_auth::{JwtAgent, JwtClaims, JwtContext, JwtKeys, PolicyConfig};
+use ankurah_proto as proto;
+use ankurah_storage_sled::SledStorageEngine;
+use jwt_simple::prelude::Duration;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Account {
+    pub name: String,
+}
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ScopedRecord {
+    pub account: Ref<Account>,
+    #[active_type(LWW)]
+    pub label: String,
+}
+
+/// A collection with no scope rules, for the control case: its rows are settled
+/// by the collection gate alone.
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Note {
+    #[active_type(LWW)]
+    pub text: String,
+}
+
+const CONFIG_JSON: &str = r#"{
+    "roles": {
+        "AccountReader": ["read_scoped_records", "read_notes"]
+    },
+    "collections": {
+        "scopedrecord": {
+            "read": "read_scoped_records",
+            "write": null,
+            "scope": [
+                { "filter": "account = $jwt.custom.account_id" }
+            ]
+        },
+        "note": {
+            "read": "read_notes",
+            "write": null
+        }
+    }
+}"#;
+
+fn configured_agent(keys: &ankurah_jwt_auth::SigningKeys) -> anyhow::Result<JwtAgent> {
+    let agent = JwtAgent::new_ephemeral();
+    agent.update_config(serde_json::from_str::<PolicyConfig>(CONFIG_JSON)?);
+    agent.set_keys(JwtKeys::Signing(keys.clone()));
+    Ok(agent)
+}
+
+fn reader_claims(account_id: proto::EntityId) -> JwtClaims {
+    let mut custom = serde_json::Map::new();
+    custom.insert("account_id".to_string(), serde_json::Value::String(account_id.to_base64()));
+    JwtClaims { sub: "reader-1".into(), roles: vec!["AccountReader".into()], email: "reader@example.com".into(), name: None, custom }
+}
+
+/// Three accounts, one record each, every record carrying a create event and an
+/// update event. `allowed` and `second` are each readable by one of the two
+/// tokens the plural case unions; `denied` is readable by neither.
+struct Fixture {
+    allowed_account_id: proto::EntityId,
+    second_account_id: proto::EntityId,
+    allowed_record_id: proto::EntityId,
+    denied_record_id: proto::EntityId,
+    allowed_events: Vec<proto::Attested<proto::Event>>,
+    second_events: Vec<proto::Attested<proto::Event>>,
+    denied_events: Vec<proto::Attested<proto::Event>>,
+}
+
+async fn build_fixture(root: &ankurah::Context) -> anyhow::Result<Fixture> {
+    let (allowed_account_id, second_account_id, denied_account_id) = {
+        let trx = root.begin();
+        let allowed = trx.create(&Account { name: "Allowed".into() }).await?;
+        let second = trx.create(&Account { name: "Second".into() }).await?;
+        let denied = trx.create(&Account { name: "Denied".into() }).await?;
+        let ids = (allowed.id(), second.id(), denied.id());
+        trx.commit().await?;
+        ids
+    };
+
+    let (allowed_record_id, second_record_id, denied_record_id) = {
+        let trx = root.begin();
+        let allowed = trx.create(&ScopedRecord { account: allowed_account_id.into(), label: "allowed".into() }).await?;
+        let second = trx.create(&ScopedRecord { account: second_account_id.into(), label: "second".into() }).await?;
+        let denied = trx.create(&ScopedRecord { account: denied_account_id.into(), label: "denied".into() }).await?;
+        let ids = (allowed.id(), second.id(), denied.id());
+        trx.commit().await?;
+        ids
+    };
+
+    // A second event per record, so the batch carries more than creates.
+    {
+        let trx = root.begin();
+        root.get::<ScopedRecordView>(allowed_record_id).await?.edit(&trx)?.label().set(&"allowed-updated".to_string())?;
+        root.get::<ScopedRecordView>(second_record_id).await?.edit(&trx)?.label().set(&"second-updated".to_string())?;
+        root.get::<ScopedRecordView>(denied_record_id).await?.edit(&trx)?.label().set(&"denied-updated".to_string())?;
+        trx.commit().await?;
+    }
+
+    let records = root.collection(&ScopedRecord::collection()).await?;
+    let allowed_events = records.dump_entity_events(allowed_record_id).await?;
+    let second_events = records.dump_entity_events(second_record_id).await?;
+    let denied_events = records.dump_entity_events(denied_record_id).await?;
+    for events in [&allowed_events, &second_events, &denied_events] {
+        assert_eq!(events.len(), 2, "fixture should carry a create and an update per record");
+    }
+
+    Ok(Fixture { allowed_account_id, second_account_id, allowed_record_id, denied_record_id, allowed_events, second_events, denied_events })
+}
+
+/// Ask a serving node for events by id and collect what it hands back.
+async fn served_event_ids<C>(
+    client: &Node<SledStorageEngine, JwtAgent>,
+    server_id: proto::EntityId,
+    cdata: &C,
+    event_ids: Vec<proto::EventId>,
+) -> anyhow::Result<HashSet<proto::EventId>>
+where
+    C: ankurah_core::util::Iterable<JwtContext>,
+{
+    let response =
+        client.request(server_id, cdata, proto::NodeRequestBody::GetEvents { collection: ScopedRecord::collection(), event_ids }).await?;
+    match response {
+        proto::NodeResponseBody::GetEvents(events) => Ok(events.iter().map(|event| event.payload.id()).collect()),
+        other => anyhow::bail!("expected a GetEvents response, got {other:?}"),
+    }
+}
+
+/// A peer asks a serving node for events by id. The serving node must hand back
+/// only the events of rows the asking token can read, and the same token asking
+/// for those rows' states must get the matching answer.
+#[tokio::test]
+async fn get_events_applies_the_same_row_scope_as_get_states() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    server.system.create().await?;
+
+    let root = server.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let claims = reader_claims(fixture.allowed_account_id);
+    let token = keys.sign(&claims, Duration::from_hours(1))?;
+    let reader = JwtContext::from_claims(claims, token);
+
+    // The event path: ask for both records' events in one batch.
+    let event_ids: Vec<proto::EventId> =
+        fixture.allowed_events.iter().chain(fixture.denied_events.iter()).map(|event| event.payload.id()).collect();
+    let served_ids = served_event_ids(&client, server.id, &reader, event_ids).await?;
+
+    for event in &fixture.denied_events {
+        assert!(
+            !served_ids.contains(&event.payload.id()),
+            "an event of a row outside the token's read scope must not be served (event {:?} of record {})",
+            event.payload.id(),
+            fixture.denied_record_id
+        );
+    }
+    for event in &fixture.allowed_events {
+        assert!(
+            served_ids.contains(&event.payload.id()),
+            "an event of a row inside the token's read scope must still be served (event {:?} of record {})",
+            event.payload.id(),
+            fixture.allowed_record_id
+        );
+    }
+
+    // The state path, same token, same two rows: the verdicts must line up.
+    let response = client
+        .request(
+            server.id,
+            &reader,
+            proto::NodeRequestBody::Get {
+                collection: ScopedRecord::collection(),
+                ids: vec![fixture.allowed_record_id, fixture.denied_record_id],
+            },
+        )
+        .await?;
+    let states = match response {
+        proto::NodeResponseBody::Get(states) => states,
+        other => anyhow::bail!("expected a Get response, got {other:?}"),
+    };
+    let state_ids: HashSet<proto::EntityId> = states.iter().map(|state| state.payload.entity_id).collect();
+    assert!(!state_ids.contains(&fixture.denied_record_id), "the state path must deny the same row the event path denied");
+    assert!(state_ids.contains(&fixture.allowed_record_id), "the state path must allow the same row the event path allowed");
+
+    Ok(())
+}
+
+/// The row scope is evaluated against the entity as the serving node
+/// currently knows it, so a node that has nothing for the entity has nothing
+/// to evaluate: it refuses. A collection carrying no scope rules is a
+/// different case -- the collection gate already settled it, and a missing
+/// entity changes nothing there, because the verdict never fetches it.
+#[tokio::test]
+async fn missing_current_state_denies_scoped_events_and_spares_unscoped_ones() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+    let agent = configured_agent(&keys)?;
+
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent.clone());
+    node.system.create().await?;
+
+    let root = node.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let note_id = {
+        let trx = root.begin();
+        let note = trx.create(&Note { text: "unscoped".into() }).await?;
+        let id = note.id();
+        trx.commit().await?;
+        id
+    };
+    let note_event = root.collection(&Note::collection()).await?.dump_entity_events(note_id).await?.remove(0);
+
+    // A second node that holds none of the fixture's entities: getters built
+    // against it find nothing current, which is the missing-state case.
+    let empty_node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    empty_node.system.create().await?;
+
+    let claims = reader_claims(fixture.allowed_account_id);
+    let token = keys.sign(&claims, Duration::from_hours(1))?;
+    let reader = JwtContext::from_claims(claims, token);
+
+    let allowed_event = fixture.allowed_events[0].clone();
+    let denied_event = fixture.denied_events[0].clone();
+
+    // Fail closed: a scoped collection with nothing current to evaluate is
+    // refused, even for an event whose row the token could otherwise read.
+    assert!(
+        agent
+            .check_read_event(&reader, &allowed_event, &empty_node.entity_getter(fixture.allowed_record_id, ScopedRecord::collection()))
+            .await
+            .is_err(),
+        "a scoped event with nothing current to evaluate must be refused rather than admitted unevaluated"
+    );
+    assert!(
+        agent
+            .check_read_event(&reader, &denied_event, &empty_node.entity_getter(fixture.denied_record_id, ScopedRecord::collection()))
+            .await
+            .is_err(),
+        "a scoped event with nothing current to evaluate must be refused"
+    );
+
+    // With the rows present, the event verdict matches the state verdict row
+    // for row. The getters are bound to each event's own entity by
+    // construction, which is what retired the old hazard of pairing an event
+    // with some other, readable row's state.
+    let records = root.collection(&ScopedRecord::collection()).await?;
+    let allowed_state = records.get_state(fixture.allowed_record_id).await?.payload;
+    let denied_state = records.get_state(fixture.denied_record_id).await?.payload;
+    assert!(agent
+        .check_read_event(&reader, &allowed_event, &node.entity_getter(fixture.allowed_record_id, ScopedRecord::collection()))
+        .await
+        .is_ok());
+    assert!(agent
+        .check_read_event(&reader, &denied_event, &node.entity_getter(fixture.denied_record_id, ScopedRecord::collection()))
+        .await
+        .is_err());
+    assert!(agent.check_read(&reader, &fixture.allowed_record_id, &ScopedRecord::collection(), &allowed_state.state).is_ok());
+    assert!(agent.check_read(&reader, &fixture.denied_record_id, &ScopedRecord::collection(), &denied_state.state).is_err());
+
+    // Control: no scope rules on `note`, so the collection gate is the whole
+    // decision. The getter aims at a node that holds nothing, and the verdict
+    // must not care: it never fetches.
+    assert!(
+        agent.check_read_event(&reader, &note_event, &empty_node.entity_getter(note_id, Note::collection())).await.is_ok(),
+        "a collection with no scope rules must stay readable when nothing current is available"
+    );
+
+    Ok(())
+}
+
+/// A privileged context is admitted before any scope rule is consulted, and
+/// the event path must keep that so: `Root` reads every row's events,
+/// including rows no token's scope would admit -- and the verdict never
+/// fetches the row. The getters below aim at a node that holds none of these
+/// entities, so a verdict that fetched would find nothing and refuse; every
+/// `Ok` is proof the privileged path decided without looking.
+///
+/// The assertion sits at the agent rather than on the wire because `Root` is a
+/// local-only context -- it cannot produce auth data, so it never travels as a
+/// request credential.
+#[tokio::test]
+async fn a_privileged_context_reads_events_of_rows_no_scope_admits() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+    let agent = configured_agent(&keys)?;
+
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent.clone());
+    node.system.create().await?;
+
+    let root = node.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let empty_node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    empty_node.system.create().await?;
+    let privileged = JwtContext::system();
+
+    for event in fixture.allowed_events.iter().chain(fixture.denied_events.iter()) {
+        assert!(
+            agent
+                .check_read_event(&privileged, event, &empty_node.entity_getter(event.payload.entity_id, ScopedRecord::collection()))
+                .await
+                .is_ok(),
+            "a privileged context must read every event, without the row being fetched at all"
+        );
+    }
+    assert!(
+        agent
+            .check_read_event(
+                &privileged,
+                &fixture.denied_events[0],
+                &node.entity_getter(fixture.denied_record_id, ScopedRecord::collection())
+            )
+            .await
+            .is_ok(),
+        "a privileged context must read a row its scope rules would refuse"
+    );
+
+    Ok(())
+}
+
+/// A caller can act under several credentials at once. Reads take the union:
+/// the events served are exactly those of the rows some member admits, and a
+/// row no member admits stays hidden even though a member could read the
+/// collection.
+#[tokio::test]
+async fn plural_credentials_read_the_union_of_their_rows_events() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    server.system.create().await?;
+
+    let root = server.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let mut readers = Vec::new();
+    for account_id in [fixture.allowed_account_id, fixture.second_account_id] {
+        let claims = reader_claims(account_id);
+        let token = keys.sign(&claims, Duration::from_hours(1))?;
+        readers.push(JwtContext::from_claims(claims, token));
+    }
+
+    let all_events: Vec<&proto::Attested<proto::Event>> =
+        fixture.allowed_events.iter().chain(fixture.second_events.iter()).chain(fixture.denied_events.iter()).collect();
+    let served_ids = served_event_ids(&client, server.id, &readers, all_events.iter().map(|event| event.payload.id()).collect()).await?;
+
+    let expected: HashSet<proto::EventId> =
+        fixture.allowed_events.iter().chain(fixture.second_events.iter()).map(|event| event.payload.id()).collect();
+    assert_eq!(
+        served_ids, expected,
+        "the union of two tokens must be served exactly the events of the rows they jointly admit -- not the third account's row ({}), \
+         and not a subset of their own",
+        fixture.denied_record_id
+    );
+
+    Ok(())
+}
+
+/// A commit publishes its event before it persists the entity's state, so a
+/// serving node can hold an event its stored state does not yet account for --
+/// and that event may be the very one that moves the row out of the caller's
+/// scope. An event the authorizing state cannot speak for is not served.
+///
+/// The window is staged rather than raced: the serving node below is given the
+/// whole event chain but only the state as of the create, and never
+/// materializes the entity, so nothing fresher is available to authorize
+/// against.
+#[tokio::test]
+async fn an_event_the_authorizing_state_does_not_cover_is_not_served() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let origin = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    origin.system.create().await?;
+    let origin_root = origin.context(JwtContext::system())?;
+    let fixture = build_fixture(&origin_root).await?;
+
+    let origin_records = origin_root.collection(&ScopedRecord::collection()).await?;
+    let create_event = fixture.allowed_events.iter().find(|event| event.payload.parent.is_empty()).expect("a create event");
+    let update_event = fixture.allowed_events.iter().find(|event| !event.payload.parent.is_empty()).expect("an update event");
+    let mut state_at_create = origin_records.get_state(fixture.allowed_record_id).await?;
+    state_at_create.payload.state.head = proto::Clock::from(create_event.payload.id());
+
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    server.system.create().await?;
+    let server_records = server.context(JwtContext::system())?.collection(&ScopedRecord::collection()).await?;
+    for event in &fixture.allowed_events {
+        server_records.add_event(event).await?;
+    }
+    server_records.set_state(state_at_create).await?;
+
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let claims = reader_claims(fixture.allowed_account_id);
+    let token = keys.sign(&claims, Duration::from_hours(1))?;
+    let reader = JwtContext::from_claims(claims, token);
+
+    let served_ids = served_event_ids(&client, server.id, &reader, vec![create_event.payload.id(), update_event.payload.id()]).await?;
+
+    assert!(
+        served_ids.contains(&create_event.payload.id()),
+        "the event the stored state accounts for must still be served, or the refusal below proves nothing"
+    );
+    assert!(!served_ids.contains(&update_event.payload.id()), "an event newer than the state that authorized it must not be served");
+
+    Ok(())
+}
+
+/// The stored state buffer is a rebuildable cache of the event log, and the
+/// EventOnly apply path leaves it behind: it commits events and advances the
+/// in-memory entity without rewriting the buffer. Authorizing from storage alone
+/// would therefore judge the row several events out of date, so a resident
+/// entity is consulted first and outranks what storage holds.
+///
+/// Here the same node holds the entity resident and up to date while its stored
+/// state is rewound to the create. The update event must still be served: the
+/// resident entity accounts for it even though the buffer does not.
+#[tokio::test]
+async fn a_resident_entity_outranks_a_rewound_stored_state() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    server.system.create().await?;
+    let root = server.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let records = root.collection(&ScopedRecord::collection()).await?;
+    let create_event = fixture.allowed_events.iter().find(|event| event.payload.parent.is_empty()).expect("a create event");
+    let update_event = fixture.allowed_events.iter().find(|event| !event.payload.parent.is_empty()).expect("an update event");
+
+    // Hold the entity resident at its true head, then rewind what storage says.
+    let _resident = root.get::<ScopedRecordView>(fixture.allowed_record_id).await?;
+    let mut rewound = records.get_state(fixture.allowed_record_id).await?;
+    rewound.payload.state.head = proto::Clock::from(create_event.payload.id());
+    records.set_state(rewound).await?;
+
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let claims = reader_claims(fixture.allowed_account_id);
+    let token = keys.sign(&claims, Duration::from_hours(1))?;
+    let reader = JwtContext::from_claims(claims, token);
+
+    let served_ids = served_event_ids(&client, server.id, &reader, vec![create_event.payload.id(), update_event.payload.id()]).await?;
+    assert_eq!(
+        served_ids,
+        HashSet::from([create_event.payload.id(), update_event.payload.id()]),
+        "the resident entity accounts for both events, so a stale stored state must not withhold either"
+    );
+
+    Ok(())
+}

--- a/extensions/jwt-auth/tests/event_read_scope_tests.rs
+++ b/extensions/jwt-auth/tests/event_read_scope_tests.rs
@@ -1,0 +1,246 @@
+//! Row-level read scopes must gate an entity's events, not only its state.
+//!
+//! A scope rule narrows which rows a token may read. The state path applies it
+//! per row, but events replay the same CRDT content, so a token that is refused
+//! a row and then granted that row's events reads the row anyway. These tests
+//! hold the two paths to the same verdict on one fixture, and pin what happens
+//! when the serving node has no current state to evaluate the rule against.
+
+mod common;
+
+use ankurah::{Model, Node, Ref};
+use ankurah_connector_local_process::LocalProcessConnection;
+use ankurah_core::policy::PolicyAgent;
+use ankurah_jwt_auth::{JwtAgent, JwtClaims, JwtContext, JwtKeys, PolicyConfig};
+use ankurah_proto as proto;
+use ankurah_storage_sled::SledStorageEngine;
+use jwt_simple::prelude::Duration;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Account {
+    pub name: String,
+}
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ScopedRecord {
+    pub account: Ref<Account>,
+    #[active_type(LWW)]
+    pub label: String,
+}
+
+/// A collection with no scope rules, for the control case: its rows are settled
+/// by the collection gate alone.
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Note {
+    #[active_type(LWW)]
+    pub text: String,
+}
+
+const CONFIG_JSON: &str = r#"{
+    "roles": {
+        "AccountReader": ["read_scoped_records", "read_notes"]
+    },
+    "collections": {
+        "scopedrecord": {
+            "read": "read_scoped_records",
+            "write": null,
+            "scope": [
+                { "filter": "account = $jwt.custom.account_id" }
+            ]
+        },
+        "note": {
+            "read": "read_notes",
+            "write": null
+        }
+    }
+}"#;
+
+fn configured_agent(keys: &ankurah_jwt_auth::SigningKeys) -> anyhow::Result<JwtAgent> {
+    let agent = JwtAgent::new_ephemeral();
+    agent.update_config(serde_json::from_str::<PolicyConfig>(CONFIG_JSON)?);
+    agent.set_keys(JwtKeys::Signing(keys.clone()));
+    Ok(agent)
+}
+
+fn reader_claims(account_id: proto::EntityId) -> JwtClaims {
+    let mut custom = serde_json::Map::new();
+    custom.insert("account_id".to_string(), serde_json::Value::String(account_id.to_base64()));
+    JwtClaims { sub: "reader-1".into(), roles: vec!["AccountReader".into()], email: "reader@example.com".into(), name: None, custom }
+}
+
+/// One record per account, each carrying a create event and an update event.
+struct Fixture {
+    allowed_account_id: proto::EntityId,
+    allowed_record_id: proto::EntityId,
+    denied_record_id: proto::EntityId,
+    allowed_events: Vec<proto::Attested<proto::Event>>,
+    denied_events: Vec<proto::Attested<proto::Event>>,
+}
+
+async fn build_fixture(root: &ankurah::Context) -> anyhow::Result<Fixture> {
+    let (allowed_account_id, denied_account_id) = {
+        let trx = root.begin();
+        let allowed = trx.create(&Account { name: "Allowed".into() }).await?;
+        let denied = trx.create(&Account { name: "Denied".into() }).await?;
+        let ids = (allowed.id(), denied.id());
+        trx.commit().await?;
+        ids
+    };
+
+    let (allowed_record_id, denied_record_id) = {
+        let trx = root.begin();
+        let allowed = trx.create(&ScopedRecord { account: allowed_account_id.into(), label: "allowed".into() }).await?;
+        let denied = trx.create(&ScopedRecord { account: denied_account_id.into(), label: "denied".into() }).await?;
+        let ids = (allowed.id(), denied.id());
+        trx.commit().await?;
+        ids
+    };
+
+    // A second event per record, so the batch carries more than creates.
+    {
+        let trx = root.begin();
+        root.get::<ScopedRecordView>(allowed_record_id).await?.edit(&trx)?.label().set(&"allowed-updated".to_string())?;
+        root.get::<ScopedRecordView>(denied_record_id).await?.edit(&trx)?.label().set(&"denied-updated".to_string())?;
+        trx.commit().await?;
+    }
+
+    let records = root.collection(&ScopedRecord::collection()).await?;
+    let allowed_events = records.dump_entity_events(allowed_record_id).await?;
+    let denied_events = records.dump_entity_events(denied_record_id).await?;
+    assert_eq!(allowed_events.len(), 2, "fixture should carry a create and an update per record");
+    assert_eq!(denied_events.len(), 2, "fixture should carry a create and an update per record");
+
+    Ok(Fixture { allowed_account_id, allowed_record_id, denied_record_id, allowed_events, denied_events })
+}
+
+/// A peer asks a serving node for events by id. The serving node must hand back
+/// only the events of rows the asking token can read, and the same token asking
+/// for those rows' states must get the matching answer.
+#[tokio::test]
+async fn get_events_applies_the_same_row_scope_as_get_states() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    server.system.create().await?;
+
+    let root = server.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let claims = reader_claims(fixture.allowed_account_id);
+    let token = keys.sign(&claims, Duration::from_hours(1))?;
+    let reader = JwtContext::from_claims(claims, token);
+
+    // The event path: ask for both records' events in one batch.
+    let event_ids: Vec<proto::EventId> =
+        fixture.allowed_events.iter().chain(fixture.denied_events.iter()).map(|event| event.payload.id()).collect();
+    let response =
+        client.request(server.id, &reader, proto::NodeRequestBody::GetEvents { collection: ScopedRecord::collection(), event_ids }).await?;
+    let served = match response {
+        proto::NodeResponseBody::GetEvents(events) => events,
+        other => anyhow::bail!("expected a GetEvents response, got {other:?}"),
+    };
+    let served_ids: HashSet<proto::EventId> = served.iter().map(|event| event.payload.id()).collect();
+
+    for event in &fixture.denied_events {
+        assert!(
+            !served_ids.contains(&event.payload.id()),
+            "an event of a row outside the token's read scope must not be served (event {:?} of record {})",
+            event.payload.id(),
+            fixture.denied_record_id
+        );
+    }
+    for event in &fixture.allowed_events {
+        assert!(
+            served_ids.contains(&event.payload.id()),
+            "an event of a row inside the token's read scope must still be served (event {:?} of record {})",
+            event.payload.id(),
+            fixture.allowed_record_id
+        );
+    }
+
+    // The state path, same token, same two rows: the verdicts must line up.
+    let response = client
+        .request(
+            server.id,
+            &reader,
+            proto::NodeRequestBody::Get {
+                collection: ScopedRecord::collection(),
+                ids: vec![fixture.allowed_record_id, fixture.denied_record_id],
+            },
+        )
+        .await?;
+    let states = match response {
+        proto::NodeResponseBody::Get(states) => states,
+        other => anyhow::bail!("expected a Get response, got {other:?}"),
+    };
+    let state_ids: HashSet<proto::EntityId> = states.iter().map(|state| state.payload.entity_id).collect();
+    assert!(!state_ids.contains(&fixture.denied_record_id), "the state path must deny the same row the event path denied");
+    assert!(state_ids.contains(&fixture.allowed_record_id), "the state path must allow the same row the event path allowed");
+
+    Ok(())
+}
+
+/// The row scope is evaluated against the entity's current state, so a serving
+/// node that has no state for the entity has nothing to evaluate: it refuses.
+/// A collection carrying no scope rules is a different case -- the collection
+/// gate already settled it, and a missing state changes nothing there.
+#[tokio::test]
+async fn missing_current_state_denies_scoped_events_and_spares_unscoped_ones() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+    let agent = configured_agent(&keys)?;
+
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent.clone());
+    node.system.create().await?;
+
+    let root = node.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let note_id = {
+        let trx = root.begin();
+        let note = trx.create(&Note { text: "unscoped".into() }).await?;
+        let id = note.id();
+        trx.commit().await?;
+        id
+    };
+    let note_event = root.collection(&Note::collection()).await?.dump_entity_events(note_id).await?.remove(0);
+
+    let records = root.collection(&ScopedRecord::collection()).await?;
+    let allowed_state = records.get_state(fixture.allowed_record_id).await?.payload.state;
+    let denied_state = records.get_state(fixture.denied_record_id).await?.payload.state;
+
+    let claims = reader_claims(fixture.allowed_account_id);
+    let token = keys.sign(&claims, Duration::from_hours(1))?;
+    let reader = JwtContext::from_claims(claims, token);
+
+    let allowed_event = fixture.allowed_events[0].clone();
+    let denied_event = fixture.denied_events[0].clone();
+
+    // Fail closed: a scoped collection with no state to evaluate is refused,
+    // even for an event whose row the token could otherwise read.
+    assert!(
+        agent.check_read_event(&reader, &allowed_event, None).is_err(),
+        "a scoped event with no current state must be refused rather than admitted unevaluated"
+    );
+    assert!(agent.check_read_event(&reader, &denied_event, None).is_err(), "a scoped event with no current state must be refused");
+
+    // With state, the event verdict matches the state verdict row for row.
+    assert!(agent.check_read_event(&reader, &allowed_event, Some(&allowed_state)).is_ok());
+    assert!(agent.check_read_event(&reader, &denied_event, Some(&denied_state)).is_err());
+    assert!(agent.check_read(&reader, &fixture.allowed_record_id, &ScopedRecord::collection(), &allowed_state).is_ok());
+    assert!(agent.check_read(&reader, &fixture.denied_record_id, &ScopedRecord::collection(), &denied_state).is_err());
+
+    // Control: no scope rules on `note`, so the collection gate is the whole
+    // decision and a missing state is not a refusal.
+    assert!(
+        agent.check_read_event(&reader, &note_event, None).is_ok(),
+        "a collection with no scope rules must stay readable when no state is available"
+    );
+
+    Ok(())
+}

--- a/extensions/jwt-auth/tests/event_read_scope_tests.rs
+++ b/extensions/jwt-auth/tests/event_read_scope_tests.rs
@@ -3,8 +3,11 @@
 //! A scope rule narrows which rows a token may read. The state path applies it
 //! per row, but events replay the same CRDT content, so a token that is refused
 //! a row and then granted that row's events reads the row anyway. These tests
-//! hold the two paths to the same verdict on one fixture, and pin what happens
-//! when the serving node has no current state to evaluate the rule against.
+//! hold the two paths to the same verdict on one fixture, and pin the rest of
+//! what the event path owes that verdict: a privileged caller still reads
+//! everything, several credentials read their union, and the state the rule is
+//! evaluated against must be the event's own entity's, must actually account
+//! for the event, and comes from the resident entity when one is held.
 
 mod common;
 
@@ -70,30 +73,36 @@ fn reader_claims(account_id: proto::EntityId) -> JwtClaims {
     JwtClaims { sub: "reader-1".into(), roles: vec!["AccountReader".into()], email: "reader@example.com".into(), name: None, custom }
 }
 
-/// One record per account, each carrying a create event and an update event.
+/// Three accounts, one record each, every record carrying a create event and an
+/// update event. `allowed` and `second` are each readable by one of the two
+/// tokens the plural case unions; `denied` is readable by neither.
 struct Fixture {
     allowed_account_id: proto::EntityId,
+    second_account_id: proto::EntityId,
     allowed_record_id: proto::EntityId,
     denied_record_id: proto::EntityId,
     allowed_events: Vec<proto::Attested<proto::Event>>,
+    second_events: Vec<proto::Attested<proto::Event>>,
     denied_events: Vec<proto::Attested<proto::Event>>,
 }
 
 async fn build_fixture(root: &ankurah::Context) -> anyhow::Result<Fixture> {
-    let (allowed_account_id, denied_account_id) = {
+    let (allowed_account_id, second_account_id, denied_account_id) = {
         let trx = root.begin();
         let allowed = trx.create(&Account { name: "Allowed".into() }).await?;
+        let second = trx.create(&Account { name: "Second".into() }).await?;
         let denied = trx.create(&Account { name: "Denied".into() }).await?;
-        let ids = (allowed.id(), denied.id());
+        let ids = (allowed.id(), second.id(), denied.id());
         trx.commit().await?;
         ids
     };
 
-    let (allowed_record_id, denied_record_id) = {
+    let (allowed_record_id, second_record_id, denied_record_id) = {
         let trx = root.begin();
         let allowed = trx.create(&ScopedRecord { account: allowed_account_id.into(), label: "allowed".into() }).await?;
+        let second = trx.create(&ScopedRecord { account: second_account_id.into(), label: "second".into() }).await?;
         let denied = trx.create(&ScopedRecord { account: denied_account_id.into(), label: "denied".into() }).await?;
-        let ids = (allowed.id(), denied.id());
+        let ids = (allowed.id(), second.id(), denied.id());
         trx.commit().await?;
         ids
     };
@@ -102,17 +111,38 @@ async fn build_fixture(root: &ankurah::Context) -> anyhow::Result<Fixture> {
     {
         let trx = root.begin();
         root.get::<ScopedRecordView>(allowed_record_id).await?.edit(&trx)?.label().set(&"allowed-updated".to_string())?;
+        root.get::<ScopedRecordView>(second_record_id).await?.edit(&trx)?.label().set(&"second-updated".to_string())?;
         root.get::<ScopedRecordView>(denied_record_id).await?.edit(&trx)?.label().set(&"denied-updated".to_string())?;
         trx.commit().await?;
     }
 
     let records = root.collection(&ScopedRecord::collection()).await?;
     let allowed_events = records.dump_entity_events(allowed_record_id).await?;
+    let second_events = records.dump_entity_events(second_record_id).await?;
     let denied_events = records.dump_entity_events(denied_record_id).await?;
-    assert_eq!(allowed_events.len(), 2, "fixture should carry a create and an update per record");
-    assert_eq!(denied_events.len(), 2, "fixture should carry a create and an update per record");
+    for events in [&allowed_events, &second_events, &denied_events] {
+        assert_eq!(events.len(), 2, "fixture should carry a create and an update per record");
+    }
 
-    Ok(Fixture { allowed_account_id, allowed_record_id, denied_record_id, allowed_events, denied_events })
+    Ok(Fixture { allowed_account_id, second_account_id, allowed_record_id, denied_record_id, allowed_events, second_events, denied_events })
+}
+
+/// Ask a serving node for events by id and collect what it hands back.
+async fn served_event_ids<C>(
+    client: &Node<SledStorageEngine, JwtAgent>,
+    server_id: proto::EntityId,
+    cdata: &C,
+    event_ids: Vec<proto::EventId>,
+) -> anyhow::Result<HashSet<proto::EventId>>
+where
+    C: ankurah_core::util::Iterable<JwtContext>,
+{
+    let response =
+        client.request(server_id, cdata, proto::NodeRequestBody::GetEvents { collection: ScopedRecord::collection(), event_ids }).await?;
+    match response {
+        proto::NodeResponseBody::GetEvents(events) => Ok(events.iter().map(|event| event.payload.id()).collect()),
+        other => anyhow::bail!("expected a GetEvents response, got {other:?}"),
+    }
 }
 
 /// A peer asks a serving node for events by id. The serving node must hand back
@@ -139,13 +169,7 @@ async fn get_events_applies_the_same_row_scope_as_get_states() -> anyhow::Result
     // The event path: ask for both records' events in one batch.
     let event_ids: Vec<proto::EventId> =
         fixture.allowed_events.iter().chain(fixture.denied_events.iter()).map(|event| event.payload.id()).collect();
-    let response =
-        client.request(server.id, &reader, proto::NodeRequestBody::GetEvents { collection: ScopedRecord::collection(), event_ids }).await?;
-    let served = match response {
-        proto::NodeResponseBody::GetEvents(events) => events,
-        other => anyhow::bail!("expected a GetEvents response, got {other:?}"),
-    };
-    let served_ids: HashSet<proto::EventId> = served.iter().map(|event| event.payload.id()).collect();
+    let served_ids = served_event_ids(&client, server.id, &reader, event_ids).await?;
 
     for event in &fixture.denied_events {
         assert!(
@@ -211,8 +235,8 @@ async fn missing_current_state_denies_scoped_events_and_spares_unscoped_ones() -
     let note_event = root.collection(&Note::collection()).await?.dump_entity_events(note_id).await?.remove(0);
 
     let records = root.collection(&ScopedRecord::collection()).await?;
-    let allowed_state = records.get_state(fixture.allowed_record_id).await?.payload.state;
-    let denied_state = records.get_state(fixture.denied_record_id).await?.payload.state;
+    let allowed_state = records.get_state(fixture.allowed_record_id).await?.payload;
+    let denied_state = records.get_state(fixture.denied_record_id).await?.payload;
 
     let claims = reader_claims(fixture.allowed_account_id);
     let token = keys.sign(&claims, Duration::from_hours(1))?;
@@ -232,14 +256,195 @@ async fn missing_current_state_denies_scoped_events_and_spares_unscoped_ones() -
     // With state, the event verdict matches the state verdict row for row.
     assert!(agent.check_read_event(&reader, &allowed_event, Some(&allowed_state)).is_ok());
     assert!(agent.check_read_event(&reader, &denied_event, Some(&denied_state)).is_err());
-    assert!(agent.check_read(&reader, &fixture.allowed_record_id, &ScopedRecord::collection(), &allowed_state).is_ok());
-    assert!(agent.check_read(&reader, &fixture.denied_record_id, &ScopedRecord::collection(), &denied_state).is_err());
+    assert!(agent.check_read(&reader, &fixture.allowed_record_id, &ScopedRecord::collection(), &allowed_state.state).is_ok());
+    assert!(agent.check_read(&reader, &fixture.denied_record_id, &ScopedRecord::collection(), &denied_state.state).is_err());
+
+    // A state paired with an event of a different entity is evidence about the
+    // wrong row: the readable row's state would admit the unreadable row's event.
+    assert!(
+        agent.check_read_event(&reader, &denied_event, Some(&allowed_state)).is_err(),
+        "an event paired with another entity's state must be refused, not evaluated against that state"
+    );
 
     // Control: no scope rules on `note`, so the collection gate is the whole
     // decision and a missing state is not a refusal.
     assert!(
         agent.check_read_event(&reader, &note_event, None).is_ok(),
         "a collection with no scope rules must stay readable when no state is available"
+    );
+
+    Ok(())
+}
+
+/// A privileged context is admitted before any scope rule is consulted, and the
+/// event path must keep that so: `Root` reads every row's events, including
+/// rows no token's scope would admit, and reads them with no state available.
+///
+/// The assertion sits at the agent rather than on the wire because `Root` is a
+/// local-only context -- it cannot produce auth data, so it never travels as a
+/// request credential.
+#[tokio::test]
+async fn a_privileged_context_reads_events_of_rows_no_scope_admits() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+    let agent = configured_agent(&keys)?;
+
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent.clone());
+    node.system.create().await?;
+
+    let root = node.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let records = root.collection(&ScopedRecord::collection()).await?;
+    let denied_state = records.get_state(fixture.denied_record_id).await?.payload;
+    let privileged = JwtContext::system();
+
+    for event in fixture.allowed_events.iter().chain(fixture.denied_events.iter()) {
+        assert!(
+            agent.check_read_event(&privileged, event, None).is_ok(),
+            "a privileged context must read every event, with or without a state to evaluate"
+        );
+    }
+    assert!(
+        agent.check_read_event(&privileged, &fixture.denied_events[0], Some(&denied_state)).is_ok(),
+        "a privileged context must read a row its scope rules would refuse"
+    );
+
+    Ok(())
+}
+
+/// A caller can act under several credentials at once. Reads take the union:
+/// the events served are exactly those of the rows some member admits, and a
+/// row no member admits stays hidden even though a member could read the
+/// collection.
+#[tokio::test]
+async fn plural_credentials_read_the_union_of_their_rows_events() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    server.system.create().await?;
+
+    let root = server.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let mut readers = Vec::new();
+    for account_id in [fixture.allowed_account_id, fixture.second_account_id] {
+        let claims = reader_claims(account_id);
+        let token = keys.sign(&claims, Duration::from_hours(1))?;
+        readers.push(JwtContext::from_claims(claims, token));
+    }
+
+    let all_events: Vec<&proto::Attested<proto::Event>> =
+        fixture.allowed_events.iter().chain(fixture.second_events.iter()).chain(fixture.denied_events.iter()).collect();
+    let served_ids = served_event_ids(&client, server.id, &readers, all_events.iter().map(|event| event.payload.id()).collect()).await?;
+
+    let expected: HashSet<proto::EventId> =
+        fixture.allowed_events.iter().chain(fixture.second_events.iter()).map(|event| event.payload.id()).collect();
+    assert_eq!(
+        served_ids, expected,
+        "the union of two tokens must be served exactly the events of the rows they jointly admit -- not the third account's row ({}), \
+         and not a subset of their own",
+        fixture.denied_record_id
+    );
+
+    Ok(())
+}
+
+/// A commit publishes its event before it persists the entity's state, so a
+/// serving node can hold an event its stored state does not yet account for --
+/// and that event may be the very one that moves the row out of the caller's
+/// scope. An event the authorizing state cannot speak for is not served.
+///
+/// The window is staged rather than raced: the serving node below is given the
+/// whole event chain but only the state as of the create, and never
+/// materializes the entity, so nothing fresher is available to authorize
+/// against.
+#[tokio::test]
+async fn an_event_the_authorizing_state_does_not_cover_is_not_served() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let origin = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    origin.system.create().await?;
+    let origin_root = origin.context(JwtContext::system())?;
+    let fixture = build_fixture(&origin_root).await?;
+
+    let origin_records = origin_root.collection(&ScopedRecord::collection()).await?;
+    let create_event = fixture.allowed_events.iter().find(|event| event.payload.parent.is_empty()).expect("a create event");
+    let update_event = fixture.allowed_events.iter().find(|event| !event.payload.parent.is_empty()).expect("an update event");
+    let mut state_at_create = origin_records.get_state(fixture.allowed_record_id).await?;
+    state_at_create.payload.state.head = proto::Clock::from(create_event.payload.id());
+
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    server.system.create().await?;
+    let server_records = server.context(JwtContext::system())?.collection(&ScopedRecord::collection()).await?;
+    for event in &fixture.allowed_events {
+        server_records.add_event(event).await?;
+    }
+    server_records.set_state(state_at_create).await?;
+
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let claims = reader_claims(fixture.allowed_account_id);
+    let token = keys.sign(&claims, Duration::from_hours(1))?;
+    let reader = JwtContext::from_claims(claims, token);
+
+    let served_ids = served_event_ids(&client, server.id, &reader, vec![create_event.payload.id(), update_event.payload.id()]).await?;
+
+    assert!(
+        served_ids.contains(&create_event.payload.id()),
+        "the event the stored state accounts for must still be served, or the refusal below proves nothing"
+    );
+    assert!(!served_ids.contains(&update_event.payload.id()), "an event newer than the state that authorized it must not be served");
+
+    Ok(())
+}
+
+/// The stored state buffer is a rebuildable cache of the event log, and the
+/// EventOnly apply path leaves it behind: it commits events and advances the
+/// in-memory entity without rewriting the buffer. Authorizing from storage alone
+/// would therefore judge the row several events out of date, so a resident
+/// entity is consulted first and outranks what storage holds.
+///
+/// Here the same node holds the entity resident and up to date while its stored
+/// state is rewound to the create. The update event must still be served: the
+/// resident entity accounts for it even though the buffer does not.
+#[tokio::test]
+async fn a_resident_entity_outranks_a_rewound_stored_state() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    server.system.create().await?;
+    let root = server.context(JwtContext::system())?;
+    let fixture = build_fixture(&root).await?;
+
+    let records = root.collection(&ScopedRecord::collection()).await?;
+    let create_event = fixture.allowed_events.iter().find(|event| event.payload.parent.is_empty()).expect("a create event");
+    let update_event = fixture.allowed_events.iter().find(|event| !event.payload.parent.is_empty()).expect("an update event");
+
+    // Hold the entity resident at its true head, then rewind what storage says.
+    let _resident = root.get::<ScopedRecordView>(fixture.allowed_record_id).await?;
+    let mut rewound = records.get_state(fixture.allowed_record_id).await?;
+    rewound.payload.state.head = proto::Clock::from(create_event.payload.id());
+    records.set_state(rewound).await?;
+
+    let client = Node::new(Arc::new(SledStorageEngine::new_test()?), configured_agent(&keys)?);
+    let _conn = LocalProcessConnection::new(&server, &client).await?;
+    client.system.wait_system_ready().await;
+
+    let claims = reader_claims(fixture.allowed_account_id);
+    let token = keys.sign(&claims, Duration::from_hours(1))?;
+    let reader = JwtContext::from_claims(claims, token);
+
+    let served_ids = served_event_ids(&client, server.id, &reader, vec![create_event.payload.id(), update_event.payload.id()]).await?;
+    assert_eq!(
+        served_ids,
+        HashSet::from([create_event.payload.id(), update_event.payload.id()]),
+        "the resident entity accounts for both events, so a stale stored state must not withhold either"
     );
 
     Ok(())

--- a/specs/concurrency/threat-model.md
+++ b/specs/concurrency/threat-model.md
@@ -141,7 +141,7 @@ Receive-side arms and the policy hook each gets (verified in
 | `EventBridge` | `apply_delta_inner` | yes | n/a | yes | catch-up batch |
 | `StateAndRelation` | `apply_delta_inner` | unimpl | unimpl | n/a | returns `InvalidUpdate` |
 | `GetEvents` resp, mid-BFS | `CachedEventGetter::get_event` | **NO** (#244) | n/a | n/a | stored via `add_event` unvalidated |
-| `GetEvents` req, served | `node.rs` `GetEvents` arm | n/a | n/a | n/a | serve side DOES `can_access_collection` + `check_read_event` |
+| `GetEvents` req, served | `node.rs` `GetEvents` arm | n/a | n/a | n/a | serve side DOES `can_access_collection` + `check_read_event` (against the entity's current state) |
 | `commit_remote_transaction` | `node.rs` same | via `check_event` | via `attest_state` | n/a | creation-event fork asymmetry (#243) |
 
 ("yes" = via `validate_and_stage`.) The key asymmetry: **every `apply_*` arm
@@ -483,9 +483,15 @@ builder), each event passes the read policy before leaving the node; a peer cann
 read events it is not permitted to.
 Trust tier: attestation-dependent (nil under PermissiveAgent).
 Enforcing seam: `node.rs` `GetEvents` arm calls
-`can_access_collection(cdata, &collection)` then `check_read_event(cdata, &event)`
-per event, pushing only allowed events; `collect_event_bridge` runs
-`check_read_event` over the collected events (post-walk).
+`can_access_collection(cdata, &collection)` then
+`check_read_event(cdata, &event, current_state)` per event, pushing only allowed
+events; `collect_event_bridge` runs `check_read_event` over the collected events
+(post-walk). The current state travels with the event so an agent that admits
+entities row by row can apply the same rule it applies in `check_read` -- without
+it the row filter reduced to the collection gate and events reconstructed content
+the state path withheld (#438). The serving node supplies the state it holds for
+the event's entity, or `None` when it holds none, and the agent decides what an
+absent state means.
 Falsifying attack (T2): request events for a collection/entity the requester cannot
 read, defeated only if the agent's read checks are correct.
 Planned test arm: read-authorization arm with a restricting agent asserting denied

--- a/specs/concurrency/threat-model.md
+++ b/specs/concurrency/threat-model.md
@@ -491,14 +491,25 @@ entities row by row can apply the same rule it applies in `check_read` -- withou
 it the row filter reduced to the collection gate and events reconstructed content
 the state path withheld (#438). The serving node supplies the state it holds for
 the event's entity, or `None` when it holds none, and the agent decides what an
-absent state means.
+absent state means. Three things keep that pairing honest: the state travels as a
+whole `EntityState` so the agent can refuse one belonging to another entity; the
+`GetEvents` arm prefers the resident entity over the stored state buffer, which the
+EventOnly apply path leaves behind; and it serves an event only when the paired
+state's head causally covers it, since a commit publishes its event before it
+persists its state and the event may be the one that moves the row out of scope.
+The bridge walk excludes any event naming a different entity than the state it is
+checked against (a grafted parent pointer), giving up the bridge for a snapshot.
 Falsifying attack (T2): request events for a collection/entity the requester cannot
 read, defeated only if the agent's read checks are correct.
 Planned test arm: read-authorization arm with a restricting agent asserting denied
 events are filtered from both `GetEvents` and `EventBridge` responses.
 Status: enforced as call sites. Note the DoS interaction: `collect_event_bridge`
 filters *after* the unbounded walk (C4-17), so a read-denied bridge still costs the
-full traversal.
+full traversal. Two accepted residuals: the verdict is about the row as it stands
+now, so a caller who can read a row today reads that row's history from before the
+scope change (#445); and the IndexedDB engine stores events without collection
+identity, so an event can be relabelled into a collection whose rules the caller
+passes (#444).
 
 ### 3.5 Local-commit policy claims
 

--- a/specs/concurrency/threat-model.md
+++ b/specs/concurrency/threat-model.md
@@ -141,7 +141,7 @@ Receive-side arms and the policy hook each gets (verified in
 | `EventBridge` | `apply_delta_inner` | yes | n/a | yes | catch-up batch |
 | `StateAndRelation` | `apply_delta_inner` | unimpl | unimpl | n/a | returns `InvalidUpdate` |
 | `GetEvents` resp, mid-BFS | `CachedEventGetter::get_event` | **NO** (#244) | n/a | n/a | stored via `add_event` unvalidated |
-| `GetEvents` req, served | `node.rs` `GetEvents` arm | n/a | n/a | n/a | serve side DOES `can_access_collection` + `check_read_event` |
+| `GetEvents` req, served | `node.rs` `GetEvents` arm | n/a | n/a | n/a | serve side DOES `can_access_collection` + `check_read_event` (against the entity as currently held, fetched lazily) |
 | `commit_remote_transaction` | `node.rs` same | via `check_event` | via `attest_state` | n/a | creation-event fork asymmetry (#243) |
 
 ("yes" = via `validate_and_stage`.) The key asymmetry: **every `apply_*` arm
@@ -483,16 +483,46 @@ builder), each event passes the read policy before leaving the node; a peer cann
 read events it is not permitted to.
 Trust tier: attestation-dependent (nil under PermissiveAgent).
 Enforcing seam: `node.rs` `GetEvents` arm calls
-`can_access_collection(cdata, &collection)` then `check_read_event(cdata, &event)`
-per event, pushing only allowed events; `collect_event_bridge` runs
-`check_read_event` over the collected events (post-walk).
+`can_access_collection(cdata, &collection)` then
+`check_read_event(cdata, &event, getter)` per event, pushing only allowed
+events; `collect_event_bridge` runs `check_read_event` over the collected events
+(post-walk). The getter (`core/src/lazy_entity_getter.rs`) is bound at
+construction to the event's own entity and collection, and fetches the row only
+if the agent's verdict turns on row content -- so an agent that admits entities
+row by row applies the same rule it applies in `check_read`, and without that
+the row filter reduced to the collection gate and events reconstructed content
+the state path withheld (#438). Fetching goes through the node's own entity
+machinery: the resident entity when one is held (the EventOnly apply path
+advances it past the stored state buffer), otherwise materialized from stored
+state, and `None` when nothing current exists, which an agent whose verdict
+needs the row treats as refusal. Binding the getter to the event's entity at
+construction is what closed the old hazard of judging an event against some
+other, readable row's state.
+The bridge walk excludes any event naming a different entity than the state it
+walks from (a grafted parent pointer), giving up the bridge for a snapshot.
 Falsifying attack (T2): request events for a collection/entity the requester cannot
 read, defeated only if the agent's read checks are correct.
 Planned test arm: read-authorization arm with a restricting agent asserting denied
 events are filtered from both `GetEvents` and `EventBridge` responses.
 Status: enforced as call sites. Note the DoS interaction: `collect_event_bridge`
 filters *after* the unbounded walk (C4-17), so a read-denied bridge still costs the
-full traversal.
+full traversal. Two accepted residuals: the verdict is about the row as it stands
+now, so a caller who can read a row today reads that row's history from before the
+scope change (#445); and the IndexedDB engine stores events without collection
+identity, so an event can be relabelled into a collection whose rules the caller
+passes (#444).
+
+Why serving events is gated at all, given that a caller must already name event
+ids: ids are not capabilities. `EventId` derives from content
+(`EventId::from_parts(entity_id, operations, parent)`, proto/src/data.rs), and a
+genesis event's parent is empty, so for a row whose creation operations are
+deterministic and low-entropy the genesis id is computable offline from guessed
+content, and each later id from the guessed chain before it. Histories carrying
+high-entropy payloads (CRDT text updates carry internal client state) are not
+practically computable, so the offline route is largely theoretical today.
+Independent of guessing, a head learned while a row was in scope keeps naming
+that row's events after the scope changes (#445). The row check holds however
+the id was obtained.
 
 ### 3.5 Local-commit policy claims
 

--- a/specs/jwt-auth/spec.md
+++ b/specs/jwt-auth/spec.md
@@ -214,6 +214,11 @@ Both run the same row-level check, so a caller refused an entity's state is also
 - No scope rules on the collection: allowed, the collection gate was the whole decision.
 - Otherwise the entity's state is loaded into a `TemporaryEntity` and each read-applicable scope predicate is evaluated against it; a context is admitted when all of its predicates hold.
 - `check_read_event` evaluates against the entity's *current* state, which the serving node passes in. When no current state is available, a collection carrying scope rules is refused (there is nothing to evaluate) and a collection without them is unaffected.
+- The state must belong to the event's own entity. A mispaired one is refused rather than evaluated: another row's state would answer for a row the caller can read in place of the row the event actually belongs to.
+
+Accepted residual: the verdict is about the row as it stands now, so a caller who can read a row today reads that row's whole history, including the part written while the row sat outside its scope. Per-event historical evaluation is tracked in [issue #445](https://github.com/ankurah/ankurah/issues/445).
+
+Engine-dependent limitation: on the IndexedDB engine events are stored without collection identity, so an event can be relabelled into a collection the caller may read and be judged by that collection's rules rather than its own ([issue #444](https://github.com/ankurah/ankurah/issues/444)).
 
 #### `validate_received_event` / `validate_received_state` / `attest_state` / `validate_causal_assertion`
 

--- a/specs/jwt-auth/spec.md
+++ b/specs/jwt-auth/spec.md
@@ -208,7 +208,12 @@ Deserializes `AuthData` back into `JwtContext`:
 
 #### `check_read` / `check_read_event`
 
-Delegates to `can_access_collection`.
+Both run the same row-level check, so a caller refused an entity's state is also refused that entity's events (events replay the same content):
+
+- `can_access_collection` first; `Root` context bypasses the rest.
+- No scope rules on the collection: allowed, the collection gate was the whole decision.
+- Otherwise the entity's state is loaded into a `TemporaryEntity` and each read-applicable scope predicate is evaluated against it; a context is admitted when all of its predicates hold.
+- `check_read_event` evaluates against the entity's *current* state, which the serving node passes in. When no current state is available, a collection carrying scope rules is refused (there is nothing to evaluate) and a collection without them is unaffected.
 
 #### `validate_received_event` / `validate_received_state` / `attest_state` / `validate_causal_assertion`
 

--- a/specs/jwt-auth/spec.md
+++ b/specs/jwt-auth/spec.md
@@ -217,15 +217,16 @@ The row-level half of write scoping: a non-privileged writer may only touch rows
 
 #### `check_read`
 
-The row-level half of read scoping: admits or refuses one entity by its serialized state, where `filter_predicate` narrows the query up front.
+The row-level half of read scoping: admits or refuses one entity by its serialized state, where `filter_predicate` narrows the query up front. `check_read` and `check_read_event` run the same row-level check through one shared helper, so a caller refused an entity's state is also refused that entity's events (events replay the same content):
 
 - Requires `can_access_collection`. `Root` passes unconditionally.
 - No scope rules for the collection: allowed.
 - Otherwise materializes the state into a `TemporaryEntity` (a state that cannot be evaluated is refused) and walks the caller's credentials: a credential admits the row when every one of its read-applicable, substituted scope predicates evaluates true, and the first admitting credential allows the read. Unauthorized and unresolvable credentials are skipped exactly as in `filter_predicate` (logged at `debug` -- the query half already warned once per query), so credential order cannot change the answer. A credential no rule constrains admits every row. A scope predicate that fails to evaluate against the row refuses the read; so does running out of credentials.
+- `check_read_event` runs the same rules against the entity as it *currently* stands, fetched through a getter the serving node hands in. The getter is bound to the event's own entity at construction -- there is no way to hand the check another row -- and the verdict fetches only when it must: a privileged caller or an unscoped collection decides before any fetch happens. When nothing current exists for an event of a scoped collection, the event is refused (there is nothing to evaluate); an unscoped collection is unaffected. A fetch failure is surfaced as an error, not a refusal.
 
-#### `check_read_event`
+Accepted residual: the verdict is about the row as it stands now, so a caller who can read a row today reads that row's whole history, including the part written while the row sat outside its scope. Per-event historical evaluation is tracked in [issue #445](https://github.com/ankurah/ankurah/issues/445).
 
-`Root` passes; otherwise delegates to `can_access_collection` for the event's collection.
+Engine-dependent limitation: on the IndexedDB engine events are stored without collection identity, so an event can be relabelled into a collection the caller may read and be judged by that collection's rules rather than its own ([issue #444](https://github.com/ankurah/ankurah/issues/444)).
 
 #### `validate_received_event` / `validate_received_state` / `attest_state` / `validate_causal_assertion`
 

--- a/tests/tests/bridge_policy.rs
+++ b/tests/tests/bridge_policy.rs
@@ -119,8 +119,16 @@ impl PolicyAgent for BridgePolicyAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
+    async fn check_read_event<SE, C>(
+        &self,
+        _data: &C,
+        event: &Attested<proto::Event>,
+        _getter: &ankurah::core::lazy_entity_getter::EntityGetter<'_, SE, Self>,
+    ) -> Result<(), AccessDenied>
+    where
+        SE: StorageEngine + Send + Sync + 'static,
+        C: Iterable<Self::ContextData> + Sync,
+    {
         if self.deny_read_events.lock().unwrap().contains(&event.payload.id()) {
             return Err(AccessDenied::ByPolicy("event read denied by test agent"));
         }
@@ -251,6 +259,80 @@ async fn test_event_bridge_respects_read_policy_on_send() -> Result<()> {
     // unverifiable state is not adopted.
     let _ = open_id;
     assert_eq!(ctx_c.get::<PetView>(pet_id).await?.age().unwrap(), "1", "client remains at its last verified state");
+
+    Ok(())
+}
+
+/// A parent pointer names an event id, not an entity, so an entity's history
+/// can be made to reach an event belonging to a different entity -- a graft,
+/// whether from a bug upstream or an event a peer forged. The bridge walk must
+/// not put such an event on the wire: the window travels as `EventFragment`s,
+/// which carry no entity id, so the receiver would apply the other entity's
+/// operations to this one. Nor can the read check catch it, since it evaluates
+/// every event in the window against this entity's state.
+///
+/// The two chains below are the same shape (one middle event, one tip) over the
+/// same known head, and differ only in which entity the middle event names, so
+/// an empty window in the grafted case is the guard's doing and not a causal
+/// comparison that never reached the walk.
+#[tokio::test]
+async fn test_event_bridge_refuses_a_window_that_leaves_the_entity() -> Result<()> {
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test().unwrap()), PermissiveAgent::new());
+    server.system.create().await?;
+    let ctx = server.context(DEFAULT_CONTEXT)?;
+
+    let (pet_id, other_id) = {
+        let trx = ctx.begin();
+        let pet = trx.create(&Pet { name: "grafted".to_string(), age: "1".to_string() }).await?;
+        let other = trx.create(&Pet { name: "elsewhere".to_string(), age: "1".to_string() }).await?;
+        let ids = (pet.id(), other.id());
+        trx.commit().await?;
+        ids
+    };
+
+    let collection = ctx.collection(&Pet::collection()).await?;
+    let known_head = collection.get_state(pet_id).await?.payload.state.head.clone();
+
+    // Write two chains onto the pet's creation event. The clean one stays on
+    // the pet throughout; the grafted one routes through an event of the other
+    // pet. Storage is written directly because no commit path will produce the
+    // graft -- that is the point of the guard.
+    let forge = |entity_id: proto::EntityId, parent: proto::Clock| {
+        let event = proto::Event { collection: Pet::collection(), entity_id, operations: proto::OperationSet::default(), parent };
+        proto::Attested::opt(event, None)
+    };
+    let clean_middle = forge(pet_id, known_head.clone());
+    let clean_tip = forge(pet_id, proto::Clock::from(clean_middle.payload.id()));
+    let grafted_middle = forge(other_id, known_head.clone());
+    let grafted_tip = forge(pet_id, proto::Clock::from(grafted_middle.payload.id()));
+    for event in [&clean_middle, &clean_tip, &grafted_middle, &grafted_tip] {
+        collection.add_event(event).await?;
+    }
+
+    let state_at = |head: proto::Clock| proto::EntityState {
+        entity_id: pet_id,
+        collection: Pet::collection(),
+        state: proto::State { head, ..Default::default() },
+    };
+
+    let clean = server
+        .collect_event_bridge_for_test(&collection, &known_head, &state_at(proto::Clock::from(clean_tip.payload.id())), &DEFAULT_CONTEXT)
+        .await?;
+    let clean_ids: HashSet<_> = clean.iter().map(|e| e.payload.id()).collect();
+    assert_eq!(
+        clean_ids,
+        HashSet::from([clean_middle.payload.id(), clean_tip.payload.id()]),
+        "the control chain must bridge, otherwise the grafted case proves nothing"
+    );
+
+    let grafted = server
+        .collect_event_bridge_for_test(&collection, &known_head, &state_at(proto::Clock::from(grafted_tip.payload.id())), &DEFAULT_CONTEXT)
+        .await?;
+    assert!(
+        grafted.is_empty(),
+        "a window reaching another entity's event must yield no bridge (the caller falls back to a state snapshot), got {:?}",
+        grafted.iter().map(|e| e.payload.id()).collect::<Vec<_>>()
+    );
 
     Ok(())
 }

--- a/tests/tests/bridge_policy.rs
+++ b/tests/tests/bridge_policy.rs
@@ -123,7 +123,7 @@ impl PolicyAgent for BridgePolicyAgent {
         &self,
         _data: &C,
         event: &Attested<proto::Event>,
-        _current_state: Option<&proto::State>,
+        _current_state: Option<&proto::EntityState>,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,
@@ -258,6 +258,80 @@ async fn test_event_bridge_respects_read_policy_on_send() -> Result<()> {
     // unverifiable state is not adopted.
     let _ = open_id;
     assert_eq!(ctx_c.get::<PetView>(pet_id).await?.age().unwrap(), "1", "client remains at its last verified state");
+
+    Ok(())
+}
+
+/// A parent pointer names an event id, not an entity, so an entity's history
+/// can be made to reach an event belonging to a different entity -- a graft,
+/// whether from a bug upstream or an event a peer forged. The bridge walk must
+/// not put such an event on the wire: the window travels as `EventFragment`s,
+/// which carry no entity id, so the receiver would apply the other entity's
+/// operations to this one. Nor can the read check catch it, since it evaluates
+/// every event in the window against this entity's state.
+///
+/// The two chains below are the same shape (one middle event, one tip) over the
+/// same known head, and differ only in which entity the middle event names, so
+/// an empty window in the grafted case is the guard's doing and not a causal
+/// comparison that never reached the walk.
+#[tokio::test]
+async fn test_event_bridge_refuses_a_window_that_leaves_the_entity() -> Result<()> {
+    let server = Node::new_durable(Arc::new(SledStorageEngine::new_test().unwrap()), PermissiveAgent::new());
+    server.system.create().await?;
+    let ctx = server.context(DEFAULT_CONTEXT)?;
+
+    let (pet_id, other_id) = {
+        let trx = ctx.begin();
+        let pet = trx.create(&Pet { name: "grafted".to_string(), age: "1".to_string() }).await?;
+        let other = trx.create(&Pet { name: "elsewhere".to_string(), age: "1".to_string() }).await?;
+        let ids = (pet.id(), other.id());
+        trx.commit().await?;
+        ids
+    };
+
+    let collection = ctx.collection(&Pet::collection()).await?;
+    let known_head = collection.get_state(pet_id).await?.payload.state.head.clone();
+
+    // Write two chains onto the pet's creation event. The clean one stays on
+    // the pet throughout; the grafted one routes through an event of the other
+    // pet. Storage is written directly because no commit path will produce the
+    // graft -- that is the point of the guard.
+    let forge = |entity_id: proto::EntityId, parent: proto::Clock| {
+        let event = proto::Event { collection: Pet::collection(), entity_id, operations: proto::OperationSet::default(), parent };
+        proto::Attested::opt(event, None)
+    };
+    let clean_middle = forge(pet_id, known_head.clone());
+    let clean_tip = forge(pet_id, proto::Clock::from(clean_middle.payload.id()));
+    let grafted_middle = forge(other_id, known_head.clone());
+    let grafted_tip = forge(pet_id, proto::Clock::from(grafted_middle.payload.id()));
+    for event in [&clean_middle, &clean_tip, &grafted_middle, &grafted_tip] {
+        collection.add_event(event).await?;
+    }
+
+    let state_at = |head: proto::Clock| proto::EntityState {
+        entity_id: pet_id,
+        collection: Pet::collection(),
+        state: proto::State { head, ..Default::default() },
+    };
+
+    let clean = server
+        .collect_event_bridge_for_test(&collection, &known_head, &state_at(proto::Clock::from(clean_tip.payload.id())), &DEFAULT_CONTEXT)
+        .await?;
+    let clean_ids: HashSet<_> = clean.iter().map(|e| e.payload.id()).collect();
+    assert_eq!(
+        clean_ids,
+        HashSet::from([clean_middle.payload.id(), clean_tip.payload.id()]),
+        "the control chain must bridge, otherwise the grafted case proves nothing"
+    );
+
+    let grafted = server
+        .collect_event_bridge_for_test(&collection, &known_head, &state_at(proto::Clock::from(grafted_tip.payload.id())), &DEFAULT_CONTEXT)
+        .await?;
+    assert!(
+        grafted.is_empty(),
+        "a window reaching another entity's event must yield no bridge (the caller falls back to a state snapshot), got {:?}",
+        grafted.iter().map(|e| e.payload.id()).collect::<Vec<_>>()
+    );
 
     Ok(())
 }

--- a/tests/tests/bridge_policy.rs
+++ b/tests/tests/bridge_policy.rs
@@ -119,8 +119,15 @@ impl PolicyAgent for BridgePolicyAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
+    fn check_read_event<C>(
+        &self,
+        _data: &C,
+        event: &Attested<proto::Event>,
+        _current_state: Option<&proto::State>,
+    ) -> Result<(), AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
         if self.deny_read_events.lock().unwrap().contains(&event.payload.id()) {
             return Err(AccessDenied::ByPolicy("event read denied by test agent"));
         }

--- a/tests/tests/check_request_error.rs
+++ b/tests/tests/check_request_error.rs
@@ -126,7 +126,7 @@ impl PolicyAgent for RejectingAgent {
         &self,
         _data: &C,
         _event: &proto::Attested<proto::Event>,
-        _current_state: Option<&proto::State>,
+        _current_state: Option<&proto::EntityState>,
     ) -> std::result::Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,

--- a/tests/tests/check_request_error.rs
+++ b/tests/tests/check_request_error.rs
@@ -122,8 +122,15 @@ impl PolicyAgent for RejectingAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, _event: &proto::Attested<proto::Event>) -> std::result::Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
+    fn check_read_event<C>(
+        &self,
+        _data: &C,
+        _event: &proto::Attested<proto::Event>,
+        _current_state: Option<&proto::State>,
+    ) -> std::result::Result<(), AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
         Ok(())
     }
 

--- a/tests/tests/check_request_error.rs
+++ b/tests/tests/check_request_error.rs
@@ -122,8 +122,16 @@ impl PolicyAgent for RejectingAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, _event: &proto::Attested<proto::Event>) -> std::result::Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
+    async fn check_read_event<SE, C>(
+        &self,
+        _data: &C,
+        _event: &proto::Attested<proto::Event>,
+        _getter: &ankurah::core::lazy_entity_getter::EntityGetter<'_, SE, Self>,
+    ) -> std::result::Result<(), AccessDenied>
+    where
+        SE: ankurah::core::storage::StorageEngine + Send + Sync + 'static,
+        C: Iterable<Self::ContextData> + Sync,
+    {
         Ok(())
     }
 

--- a/tests/tests/commit_atomicity.rs
+++ b/tests/tests/commit_atomicity.rs
@@ -119,8 +119,15 @@ impl PolicyAgent for DenySecondAlbumEventAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, _event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
+    fn check_read_event<C>(
+        &self,
+        _data: &C,
+        _event: &Attested<proto::Event>,
+        _current_state: Option<&proto::State>,
+    ) -> Result<(), AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
         Ok(())
     }
 

--- a/tests/tests/commit_atomicity.rs
+++ b/tests/tests/commit_atomicity.rs
@@ -119,8 +119,16 @@ impl PolicyAgent for DenySecondAlbumEventAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, _event: &Attested<proto::Event>) -> Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
+    async fn check_read_event<SE, C>(
+        &self,
+        _data: &C,
+        _event: &Attested<proto::Event>,
+        _getter: &ankurah::core::lazy_entity_getter::EntityGetter<'_, SE, Self>,
+    ) -> Result<(), AccessDenied>
+    where
+        SE: StorageEngine + Send + Sync + 'static,
+        C: Iterable<Self::ContextData> + Sync,
+    {
         Ok(())
     }
 

--- a/tests/tests/commit_atomicity.rs
+++ b/tests/tests/commit_atomicity.rs
@@ -123,7 +123,7 @@ impl PolicyAgent for DenySecondAlbumEventAgent {
         &self,
         _data: &C,
         _event: &Attested<proto::Event>,
-        _current_state: Option<&proto::State>,
+        _current_state: Option<&proto::EntityState>,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,

--- a/tests/tests/schema_registration.rs
+++ b/tests/tests/schema_registration.rs
@@ -841,7 +841,7 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
         &self,
         _data: &C,
         _event: &proto::Attested<proto::Event>,
-        _current_state: Option<&proto::State>,
+        _current_state: Option<&proto::EntityState>,
     ) -> Result<(), ankurah::policy::AccessDenied>
     where
         C: ankurah::core::util::Iterable<Self::ContextData>,

--- a/tests/tests/schema_registration.rs
+++ b/tests/tests/schema_registration.rs
@@ -837,8 +837,15 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, _event: &proto::Attested<proto::Event>) -> Result<(), ankurah::policy::AccessDenied>
-    where C: ankurah::core::util::Iterable<Self::ContextData> {
+    fn check_read_event<C>(
+        &self,
+        _data: &C,
+        _event: &proto::Attested<proto::Event>,
+        _current_state: Option<&proto::State>,
+    ) -> Result<(), ankurah::policy::AccessDenied>
+    where
+        C: ankurah::core::util::Iterable<Self::ContextData>,
+    {
         Ok(())
     }
 

--- a/tests/tests/schema_registration.rs
+++ b/tests/tests/schema_registration.rs
@@ -837,8 +837,16 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
         Ok(())
     }
 
-    fn check_read_event<C>(&self, _data: &C, _event: &proto::Attested<proto::Event>) -> Result<(), ankurah::policy::AccessDenied>
-    where C: ankurah::core::util::Iterable<Self::ContextData> {
+    async fn check_read_event<SE, C>(
+        &self,
+        _data: &C,
+        _event: &proto::Attested<proto::Event>,
+        _getter: &ankurah::core::lazy_entity_getter::EntityGetter<'_, SE, Self>,
+    ) -> Result<(), ankurah::policy::AccessDenied>
+    where
+        SE: ankurah::core::storage::StorageEngine + Send + Sync + 'static,
+        C: ankurah::core::util::Iterable<Self::ContextData> + Sync,
+    {
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #438: `check_read_event` authorized at collection level only, so for any collection carrying a row-level read scope, entity STATE was filtered per row while that entity's EVENTS were readable by any token passing the collection gate — and events reconstruct CRDT content, so GetEvents was a path around the row scope.

**The fix.** One private `check_read_entity` holds the whole row-level read decision (collection gate, privileged bypass, no-scope-rules early out, TemporaryEntity, `enforce_read_scope`), and both `check_read` and `check_read_event` delegate into it — the event path inherits the enforcement's semantics (including #436's ruled skip behavior) rather than restating them. When a scoped collection has no current state to evaluate, the read refuses; unscoped collections keep their existing collection-gate behavior. Both halves pinned by tests.

**Three guards make the guarantee hold under adversarial review** (two independent review passes, findings adjudicated and applied):

- **The pairing is a contract, not a convention.** `check_read_event` takes `Option<&proto::EntityState>` and the agent refuses a state whose entity id differs from the event's. The trait doc is normative: the caller MUST supply the state of the event's own entity.
- **A state only authorizes events it can speak for.** Commits publish events before persisting state, so a served event could postdate the state that authorized it — including the very event that moves the row out of the caller's scope. GetEvents now serves an event only if the authorizing state's head causally covers it (head membership is O(1); anything older costs a DAG walk proportional to the distance, budget-capped and fail-closed on ambiguity — a peer backfilling deep history one event per request pays that depth per call, noted in the method doc). The node's resident entity outranks the stored state buffer, which closes the indefinite variant of the race under the EventOnly apply path.
- **The event bridge walks one entity's history or none.** A graft in a readable entity's ancestry can reference another entity's events; the walk now excludes any fetched event whose entity id differs from the bridge's entity and falls back to the existing state-snapshot path, so a foreign event is never checked against the wrong row's state.

**Signature ripple, contained:** the trait change touches PermissiveAgent, core's two call sites, and four test-only agents. GetEvents batches states over the distinct entities in the served set (the default `get_states` walks one entity at a time — K distinct entities cost K sequential reads until an engine grows a real multi-key read).

**Accepted residuals, documented in the spec and trait rather than implied:** event reads are authorized against the CURRENT row state, so a row's history from before a scope change remains readable to a caller who can read the row today — per-event historical evaluation is tracked in #445. Separately, the IndexedDB engine stores events without collection identity, so on that engine an event can be requested through the wrong collection past every gate — engine fix tracked in #444. The live subscription delivery path (the reactor's StateAndEvent) rides the #426 recomposition, per the plan.

**Tests.** The original wire-path pair (a token's GetEvents returns exactly the allow/deny split its Get returns, asserted in both directions; missing state refuses on scoped collections, spares unscoped ones) plus: privileged caller, plural-credential union on the event path, an event the authorizing state does not cover is refused, a resident entity outranks a rewound stored state, and a forged cross-entity ancestry does not bridge (via a test-helpers-gated bridge wrapper, disclosed). Every guard was mutation-verified — reverting each makes its test fail on the leak assertion. Full workspace battery: 819 passed, 0 failed.
