### PR TITLE
Harden release branch publishing

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -2,7 +2,7 @@ name: Format Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 jobs:
   format:
@@ -17,7 +17,7 @@ jobs:
         run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
       - name: Install Taplo
-        run: cargo install taplo-cli
+        run: cargo +stable install taplo-cli
 
       - name: Check Rust formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,14 @@ name: Publish Crates
 
 on:
   push:
-    branches: [main]
-    paths: ["**/Cargo.toml"]
+    branches: ["release/**"]
+    # RELEASES changing is explicit publish intent. The version itself comes
+    # from the lockstep Cargo manifests and is validated against the branch.
+    paths: [RELEASES]
+
+concurrency:
+  group: crates-io-publish
+  cancel-in-progress: false
 
 permissions:
   contents: write # Need to create and push tags
@@ -17,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,25 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 jobs:
+  release-scripts:
+    name: Validate release scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-edit
+        run: cargo install cargo-edit --version 0.13.8 --locked
+
+      - name: Run release script checks
+        run: |
+          ./.release/tests/release-context.sh
+          ./.release/tests/bump-version.sh
+          ./.release/tests/publish.sh
+
   liaison:
     name: Verify README examples
     runs-on: ubuntu-latest

--- a/.github/workflows/wasm-browser-tests.yml
+++ b/.github/workflows/wasm-browser-tests.yml
@@ -2,7 +2,7 @@ name: WASM Browser Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 jobs:
   wasm-browser-tests:

--- a/.release/README.md
+++ b/.release/README.md
@@ -1,0 +1,44 @@
+# Releasing Ankurah
+
+Ankurah releases are prepared and published only from a maintenance branch
+named `release/<major>.<minor>`. Merging ordinary work to `main` never
+publishes crates.
+
+The lockstep versions in the workspace `Cargo.toml` files are the release
+version's source of truth. `RELEASES` is a human changelog and the change that
+signals publish intent; scripts never infer a version from its first line.
+
+## Prepare a release
+
+1. Work on the matching release branch, such as `release/0.9`.
+2. Add exactly one `RELEASES` entry for the intended version. Entries are
+   conventionally newest-first, but their order has no machine significance.
+3. Run the bump with an explicit stable version:
+
+   ```sh
+   .release/bump-version.sh 0.9.1
+   ```
+
+   The requested version must be greater than the workspace's current
+   version and its major/minor pair must match the release branch.
+
+4. Review the Cargo manifests, `Cargo.lock`, and changelog together. Open a PR
+   to the same release branch and let its normal CI complete.
+
+Merging that PR pushes the `RELEASES` change to `release/0.9`, which starts the
+publish workflow. The workflow independently verifies that every workspace
+package has the same `0.9.1` version, the publish list names real packages,
+the lockfile is current, and the changelog contains exactly one 0.9.1 entry.
+
+## Publishing and retrying
+
+Crates publish in dependency order with `cargo publish --locked`. Each
+successful crate gets a tag such as `ankurah-core-v0.9.1` at the release
+commit. An existing tag is accepted only when it already points to that exact
+commit; a same-named tag on another commit aborts publishing instead of being
+silently ignored.
+
+If a run stops after publishing only some crates, use GitHub Actions' **Re-run
+failed jobs** action on the same push. Already-published crates are accepted,
+their tags are repaired or verified, and publishing resumes in dependency
+order.

--- a/.release/bump-version.sh
+++ b/.release/bump-version.sh
@@ -3,13 +3,26 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Get version from top line of RELEASES file
-version=$(head -n 1 RELEASES | cut -d' ' -f1)
+if [[ "$#" != "1" ]]; then
+    echo "usage: .release/bump-version.sh <major.minor.patch>" >&2
+    exit 2
+fi
 
-echo "Bumping all workspace crates to version $version"
+version="$1"
+
+# shellcheck source=.release/release-context.sh
+source .release/release-context.sh
+
+branch="$(release_branch_name)"
+validate_release_version "$version" "$branch"
+validate_release_notes "$version"
+current="$(workspace_release_version)"
+validate_version_advance "$current" "$version"
+
+echo "Bumping $branch workspace crates from $current to $version"
 
 # Step 1: Set all package versions using cargo-edit
-cargo set-version --workspace "$version"
+cargo set-version --workspace --offline "$version"
 
 # Step 2: Get workspace crate names and manifest paths
 crates=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
@@ -19,12 +32,26 @@ manifests=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].man
 echo "Updating dependency versions to exact match..."
 for manifest in $manifests; do
     for crate in $crates; do
-        # Escape hyphens for sed regex
-        crate_pattern=$(echo "$crate" | sed 's/-/\\-/g')
-        
-        # Update table version: crate = { version = "^x.y.z" } -> crate = { version = "=x.y.z" }
-        sed -i '' -E "s/(${crate_pattern}[[:space:]]*=[[:space:]]*\{[^}]*version[[:space:]]*=[[:space:]]*\")[^\"]+\"/\1=$version\"/g" "$manifest"
+        # Update table dependencies such as:
+        # crate = { path = "...", version = "=x.y.z" }
+        RELEASE_CRATE="$crate" RELEASE_VERSION="$version" perl -0pi -e '
+            BEGIN {
+                $crate = quotemeta($ENV{"RELEASE_CRATE"});
+                $version = $ENV{"RELEASE_VERSION"};
+            }
+            s/(\b$crate\s*=\s*\{[^}]*\bversion\s*=\s*")[^"]+"/$1=$version"/g;
+        ' "$manifest"
     done
 done
 
-echo "Done. Run 'cargo check' to verify."
+# Refresh Cargo.lock, then prove the result is internally consistent.
+cargo metadata --no-deps --format-version=1 >/dev/null
+metadata="$(workspace_metadata)"
+actual="$(workspace_release_version "$metadata")"
+if [[ "$actual" != "$version" ]]; then
+    release_error "version bump produced $actual, expected $version"
+    exit 1
+fi
+validate_published_crates "$version" .release/published_crates "$metadata"
+
+echo "Version $version prepared. Review and commit the Cargo and RELEASES changes together."

--- a/.release/publish.sh
+++ b/.release/publish.sh
@@ -1,41 +1,74 @@
 #!/bin/bash
 set -euo pipefail
 
-# Ankurah Publishing Script
-# Publishes crates based on the top entry in the RELEASES file
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+# shellcheck source=.release/release-context.sh
+source .release/release-context.sh
 
 PUBLISHED_CRATES_FILE=".release/published_crates"
+metadata="$(workspace_metadata)"
+version="$(workspace_release_version "$metadata")"
+branch="$(release_branch_name)"
+
+validate_release_version "$version" "$branch"
+validate_release_notes "$version"
+validate_published_crates "$version" "$PUBLISHED_CRATES_FILE" "$metadata"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    release_error "publishing requires a clean working tree"
+    exit 1
+fi
+
+release_commit="$(git rev-parse HEAD)"
+git fetch --tags origin
+
+# Reject every tag collision before the first irreversible crate publication.
+while IFS= read -r crate || [[ -n "$crate" ]]; do
+    case "$crate" in
+        "" | \#*) continue ;;
+    esac
+    validate_release_tag "${crate}-v${version}" "$release_commit"
+done < "$PUBLISHED_CRATES_FILE"
+
+ensure_release_tag() {
+    local tag="$1"
+    local tagged_commit
+    validate_release_tag "$tag" "$release_commit"
+    tagged_commit="$(git rev-parse -q --verify "refs/tags/$tag^{commit}" 2>/dev/null || true)"
+
+    if [[ -z "$tagged_commit" ]]; then
+        git tag "$tag" "$release_commit"
+    fi
+    git push origin "refs/tags/$tag"
+}
 
 # Publish crates in dependency order and create tags
-while read -r crate; do
+while IFS= read -r crate || [[ -n "$crate" ]]; do
     # Skip comments and empty lines
-    [[ "$crate" =~ ^#.*$ ]] || [[ -z "$crate" ]] && continue
-    
+    case "$crate" in
+        "" | \#*) continue ;;
+    esac
+
     echo
     echo "📦 Publishing $crate..."
-    
-    # Get the actual version of this crate using cargo metadata + jq
-    version=$(cargo metadata --no-deps --format-version=1 2>/dev/null | jq -r --arg name "$crate" '.packages[] | select(.name==$name) | .version')
-    
-    # Publish crate (treat "already exists" as success)
-    if output=$(cargo publish --package "$crate" 2>&1); then
-        echo "   ✅  $version Published successfully"
-        # Create and push tag for this crate
-        tag="${crate}-v${version}"
-        echo "   🏷️  Creating tag $tag..."
-        git tag "$tag" || echo "   Tag $tag already exists"
-        git push origin "$tag" || echo "   Tag $tag already pushed"
 
+    # Publish crate (treat "already exists" as success)
+    if output=$(cargo publish --locked --package "$crate" 2>&1); then
+        echo "   ✅  $version Published successfully"
     elif echo "$output" | grep -q "already exists on crates.io"; then
         echo "   ℹ️  $version already exists on crates.io"
-
     else
         echo "   ❌ Failed to publish"
         echo "$output"
         exit 1
     fi
-    
+
+    tag="${crate}-v${version}"
+    echo "   🏷️  Ensuring $tag points to $release_commit..."
+    ensure_release_tag "$tag"
 done < "$PUBLISHED_CRATES_FILE"
 
 echo
-echo "🎉 Done!" 
+echo "🎉 Done!"

--- a/.release/release-context.sh
+++ b/.release/release-context.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+# Shared validation for release preparation and publishing. This file is
+# sourced by scripts which enable `set -euo pipefail` themselves.
+
+release_error() {
+    echo "release error: $*" >&2
+}
+
+release_branch_name() {
+    local branch="${RELEASE_BRANCH:-${GITHUB_REF_NAME:-}}"
+    if [[ -z "$branch" ]]; then
+        branch="$(git branch --show-current)"
+    fi
+    if [[ -z "$branch" ]]; then
+        release_error "cannot determine the current branch; set RELEASE_BRANCH explicitly"
+        return 1
+    fi
+    printf '%s\n' "$branch"
+}
+
+validate_release_version() {
+    local version="$1"
+    local branch="${2:-$(release_branch_name)}"
+
+    if [[ ! "$branch" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
+        release_error "publishing requires a branch named release/<major>.<minor>; got $branch"
+        return 1
+    fi
+    local branch_major="${BASH_REMATCH[1]}"
+    local branch_minor="${BASH_REMATCH[2]}"
+
+    if [[ ! "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        release_error "version must be an explicit stable <major>.<minor>.<patch>; got $version"
+        return 1
+    fi
+    local version_major="${BASH_REMATCH[1]}"
+    local version_minor="${BASH_REMATCH[2]}"
+
+    if [[ "$version_major" != "$branch_major" || "$version_minor" != "$branch_minor" ]]; then
+        release_error "version $version does not belong on $branch"
+        return 1
+    fi
+}
+
+validate_version_advance() {
+    local current="$1"
+    local next="$2"
+    local current_major current_minor current_patch
+    local next_major next_minor next_patch
+
+    if [[ ! "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        release_error "current workspace version is not stable semver: $current"
+        return 1
+    fi
+    current_major="${BASH_REMATCH[1]}"
+    current_minor="${BASH_REMATCH[2]}"
+    current_patch="${BASH_REMATCH[3]}"
+    if [[ ! "$next" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        release_error "next workspace version is not stable semver: $next"
+        return 1
+    fi
+    next_major="${BASH_REMATCH[1]}"
+    next_minor="${BASH_REMATCH[2]}"
+    next_patch="${BASH_REMATCH[3]}"
+
+    if ((10#$next_major < 10#$current_major)) ||
+        ((10#$next_major == 10#$current_major && 10#$next_minor < 10#$current_minor)) ||
+        ((10#$next_major == 10#$current_major && 10#$next_minor == 10#$current_minor && 10#$next_patch <= 10#$current_patch)); then
+        release_error "version must advance from $current; got $next"
+        return 1
+    fi
+}
+
+workspace_metadata() {
+    cargo metadata --locked --no-deps --format-version=1
+}
+
+workspace_release_version() {
+    local metadata="${1:-$(workspace_metadata)}"
+    local versions
+    versions="$(jq -r '[.packages[].version] | unique | .[]' <<<"$metadata")"
+    local count
+    count="$(wc -l <<<"$versions" | tr -d ' ')"
+    if [[ "$count" != "1" || -z "$versions" ]]; then
+        release_error "workspace packages must have one lockstep version; found: ${versions//$'\n'/, }"
+        return 1
+    fi
+    printf '%s\n' "$versions"
+}
+
+validate_release_notes() {
+    local version="$1"
+    local notes_file="${2:-RELEASES}"
+    local count
+    count="$(awk -v version="$version" '$1 == version { count += 1 } END { print count + 0 }' "$notes_file")"
+    if [[ "$count" != "1" ]]; then
+        release_error "$notes_file must contain exactly one changelog entry for $version; found $count"
+        return 1
+    fi
+}
+
+validate_published_crates() {
+    local version="$1"
+    local crates_file="${2:-.release/published_crates}"
+    local metadata="${3:-$(workspace_metadata)}"
+    local crate_count=0
+    local crate
+    local duplicates
+
+    duplicates="$(awk 'NF && $1 !~ /^#/ { print $1 }' "$crates_file" | sort | uniq -d)"
+    if [[ -n "$duplicates" ]]; then
+        release_error "$crates_file contains duplicate crates: ${duplicates//$'\n'/, }"
+        return 1
+    fi
+
+    while IFS= read -r crate || [[ -n "$crate" ]]; do
+        [[ -z "$crate" || "$crate" == \#* ]] && continue
+        crate_count=$((crate_count + 1))
+
+        local matches
+        matches="$(jq -r --arg name "$crate" '[.packages[] | select(.name == $name)] | length' <<<"$metadata")"
+        if [[ "$matches" != "1" ]]; then
+            release_error "$crates_file names $crate $matches times in workspace metadata"
+            return 1
+        fi
+
+        local crate_version
+        crate_version="$(jq -r --arg name "$crate" '.packages[] | select(.name == $name) | .version' <<<"$metadata")"
+        if [[ "$crate_version" != "$version" ]]; then
+            release_error "$crate is version $crate_version, expected $version"
+            return 1
+        fi
+    done < "$crates_file"
+
+    if [[ "$crate_count" == "0" ]]; then
+        release_error "$crates_file contains no crates"
+        return 1
+    fi
+}
+
+validate_release_tag() {
+    local tag="$1"
+    local release_commit="$2"
+    local tagged_commit
+    tagged_commit="$(git rev-parse -q --verify "refs/tags/$tag^{commit}" 2>/dev/null || true)"
+
+    if [[ -n "$tagged_commit" && "$tagged_commit" != "$release_commit" ]]; then
+        release_error "tag $tag already points to $tagged_commit, not release commit $release_commit"
+        return 1
+    fi
+}

--- a/.release/tests/bump-version.sh
+++ b/.release/tests/bump-version.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+sandbox="$(mktemp -d)"
+cleanup() {
+    case "${sandbox:?}" in
+        /tmp/* | /private/tmp/* | /var/folders/* | /private/var/folders/*) rm -rf -- "$sandbox" ;;
+        *) echo "refusing to remove unexpected temporary path: $sandbox" >&2 ;;
+    esac
+}
+trap cleanup EXIT
+
+mkdir -p "$sandbox/.release" "$sandbox/base" "$sandbox/app"
+cp "$root/.release/bump-version.sh" "$root/.release/release-context.sh" "$sandbox/.release/"
+
+printf '%s\n' \
+    '[workspace]' \
+    'members = ["base", "app"]' \
+    'resolver = "2"' > "$sandbox/Cargo.toml"
+
+printf '%s\n' \
+    '[package]' \
+    'name = "release-test-base"' \
+    'version = "0.9.0"' \
+    'edition = "2021"' > "$sandbox/base/Cargo.toml"
+printf '' > "$sandbox/base/lib.rs"
+printf '%s\n' \
+    '[lib]' \
+    'path = "lib.rs"' >> "$sandbox/base/Cargo.toml"
+
+printf '%s\n' \
+    '[package]' \
+    'name = "release-test-app"' \
+    'version = "0.9.0"' \
+    'edition = "2021"' \
+    '' \
+    '[dependencies]' \
+    'release-test-base = { path = "../base", version = "=0.9.0" }' \
+    '' \
+    '[lib]' \
+    'path = "lib.rs"' > "$sandbox/app/Cargo.toml"
+printf '' > "$sandbox/app/lib.rs"
+
+printf '%s\n' \
+    '0.9.1 synthetic maintenance release' \
+    '0.9.0 prior release' > "$sandbox/RELEASES"
+printf '%s\n' 'release-test-base' 'release-test-app' > "$sandbox/.release/published_crates"
+
+(cd "$sandbox" && cargo generate-lockfile --offline)
+
+if RELEASE_BRANCH=release/0.9 "$sandbox/.release/bump-version.sh" >/dev/null 2>&1; then
+    echo "bump-version accepted an implicit version" >&2
+    exit 1
+fi
+if RELEASE_BRANCH=release/0.9 "$sandbox/.release/bump-version.sh" 0.10.0 >/dev/null 2>&1; then
+    echo "bump-version accepted a version from another release series" >&2
+    exit 1
+fi
+
+RELEASE_BRANCH=release/0.9 "$sandbox/.release/bump-version.sh" 0.9.1
+
+versions="$(cd "$sandbox" && cargo metadata --locked --no-deps --format-version=1 | jq -r '[.packages[].version] | unique | .[]')"
+if [[ "$versions" != "0.9.1" ]]; then
+    echo "unexpected bumped versions: $versions" >&2
+    exit 1
+fi
+if ! grep -Fq 'version = "=0.9.1"' "$sandbox/app/Cargo.toml"; then
+    echo "internal dependency pin was not bumped" >&2
+    exit 1
+fi
+
+echo "explicit version bump checks passed"

--- a/.release/tests/publish.sh
+++ b/.release/tests/publish.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+sandbox="$(mktemp -d)"
+cleanup() {
+    case "${sandbox:?}" in
+        /tmp/* | /private/tmp/* | /var/folders/* | /private/var/folders/*) rm -rf -- "$sandbox" ;;
+        *) echo "refusing to remove unexpected temporary path: $sandbox" >&2 ;;
+    esac
+}
+trap cleanup EXIT
+
+repo="$sandbox/repo"
+remote="$sandbox/origin.git"
+fake_bin="$sandbox/bin"
+publish_log="$sandbox/published"
+real_cargo="$(command -v cargo)"
+
+mkdir -p "$repo/.release" "$repo/base" "$repo/app" "$fake_bin"
+cp "$root/.release/publish.sh" "$root/.release/release-context.sh" "$repo/.release/"
+
+printf '%s\n' \
+    '[workspace]' \
+    'members = ["base", "app"]' \
+    'resolver = "2"' > "$repo/Cargo.toml"
+printf '%s\n' \
+    '[package]' \
+    'name = "release-test-base"' \
+    'version = "0.9.1"' \
+    'edition = "2021"' \
+    '' \
+    '[lib]' \
+    'path = "lib.rs"' > "$repo/base/Cargo.toml"
+printf '' > "$repo/base/lib.rs"
+printf '%s\n' \
+    '[package]' \
+    'name = "release-test-app"' \
+    'version = "0.9.1"' \
+    'edition = "2021"' \
+    '' \
+    '[dependencies]' \
+    'release-test-base = { path = "../base", version = "=0.9.1" }' \
+    '' \
+    '[lib]' \
+    'path = "lib.rs"' > "$repo/app/Cargo.toml"
+printf '' > "$repo/app/lib.rs"
+printf '%s\n' '0.9.1 synthetic maintenance release' > "$repo/RELEASES"
+printf '%s\n' 'release-test-base' 'release-test-app' > "$repo/.release/published_crates"
+
+# The single-quoted lines are the literal body of the fake cargo executable.
+# shellcheck disable=SC2016
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'if [[ "${1:-}" == "metadata" ]]; then' \
+    '    exec "${RELEASE_TEST_REAL_CARGO:?}" "$@"' \
+    'fi' \
+    'if [[ "${1:-}" != "publish" ]]; then' \
+    '    echo "unexpected cargo command: $*" >&2' \
+    '    exit 1' \
+    'fi' \
+    'shift' \
+    'package=""' \
+    'locked=0' \
+    'while [[ "$#" -gt 0 ]]; do' \
+    '    case "$1" in' \
+    '        --locked) locked=1 ;;' \
+    '        --package) shift; package="${1:-}" ;;' \
+    '    esac' \
+    '    shift' \
+    'done' \
+    '[[ "$locked" == "1" && -n "$package" ]] || exit 1' \
+    'printf "%s\n" "$package" >> "${RELEASE_TEST_PUBLISH_LOG:?}"' \
+    'if [[ "${RELEASE_TEST_ALREADY_EXISTS:-0}" == "1" ]]; then' \
+    '    echo "crate $package already exists on crates.io" >&2' \
+    '    exit 1' \
+    'fi' > "$fake_bin/cargo"
+chmod +x "$fake_bin/cargo"
+
+(cd "$repo" && "$real_cargo" generate-lockfile --offline)
+git -C "$repo" init -qb release/0.9
+git -C "$repo" config user.name release-test
+git -C "$repo" config user.email release-test@example.com
+git -C "$repo" add .
+git -C "$repo" commit -qm release
+git init -q --bare "$remote"
+git -C "$repo" remote add origin "$remote"
+git -C "$repo" push -qu origin release/0.9
+
+PATH="$fake_bin:$PATH" \
+    RELEASE_BRANCH=release/0.9 \
+    RELEASE_TEST_REAL_CARGO="$real_cargo" \
+    RELEASE_TEST_PUBLISH_LOG="$publish_log" \
+    "$repo/.release/publish.sh"
+
+release_commit="$(git -C "$repo" rev-parse HEAD)"
+for crate in release-test-base release-test-app; do
+    tag="${crate}-v0.9.1"
+    if [[ "$(git --git-dir="$remote" rev-parse "refs/tags/$tag")" != "$release_commit" ]]; then
+        echo "remote tag $tag does not point to the release commit" >&2
+        exit 1
+    fi
+done
+
+# A partial-run retry must accept published crates and preserve exact tags.
+PATH="$fake_bin:$PATH" \
+    RELEASE_BRANCH=release/0.9 \
+    RELEASE_TEST_REAL_CARGO="$real_cargo" \
+    RELEASE_TEST_PUBLISH_LOG="$publish_log" \
+    RELEASE_TEST_ALREADY_EXISTS=1 \
+    "$repo/.release/publish.sh"
+
+if [[ "$(wc -l < "$publish_log" | tr -d ' ')" != "4" ]]; then
+    echo "publish retry did not visit every crate" >&2
+    exit 1
+fi
+
+echo "publish and retry checks passed"

--- a/.release/tests/release-context.sh
+++ b/.release/tests/release-context.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# shellcheck source=.release/release-context.sh
+source "$root/.release/release-context.sh"
+
+expect_failure() {
+    if "$@" >/dev/null 2>&1; then
+        echo "expected failure: $*" >&2
+        exit 1
+    fi
+}
+
+validate_release_version "0.9.1" "release/0.9"
+validate_release_version "0.10.0" "release/0.10"
+expect_failure validate_release_version "0.9.1" "main"
+expect_failure validate_release_version "0.10.0" "release/0.9"
+expect_failure validate_release_version "0.9" "release/0.9"
+expect_failure validate_release_version "0.9.1-alpha.1" "release/0.9"
+validate_version_advance "0.9.0" "0.9.1"
+validate_version_advance "0.9.9" "0.10.0"
+expect_failure validate_version_advance "0.9.1" "0.9.1"
+expect_failure validate_version_advance "0.9.1" "0.9.0"
+
+workspace_version="$(workspace_release_version)"
+workspace_series="${workspace_version%.*}"
+validate_release_version "$workspace_version" "release/$workspace_series"
+validate_release_notes "$workspace_version" "$root/RELEASES"
+validate_published_crates "$workspace_version" "$root/.release/published_crates"
+expect_failure workspace_release_version '{"packages":[{"version":"0.9.0"},{"version":"0.9.1"}]}'
+
+# RELEASES is a changelog, not an implicit version source. A matching entry can
+# appear anywhere in the file.
+notes="$(mktemp)"
+printf '1.0.0 newest\n0.9.1 maintenance\n' > "$notes"
+validate_release_notes "0.9.1" "$notes"
+expect_failure validate_release_notes "0.9.2" "$notes"
+
+duplicate_crates="$(mktemp)"
+printf 'ankql\nankql\n' > "$duplicate_crates"
+expect_failure validate_published_crates "$workspace_version" "$duplicate_crates"
+
+tag_repo="$(mktemp -d)"
+cleanup() {
+    rm -f -- "${notes:?}" "${duplicate_crates:?}"
+    case "${tag_repo:?}" in
+        /tmp/* | /private/tmp/* | /var/folders/* | /private/var/folders/*) rm -rf -- "$tag_repo" ;;
+        *) echo "refusing to remove unexpected temporary path: $tag_repo" >&2 ;;
+    esac
+}
+trap cleanup EXIT
+git -C "$tag_repo" init -q
+git -C "$tag_repo" config user.name release-test
+git -C "$tag_repo" config user.email release-test@example.com
+printf 'first\n' > "$tag_repo/value"
+git -C "$tag_repo" add value
+git -C "$tag_repo" commit -qm first
+first_commit="$(git -C "$tag_repo" rev-parse HEAD)"
+git -C "$tag_repo" tag example-v0.9.1
+printf 'second\n' > "$tag_repo/value"
+git -C "$tag_repo" commit -qam second
+second_commit="$(git -C "$tag_repo" rev-parse HEAD)"
+(cd "$tag_repo" && validate_release_tag example-v0.9.1 "$first_commit")
+expect_failure bash -c "cd '$tag_repo' && source '$root/.release/release-context.sh' && validate_release_tag example-v0.9.1 '$second_commit'"
+
+ALLOW_DIRTY_RELEASE=1 RELEASE_BRANCH="release/$workspace_series" "$root/.release/validate-release.sh"
+expect_failure env ALLOW_DIRTY_RELEASE=1 RELEASE_BRANCH=main "$root/.release/validate-release.sh"
+
+bash -n "$root/.release/release-context.sh"
+bash -n "$root/.release/validate-release.sh"
+bash -n "$root/.release/bump-version.sh"
+bash -n "$root/.release/publish.sh"
+
+echo "release script checks passed"

--- a/.release/validate-release.sh
+++ b/.release/validate-release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+# shellcheck source=.release/release-context.sh
+source .release/release-context.sh
+
+metadata="$(workspace_metadata)"
+version="$(workspace_release_version "$metadata")"
+branch="$(release_branch_name)"
+
+validate_release_version "$version" "$branch"
+validate_release_notes "$version"
+validate_published_crates "$version" .release/published_crates "$metadata"
+
+if [[ -n "$(git status --porcelain)" && "${ALLOW_DIRTY_RELEASE:-0}" != "1" ]]; then
+    release_error "publishing requires a clean working tree"
+    exit 1
+fi
+
+echo "release validated: $version from $branch"


### PR DESCRIPTION
## Summary

- publish maintenance releases from pushes to `release/**` when `RELEASES` changes
- require an explicit stable version and enforce branch, workspace, changelog, package-list, lockfile, and tag consistency before publishing
- support safe retries after partial crates.io publication while rejecting conflicting tags
- run native, formatting, browser, and release-script checks on pull requests targeting maintenance branches

This establishes the complete release path for `release/0.9`. The corresponding workflow change on `main` remains a separate PR so the default branch also stops using its old Cargo-manifest publish trigger.

## Release workflow

The workspace Cargo manifests are the version source of truth. A maintainer runs `.release/bump-version.sh <major.minor.patch>` before committing, reviews the manifest, lockfile, and `RELEASES` changes together, and merges them into the matching `release/<major>.<minor>` branch. The `RELEASES` push then starts publishing.

Before the first crate is published, the workflow validates the complete release and every expected tag. Crates publish in dependency order. A retry accepts an already-published crate, but an existing tag is accepted only when it points to the exact release commit.

## Validation

- `.release/tests/release-context.sh`
- `.release/tests/bump-version.sh`
- `.release/tests/publish.sh`
- ShellCheck with sourced-file following
- actionlint on all changed workflows
- `git diff --cached --check`

## Review

Daniel completed the line-by-line review and staged the entire final diff, including both CI follow-ups, before commit `45fd6348` was created.
