### PR TITLE
jwt-auth, core: pin the fail-closed facts a subject that is not an entity id rests on

### DIFF
--- a/core/src/selection/filter.rs
+++ b/core/src/selection/filter.rs
@@ -361,6 +361,53 @@ mod tests {
         );
     }
 
+    /// A row carrying a `Ref` field, whose value is an EntityId rather than a
+    /// string. Policy filters compare such a field against a claim value, and
+    /// the claim value need not be an id at all.
+    #[derive(Debug, Clone, PartialEq)]
+    struct OwnedItem {
+        owner: ankurah_proto::EntityId,
+    }
+
+    impl Filterable for OwnedItem {
+        fn collection(&self) -> &str { "records" }
+
+        fn value(&self, name: &str) -> Option<Value> {
+            match name {
+                "owner" => Some(Value::EntityId(self.owner)),
+                _ => None,
+            }
+        }
+    }
+
+    /// An EntityId-typed field compared against a string that is not an id
+    /// answers false, and never an error. `evaluate_predicate` propagates an
+    /// error out of the whole predicate, so an erroring comparison here would
+    /// fail the caller's entire query — including the arms of an OR that would
+    /// otherwise have admitted rows — where false merely denies this row.
+    ///
+    /// This is the row-side half of what a scope rule like `owner = $jwt.sub`
+    /// does when the subject is a distinguished literal rather than a user's
+    /// id: ankurah-jwt-auth substitutes such a subject as a String literal
+    /// (its `variables::typed_expr`), and it arrives here.
+    #[test]
+    fn test_entity_id_field_never_equals_a_non_id_string() {
+        let row = OwnedItem { owner: ankurah_proto::EntityId::new() };
+
+        // 'guest' does not parse as an EntityId, so the cast toward the field's
+        // type fails and the surviving comparison is the row's id rendered as
+        // a string — which no non-id value equals.
+        let selection = parse_selection("owner = 'guest'").unwrap();
+        assert_eq!(evaluate_predicate(&row, &selection.predicate), Ok(false), "a subject that is not an id must deny the row, not error");
+
+        // The control that keeps the false above honest: the comparator does
+        // cross this type pair, so the false is a comparison that answered no
+        // and not a comparator that refuses EntityId-against-String outright —
+        // which would answer false for every string, including the right one.
+        let selection = parse_selection(&format!("owner = '{}'", row.owner.to_base64())).unwrap();
+        assert_eq!(evaluate_predicate(&row, &selection.predicate), Ok(true), "the row's own id, as a string, must still match");
+    }
+
     // JSON path traversal tests
     mod json_tests {
         use super::*;

--- a/extensions/jwt-auth/src/variables.rs
+++ b/extensions/jwt-auth/src/variables.rs
@@ -210,6 +210,25 @@ mod tests {
         assert_eq!(rhs_literal(&result), &Literal::EntityId(id.to_ulid()));
     }
 
+    /// A subject that is not an entity id substitutes as a plain String
+    /// literal. Deployments mint such a subject on purpose — a distinguished
+    /// literal like `guest` for a reader who is not a user — and every query
+    /// that reader makes carries it through here, so the fallback is
+    /// load-bearing rather than incidental: an error arm added to
+    /// [`typed_expr`] would fail whole queries instead of narrowing them, and a
+    /// value accepted as an id would let `user = $jwt.sub` match a row.
+    ///
+    /// `test_entity_id_value_becomes_typed_literal` above pins the other side
+    /// of the same branch, and the downstream half of the fact — an
+    /// EntityId-typed field never equals a String literal, and answers false
+    /// rather than erroring — is pinned in ankurah-core's `selection::filter`.
+    #[test]
+    fn test_non_id_subject_falls_back_to_string_literal() {
+        let claims = test_claims("guest");
+        let result = parse_and_substitute("user = $jwt.sub", &claims).expect("a subject that is not an id must substitute, not error");
+        assert_eq!(rhs_literal(&result), &Literal::String("guest".to_string()));
+    }
+
     #[test]
     fn test_literal_placeholder_in_filter_fails_closed() {
         // A raw `?` in the filter has no corresponding claim value; the

--- a/extensions/jwt-auth/tests/keys_tests.rs
+++ b/extensions/jwt-auth/tests/keys_tests.rs
@@ -45,6 +45,42 @@ fn test_sign_and_verify_no_name() {
     assert!(verified.name.is_none());
 }
 
+/// A token carrying no subject claim at all is refused by both decode paths.
+///
+/// This is why a deployment that wants a subject meaning "not a user" mints a
+/// distinguished literal instead of leaving the claim out: an absent subject is
+/// not a second, quieter kind of caller, it is a token that does not decode.
+/// Softening either path into a default would turn a token with no subject into
+/// one whose subject is `""`, and a scope rule comparing a field against
+/// `$jwt.sub` would then run against that empty value instead of the token
+/// being refused outright.
+#[test]
+fn test_absent_subject_claim_fails_both_decode_paths() {
+    use jwt_simple::prelude::{Claims, RS256KeyPair, RSAKeyPairLike};
+
+    // SigningKeys::sign always writes claims.sub into the standard subject
+    // claim, so a subject-less token has to be built against jwt_simple
+    // directly. Everything else about the token is well formed and current —
+    // the signature verifies and the expiry is an hour out — so the absent
+    // subject is the only thing either path can be refusing.
+    let keys = common::test_keys();
+    let key_pair = RS256KeyPair::from_pem(&keys.private_key_pem().unwrap()).unwrap();
+    let claims = JwtClaims {
+        sub: String::new(),
+        roles: vec!["Reader".into()],
+        email: "reader@example.com".into(),
+        name: None,
+        custom: serde_json::Map::new(),
+    };
+    let token = key_pair.sign(Claims::with_custom_claims(claims, Duration::from_hours(1))).unwrap();
+
+    let err = keys.verify(&token).expect_err("SigningKeys::verify must refuse a token with no subject claim").to_string();
+    assert!(err.contains("subject"), "the refusal must name the absent subject, got: {err}");
+
+    let err = parse_claims_unverified(&token).expect_err("parse_claims_unverified must refuse a token with no subject claim").to_string();
+    assert!(err.contains("sub"), "the refusal must name the absent subject, got: {err}");
+}
+
 #[test]
 fn test_verify_wrong_key_fails() {
     let keys1 = common::test_keys();

--- a/extensions/jwt-auth/tests/nonid_subject_tests.rs
+++ b/extensions/jwt-auth/tests/nonid_subject_tests.rs
@@ -1,0 +1,195 @@
+//! What a scope rule does when the subject is not an entity id.
+//!
+//! A deployment may mint a subject that names no user — a distinguished
+//! literal such as `guest`, for a reader who has not signed in — and every
+//! `$jwt.sub` scope rule in its policy then compares a field against that
+//! literal. Evaluating such a comparison must answer false rather than error,
+//! because an error escapes the whole predicate: it takes down the OR arms
+//! that would have admitted rows, and `enforce_read_scope` turns it into a
+//! refusal of the row outright. False denies only what it compares and leaves
+//! the rest of the predicate standing.
+//!
+//! The pieces this rests on are pinned where each one lives: substitution
+//! producing a String literal rather than an error, in `variables`'s own tests;
+//! an EntityId-typed field answering false rather than erroring against a
+//! String, in ankurah-core's `selection::filter`; and an absent subject staying
+//! a decode error on both paths, in `keys_tests`. What is pinned here is the
+//! composition of those pieces — an OR of scope clauses, and the two access
+//! paths a caller actually reaches.
+
+mod common;
+
+use ankql::ast::Predicate;
+use ankurah::{Model, Node, Ref};
+use ankurah_core::{
+    policy::PolicyAgent,
+    selection::filter::{evaluate_predicate, Filterable},
+    value::Value,
+};
+use ankurah_jwt_auth::{JwtAgent, JwtContext, JwtKeys, PolicyConfig, SigningKeys};
+use ankurah_proto::{CollectionId, EntityId};
+use ankurah_storage_sled::SledStorageEngine;
+use std::sync::Arc;
+
+/// A credential holding one role, signed by `keys`.
+fn context(keys: &SigningKeys, sub: &str, role: &str) -> JwtContext {
+    let claims = common::make_claims(sub, &[role], "reader@example.com");
+    let token = common::sign_token(keys, &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+fn agent_with(config_json: &str, keys: &SigningKeys) -> JwtAgent {
+    let agent = JwtAgent::new_ephemeral();
+    agent.update_config(serde_json::from_str::<PolicyConfig>(config_json).expect("test policy must parse"));
+    agent.set_keys(JwtKeys::Signing(keys.clone()));
+    agent
+}
+
+// ---------------------------------------------------------------------------
+// An OR of scope clauses
+// ---------------------------------------------------------------------------
+
+/// A note whose two owner-ish fields are `Ref`s, so they evaluate as EntityIds
+/// — the same shape a `Ref<User>` column takes when a scope rule reads it.
+#[derive(Clone, Copy)]
+struct NoteRow {
+    owner: EntityId,
+    reviewer: EntityId,
+    visibility: &'static str,
+}
+
+impl Filterable for NoteRow {
+    fn collection(&self) -> &str { "note" }
+
+    fn value(&self, name: &str) -> Option<Value> {
+        match name {
+            "owner" => Some(Value::EntityId(self.owner)),
+            "reviewer" => Some(Value::EntityId(self.reviewer)),
+            "visibility" => Some(Value::String(self.visibility.to_string())),
+            _ => None,
+        }
+    }
+}
+
+const OR_SCOPE_CONFIG: &str = r#"{
+    "roles": { "reader": ["note:read"] },
+    "collections": {
+        "note": {
+            "read": "note:read",
+            "write": null,
+            "scope": [{ "filter": "owner = $jwt.sub OR reviewer = $jwt.sub OR visibility = 'shared'" }]
+        }
+    }
+}"#;
+
+/// A subject that is not an entity id makes each `$jwt.sub` clause answer
+/// false, and a false clause is only a false clause: it denies the rows no
+/// other clause admits, and admits the rows another clause does. An error in
+/// one clause would instead escape the whole OR — the row-by-row half via
+/// `enforce_read_scope`, which turns any evaluation error into a refusal, and
+/// the query half by failing the caller's fetch outright.
+#[test]
+fn test_or_composed_scope_denies_the_row_without_erroring() {
+    let keys = common::test_keys();
+    let agent = agent_with(OR_SCOPE_CONFIG, &keys);
+    let collection = CollectionId::from("note");
+
+    let owner = EntityId::new();
+    let reviewer = EntityId::new();
+    let private = NoteRow { owner, reviewer, visibility: "private" };
+    let shared = NoteRow { owner, reviewer, visibility: "shared" };
+
+    // The caller asks for everything, so the scope rule is the only thing
+    // narrowing the query.
+    let guest = context(&keys, "guest", "reader");
+    let filtered = agent.filter_predicate(&guest, &collection, Predicate::True).expect("a subject that is not an id must still filter");
+
+    let admits = |row: NoteRow| evaluate_predicate(&row, &filtered).expect("the filtered predicate must evaluate, not error");
+    assert!(!admits(private), "neither id clause can match a subject that is not an id, so the row is denied");
+    assert!(admits(shared), "the clause that does not read the subject still admits its rows");
+
+    // The control that keeps the denial honest: the same clauses admit the
+    // owner's own row when the subject is that owner's id, so the false above
+    // is a comparison that answered no rather than a clause that never matches.
+    let member = context(&keys, &owner.to_base64(), "reader");
+    let filtered = agent.filter_predicate(&member, &collection, Predicate::True).expect("a member's subject filters too");
+    assert!(
+        evaluate_predicate(&private, &filtered).expect("the filtered predicate must evaluate, not error"),
+        "the owner's own row must pass the same clause that denied the guest"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Both access paths, end to end
+// ---------------------------------------------------------------------------
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Person {
+    pub name: String,
+}
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Doc {
+    pub owner: Ref<Person>,
+    pub body: String,
+}
+
+const OWNER_SCOPE_CONFIG: &str = r#"{
+    "roles": { "user": ["doc:read"], "guest": ["doc:read"] },
+    "collections": {
+        "doc": {
+            "read": "doc:read",
+            "write": null,
+            "scope": [{ "filter": "owner = $jwt.sub" }]
+        }
+    }
+}"#;
+
+/// The whole posture, against a real node: a caller whose subject is not an
+/// entity id reaches the collection — its role grants that — and the row-local
+/// scope rule then leaves it nothing, on both paths a reader can take. The
+/// owner's own credential takes both paths successfully over the same row, so
+/// what the other caller is denied is its subject and not the fixture.
+///
+/// The claim under test is that no row reaches such a caller, which is why the
+/// query half asserts that and not a particular refusal: the two paths refuse
+/// differently, and the query path's refusal depends on the scoped column's
+/// type. Read by id, the scope is evaluated against the row and denies it.
+/// Queried over the `Ref` column here, the storage planner cannot encode a
+/// string that is not an id into an index key over EntityIds, so the fetch
+/// fails outright rather than answering with nothing — fail-closed, but an
+/// error rather than an empty result. (Scope the same rule on a String column
+/// instead and the comparison is representable, so the fetch simply returns no
+/// rows.) A change that turned the middle case into an empty answer would be an
+/// improvement and must not fail this test; a change that handed over a row
+/// must fail it.
+#[tokio::test]
+async fn test_non_id_subject_reaches_no_row_on_either_path() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent_with(OWNER_SCOPE_CONFIG, &keys));
+    node.system.create().await?;
+
+    let root = node.context(JwtContext::system())?;
+    let (person_id, doc_id) = {
+        let trx = root.begin();
+        let person = trx.create(&Person { name: "Owner".into() }).await?;
+        let doc = trx.create(&Doc { owner: person.id().into(), body: "hello".into() }).await?;
+        let ids = (person.id(), doc.id());
+        trx.commit().await?;
+        ids
+    };
+
+    let member = node.context(context(&keys, &person_id.to_base64(), "user"))?;
+    assert_eq!(member.fetch::<DocView>("body = 'hello'").await?.len(), 1, "the owner's query returns the owner's row");
+    assert!(member.get::<DocView>(doc_id).await.is_ok(), "the owner may read its own row by id");
+
+    let guest = node.context(context(&keys, "guest", "guest"))?;
+    // A refused query and an empty one are both fail-closed; a returned row is
+    // not. See the note above on why this path refuses rather than empties.
+    if let Ok(rows) = guest.fetch::<DocView>("body = 'hello'").await {
+        assert!(rows.is_empty(), "a subject that is not an id owns no row, but the query handed over {}", rows.len());
+    }
+    assert!(guest.get::<DocView>(doc_id).await.is_err(), "the same row read by id is refused rather than handed over");
+
+    Ok(())
+}


### PR DESCRIPTION
Tests only. No behavior changes, and this un-gates nothing: the typed-`Subject` accessor half of #453 stays open and unaddressed here.

## What this is for

A deployment may mint a subject that names no user — a distinguished literal such as `guest`, for a reader who has not signed in — and every `$jwt.sub` scope rule in its policy then compares a field against that literal. ankurah/community is about to do exactly this for its signed-out visitors, so that policy tells guest from member by claims rather than by token absence (community#65). That design was verified against source at 0.9.0 and rests on four facts, all true today and each pinned by nothing: a refactor could invert one and leave the suite green.

Nothing here changes what any of those facts are. Each new test sits with the code it pins, and `extensions/jwt-auth/tests/nonid_subject_tests.rs` holds the two compositions that span crates.

## The four facts, and why a live consumer cares

**1. Substitution falls back to a String literal, and does not error.**
`variables::typed_expr` tries a claim value as an `EntityId` and, failing that, produces `Literal::String`. `guest` cannot parse as an id, so a rule reading `$jwt.sub` becomes a comparison against a plain string.
*Pinned by* `variables::tests::test_non_id_subject_falls_back_to_string_literal` (`extensions/jwt-auth/src/variables.rs`).
*Why it matters:* an error arm added here would fail every query such a reader makes, on every collection, instead of narrowing the ones with scope rules. A value accepted as an id would make `user = $jwt.sub` match rows.

**2. An EntityId-typed field compared against that string answers false, never an error.**
`compare_values_with_cast` casts across the type pair and returns a bool; it has no error path.
*Pinned by* `selection::filter::tests::test_entity_id_field_never_equals_a_non_id_string` (`core/src/selection/filter.rs`), with a positive control — the row's own id, as a string, still matches — so the pin fails both if the comparison starts erroring and if the comparator stops crossing the type pair at all.
*Why it matters:* `evaluate_predicate` propagates an error out of the whole predicate. False denies one comparison; an error takes down the query.

**3. An OR of scope clauses composes those falses into a denial, and no failed clause escapes it.**
*Pinned by* `test_or_composed_scope_denies_the_row_without_erroring` (`extensions/jwt-auth/tests/nonid_subject_tests.rs`), over a rule of the shape `owner = $jwt.sub OR reviewer = $jwt.sub OR visibility = 'shared'` against rows whose `owner` and `reviewer` are `Ref`s. Three assertions: the two id clauses deny the row; the clause that does not read the subject still admits its own rows (so a failed clause has not escaped the OR); and the owner's own credential is admitted by the same clause that denied the other caller.
*Why it matters:* this is the shape a real policy has. If one clause could error, an unrelated arm's rows would disappear with it, and `enforce_read_scope` would turn the error into a refusal of the row.

**4. An absent subject stays a hard error on both decode paths.**
*Pinned by* `test_absent_subject_claim_fails_both_decode_paths` (`extensions/jwt-auth/tests/keys_tests.rs`), over a token that is well formed in every other respect — the signature verifies, the expiry is an hour out — so the absent subject is the only thing either path can be refusing.
*Why it matters:* this is the reason the design uses a literal rather than leaving `sub` out. Softening either path into a default would turn "no subject" into "subject is `""`", and scope rules would start comparing fields against an empty string instead of the token being refused.

## The end-to-end shape

`test_non_id_subject_reaches_no_row_on_either_path` runs both reader paths against a durable sled-backed node with a `owner = $jwt.sub` scope rule over a `Ref<Person>` column: the caller's role reaches the collection, and the scope rule is what leaves it nothing. The owner's own credential succeeds on both paths over the same row, so what the other caller is denied is its subject and not the fixture.

The assertion is *no row reaches such a caller*, rather than a particular refusal, because the two paths refuse differently and the query path's refusal depends on the scoped column's type:

- read by id, the scope is evaluated against the row and denies it;
- queried over a `Ref` column, the storage planner cannot encode a string that is not an id into an index key over `EntityId`s, so the fetch fails with a `TypeMismatch` rather than answering with nothing — fail-closed, but an error and not an empty result;
- queried over a `String` column, the same comparison is representable and the fetch simply returns no rows.

The middle case is worth knowing about: the design record for community#65 recorded the query path as "no match, no error", and at the evaluator that is exactly right, but a sled-backed fetch over a `Ref` column refuses the query instead. No row escapes either way. A change that turned that case into an empty answer would be an improvement and must not fail this test; a change that handed over a row must fail it.

## Verification

Every pin was checked against a deliberate local inversion of the code it guards, each reverted afterward:

| Inversion applied locally | Caught by |
| --- | --- |
| `evaluate_predicate` errors on mismatched comparison types | facts 2 and 3 |
| `typed_expr` rejects a value that is not an entity id | fact 1 |
| either decode path defaults an absent subject to `""` | fact 4 (each path independently) |
| `enforce_read_scope` stops denying on a false predicate | end-to-end, by-id half |
| a subject that is not an id is treated as unscoped | fact 3 and the end-to-end query half |

Gates: `cargo test -p ankurah-core -p ankurah-jwt-auth` green (18 test binaries, 0 failures), `cargo fmt --all -- --check` clean, `cargo check --tests` clean.

Refs #453.
