### PR TITLE
planner: bounds are a prefilter; the residual re-checks every term

### DIFF
--- a/extensions/jwt-auth/tests/scope_column_overlap_tests.rs
+++ b/extensions/jwt-auth/tests/scope_column_overlap_tests.rs
@@ -1,0 +1,254 @@
+//! What a read scope does when the caller's own filter names the same column.
+//!
+//! A read scope is composed onto the caller's predicate as another conjunct, so
+//! `{ "filter": "owner = $jwt.sub" }` and a caller asking for `owner = <someone
+//! else>` produce one predicate with two terms on `owner`. Nothing about that
+//! is special to policy — it is the ordinary case of a column carrying more
+//! terms than an index key has positions for it, pinned in the storage planner
+//! by `repeated_column_tests` in `storage/common/src/planner.rs` and over sled
+//! rows by `tests/tests/sled/repeated_column.rs`.
+//!
+//! It gets its own coverage here because this is the composition consumers
+//! actually run, and because it is the case where a term the planner forgets is
+//! visible as a row: an index scan that answers a two-term query using only the
+//! first term returns rows the second term excludes. The checks run against a
+//! sled-backed durable node over both paths a reader takes — a one-shot `fetch`
+//! and a LiveQuery.
+
+mod common;
+
+use ankurah::{Model, Node, Ref};
+use ankurah_jwt_auth::{JwtAgent, JwtContext, JwtKeys, PolicyConfig, SigningKeys};
+use ankurah_storage_sled::SledStorageEngine;
+use std::sync::Arc;
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct OverlapUser {
+    pub name: String,
+}
+
+/// A scoped column that is a `Ref`, which collates as raw EntityId bytes.
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct OverlapDoc {
+    pub owner: Ref<OverlapUser>,
+    pub label: String,
+}
+
+/// The same scope over a String column, which collates as text and admits range
+/// comparisons a `Ref` column does not usefully take.
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct OverlapNote {
+    pub owner: String,
+    pub label: String,
+}
+
+/// Two scoped columns under one disjunctive rule — the shape a direct-message
+/// thread takes, where either participant may read.
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct OverlapThread {
+    pub first: Ref<OverlapUser>,
+    pub second: Ref<OverlapUser>,
+    pub label: String,
+}
+
+const CONFIG_JSON: &str = r#"{
+    "roles": { "Member": ["doc:read", "user:read"] },
+    "collections": {
+        "overlapdoc":    { "read": "doc:read", "scope": [{ "filter": "owner = $jwt.sub" }] },
+        "overlapnote":   { "read": "doc:read", "scope": [{ "filter": "owner = $jwt.sub" }] },
+        "overlapthread": { "read": "doc:read", "scope": [{ "filter": "first = $jwt.sub OR second = $jwt.sub" }] },
+        "overlapuser":   { "read": "user:read" }
+    }
+}"#;
+
+fn member_context(keys: &SigningKeys, subject: &str) -> JwtContext {
+    let claims = common::make_claims(subject, &["Member"], "member@example.com");
+    let token = common::sign_token(keys, &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+/// Alice, Bob and Carol; one document, note and thread per pairing, on a node
+/// whose policy scopes each collection to the reader.
+struct Fixture {
+    node: Node<SledStorageEngine, JwtAgent>,
+    keys: SigningKeys,
+    alice: ankurah::EntityId,
+    bob: ankurah::EntityId,
+    carol: ankurah::EntityId,
+}
+
+impl Fixture {
+    async fn build() -> anyhow::Result<Self> {
+        let keys = common::test_keys();
+        let agent = JwtAgent::new_ephemeral();
+        agent.update_config(serde_json::from_str::<PolicyConfig>(CONFIG_JSON)?);
+        agent.set_keys(JwtKeys::Signing(keys.clone()));
+
+        let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent);
+        node.system.create().await?;
+
+        let root = node.context(JwtContext::system())?;
+        let (alice, bob, carol) = {
+            let trx = root.begin();
+            let alice = trx.create(&OverlapUser { name: "Alice".into() }).await?;
+            let bob = trx.create(&OverlapUser { name: "Bob".into() }).await?;
+            let carol = trx.create(&OverlapUser { name: "Carol".into() }).await?;
+            let ids = (alice.id(), bob.id(), carol.id());
+            trx.commit().await?;
+            ids
+        };
+        {
+            let trx = root.begin();
+            trx.create(&OverlapDoc { owner: alice.into(), label: "shared label".into() }).await?;
+            trx.create(&OverlapDoc { owner: bob.into(), label: "shared label".into() }).await?;
+            trx.create(&OverlapNote { owner: alice.to_base64(), label: "shared label".into() }).await?;
+            trx.create(&OverlapNote { owner: bob.to_base64(), label: "shared label".into() }).await?;
+            trx.create(&OverlapThread { first: alice.into(), second: carol.into(), label: "alice-carol".into() }).await?;
+            trx.create(&OverlapThread { first: bob.into(), second: carol.into(), label: "bob-carol".into() }).await?;
+            trx.commit().await?;
+        }
+
+        Ok(Self { node, keys, alice, bob, carol })
+    }
+
+    fn as_alice(&self) -> anyhow::Result<ankurah::Context> { Ok(self.node.context(member_context(&self.keys, &self.alice.to_base64()))?) }
+}
+
+/// The caller filters on the scoped column and names the other member. Both
+/// terms are on `owner`, and the answer is the rows that satisfy both — none.
+/// The control in the same test is the caller naming its own id on that column,
+/// which does return its row, so the empty answer is the scope's term applying
+/// rather than the query matching nothing.
+#[tokio::test]
+async fn caller_equality_on_the_scoped_column_does_not_replace_the_scope() -> anyhow::Result<()> {
+    let f = Fixture::build().await?;
+    let alice = f.as_alice()?;
+
+    // Ref-typed scoped column.
+    let own = format!("owner = '{}'", f.alice.to_base64());
+    let rows = alice.fetch::<OverlapDocView>(own.as_str()).await?;
+    assert_eq!(rows.len(), 1, "the caller's own row must still be reachable");
+    assert_eq!(rows[0].owner()?.id(), f.alice, "and it must be the caller's own row");
+
+    let other = format!("owner = '{}'", f.bob.to_base64());
+    let rows = alice.fetch::<OverlapDocView>(other.as_str()).await?;
+    assert!(rows.is_empty(), "the scope's term on `owner` must still apply, but the fetch returned {} row(s)", rows.len());
+
+    // String-typed scoped column, same shape.
+    let own = format!("owner = '{}'", f.alice.to_base64());
+    assert_eq!(alice.fetch::<OverlapNoteView>(own.as_str()).await?.len(), 1);
+    let other = format!("owner = '{}'", f.bob.to_base64());
+    let rows = alice.fetch::<OverlapNoteView>(other.as_str()).await?;
+    assert!(rows.is_empty(), "a String scoped column must hold its term too, but the fetch returned {} row(s)", rows.len());
+
+    Ok(())
+}
+
+/// The caller's term on the scoped column is a range rather than an equality.
+/// The scope's equality is the one the key range can hold, so the caller's
+/// range is the leftover term — the same loss with the halves swapped, and the
+/// caller gets rows outside the range it asked for rather than rows outside its
+/// scope.
+#[tokio::test]
+async fn caller_range_on_the_scoped_column_still_applies() -> anyhow::Result<()> {
+    let f = Fixture::build().await?;
+    let alice = f.as_alice()?;
+    let alice_b64 = f.alice.to_base64();
+
+    // A range that excludes the caller's own id leaves nothing, whichever side
+    // of the caller's id the bound falls on.
+    let above = format!("owner > '{alice_b64}'");
+    let rows = alice.fetch::<OverlapNoteView>(above.as_str()).await?;
+    assert!(rows.is_empty(), "the caller's own row is not above its own id, yet the fetch returned {} row(s)", rows.len());
+
+    let below = format!("owner < '{alice_b64}'");
+    let rows = alice.fetch::<OverlapNoteView>(below.as_str()).await?;
+    assert!(rows.is_empty(), "nor below it, yet the fetch returned {} row(s)", rows.len());
+
+    // A range that includes it returns exactly it, and never the other
+    // member's row, whichever way the two ids happen to sort.
+    let inclusive = format!("owner >= '{alice_b64}' AND owner <= '{alice_b64}'");
+    let rows = alice.fetch::<OverlapNoteView>(inclusive.as_str()).await?;
+    assert_eq!(rows.len(), 1, "a range that brackets the caller's own id must return that row");
+    assert_eq!(rows[0].owner()?, alice_b64);
+
+    Ok(())
+}
+
+/// A disjunctive scope rule over two columns, with the caller naming one of
+/// them. A disjunction never becomes a key range, so it stays in the residual
+/// predicate and is re-checked per row. This shape was already sound; the test
+/// is here so that a later change to which terms the planner encodes cannot
+/// quietly take the disjunction with it.
+#[tokio::test]
+async fn disjunctive_scope_holds_when_the_caller_names_a_scoped_column() -> anyhow::Result<()> {
+    let f = Fixture::build().await?;
+    let alice = f.as_alice()?;
+
+    let own = format!("first = '{}'", f.alice.to_base64());
+    assert_eq!(alice.fetch::<OverlapThreadView>(own.as_str()).await?.len(), 1, "the caller's own thread must still be reachable");
+
+    let other = format!("first = '{}'", f.bob.to_base64());
+    let rows = alice.fetch::<OverlapThreadView>(other.as_str()).await?;
+    assert!(rows.is_empty(), "neither arm of the scope admits Bob's thread, yet the fetch returned {} row(s)", rows.len());
+
+    // The caller's own filter is itself a disjunction naming both scoped
+    // columns, so neither side of the composed predicate is a plain equality.
+    let both = format!("first = '{}' OR second = '{}'", f.bob.to_base64(), f.carol.to_base64());
+    let rows = alice.fetch::<OverlapThreadView>(both.as_str()).await?;
+    assert_eq!(rows.len(), 1, "Alice's own thread has Carol as its second participant, so her scope admits exactly it");
+    assert_eq!(rows[0].label()?, "alice-carol");
+
+    Ok(())
+}
+
+/// The same two terms on the scoped column, read through a LiveQuery rather
+/// than a one-shot fetch. A LiveQuery's initial results come from the same
+/// storage query, and its later results come from the reactor re-checking each
+/// commit; both have to hold.
+#[tokio::test]
+async fn caller_equality_on_the_scoped_column_holds_for_a_live_query() -> anyhow::Result<()> {
+    let f = Fixture::build().await?;
+    let alice = f.as_alice()?;
+
+    let own = format!("owner = '{}'", f.alice.to_base64());
+    let own_lq = alice.query::<OverlapDocView>(own.as_str())?;
+    own_lq.wait_initialized().await;
+    assert_eq!(own_lq.ids().len(), 1, "the caller's own row must still reach its LiveQuery");
+
+    let other = format!("owner = '{}'", f.bob.to_base64());
+    let other_lq = alice.query::<OverlapDocView>(other.as_str())?;
+    other_lq.wait_initialized().await;
+    assert_eq!(other_lq.ids().len(), 0, "the scope's term must apply to the LiveQuery's initial results");
+
+    // A row committed after the subscription reaches the LiveQuery through the
+    // reactor rather than the planner, so check that arrival path too.
+    {
+        let root = f.node.context(JwtContext::system())?;
+        let trx = root.begin();
+        trx.create(&OverlapDoc { owner: f.bob.into(), label: "committed later".into() }).await?;
+        trx.commit().await?;
+    }
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+    assert_eq!(other_lq.ids().len(), 0, "a row committed later must not reach the LiveQuery either");
+
+    Ok(())
+}
+
+/// The caller filters on a different column than the scope. Nothing here is at
+/// risk from a repeated column, and that is the point: it is the control that
+/// says the fixture and the scope both work, so the empty answers above are the
+/// second term applying.
+#[tokio::test]
+async fn caller_filter_on_another_column_leaves_the_scope_intact() -> anyhow::Result<()> {
+    let f = Fixture::build().await?;
+    let alice = f.as_alice()?;
+
+    let rows = alice.fetch::<OverlapDocView>("label = 'shared label'").await?;
+    assert_eq!(rows.len(), 1, "both members' rows carry that label; the scope keeps one");
+    assert_eq!(rows[0].owner()?.id(), f.alice);
+
+    let _ = f.carol; // named in the fixture for the thread pairings
+
+    Ok(())
+}

--- a/storage/common/src/planner.rs
+++ b/storage/common/src/planner.rs
@@ -21,6 +21,57 @@ impl PlannerConfig {
     pub fn full_support() -> Self { Self::new(true) }
 }
 
+/// The predicate terms an index range actually carries.
+///
+/// This exists to keep the planner honest about a soundness rule: choosing an
+/// index is an optimization, and the residual predicate is what makes the
+/// answer correct. Every term the range does not encode has to be re-checked
+/// against each row the scan returns, so a term that is neither encoded nor
+/// residual is a term nothing enforces — the scan then answers with rows the
+/// query excluded.
+///
+/// The planner records what it encoded rather than inferring it from column
+/// names, because one column can carry several terms. `owner = A AND owner = B`
+/// puts two terms on `owner`; a key range can encode one of them, and knowing
+/// that `owner` is "handled" says nothing about the other. The same goes for
+/// range terms: folding picks the most restrictive endpoint per side, and a
+/// term whose value the winning endpoint cannot be compared against (values of
+/// different types have no order) is folded away without being enforced, so
+/// only the terms the final endpoints imply are recorded.
+#[derive(Debug, Default)]
+struct EncodedTerms {
+    /// The exact comparisons the bounds enforce, as (column path, operator,
+    /// value). An equality appears as the point bound it became; a range term
+    /// appears only when the final folded endpoint implies it.
+    terms: Vec<(String, ComparisonOperator, Value)>,
+}
+
+impl EncodedTerms {
+    /// Does the key range already enforce this comparison, making a per-row
+    /// re-check redundant? Answer no whenever unsure: an unnecessary re-check
+    /// costs a comparison, a missing one hands back a row the query excluded.
+    fn covers(&self, field: &str, operator: &ComparisonOperator, value: &Value) -> bool {
+        // NotEqual, In and Between never become key-range endpoints, so they
+        // are never recorded and never covered.
+        self.terms.iter().any(|(column, op, encoded)| column == field && op == operator && encoded == value)
+    }
+}
+
+/// Append `part` unless the key already covers that path.
+///
+/// A key that names one column twice narrows nothing the single-column key
+/// would not: both positions read the same stored value. It is worse than
+/// useless, because the bound placed on the second position is copied from the
+/// first position's term, which makes the key look like it enforces a term it
+/// never saw. Keep the key over distinct paths and let the terms it cannot hold
+/// fall through to the residual predicate.
+fn push_keypart_once(keyparts: &mut Vec<IndexKeyPart>, part: IndexKeyPart) {
+    let path = part.full_path();
+    if !keyparts.iter().any(|existing| existing.full_path() == path) {
+        keyparts.push(part);
+    }
+}
+
 pub struct Planner {
     config: PlannerConfig,
 }
@@ -130,17 +181,23 @@ impl Planner {
         }
 
         // Keyparts: EQ prefix (using asc_path for multi-step path support)
-        let mut index_keyparts: Vec<IndexKeyPart> = equalities.iter().map(|(f, v)| IndexKeyPart::asc_path(f, ValueType::of(v))).collect();
+        let mut index_keyparts: Vec<IndexKeyPart> = Vec::new();
+        for (field, value) in equalities {
+            push_keypart_once(&mut index_keyparts, IndexKeyPart::asc_path(field, ValueType::of(value)));
+        }
 
         // Append ORDER BY fields per capability
         if self.config.supports_desc_indexes {
             for item in order_by {
                 if item.path.is_simple() {
                     let name = item.path.first();
-                    index_keyparts.push(match item.direction {
-                        ankql::ast::OrderDirection::Asc => IndexKeyPart::asc(name.to_string(), ValueType::String),
-                        ankql::ast::OrderDirection::Desc => IndexKeyPart::desc(name.to_string(), ValueType::String),
-                    });
+                    push_keypart_once(
+                        &mut index_keyparts,
+                        match item.direction {
+                            ankql::ast::OrderDirection::Asc => IndexKeyPart::asc(name.to_string(), ValueType::String),
+                            ankql::ast::OrderDirection::Desc => IndexKeyPart::desc(name.to_string(), ValueType::String),
+                        },
+                    );
                 }
             }
         } else {
@@ -151,7 +208,7 @@ impl Planner {
                 if item.path.is_simple() {
                     let name = item.path.first();
                     if !broke && item.direction == first_dir {
-                        index_keyparts.push(IndexKeyPart::asc(name.to_string(), ValueType::String));
+                        push_keypart_once(&mut index_keyparts, IndexKeyPart::asc(name.to_string(), ValueType::String));
                     } else {
                         broke = true;
                     }
@@ -169,7 +226,7 @@ impl Planner {
             }
         });
 
-        let bounds = match applied_ineq {
+        let (bounds, encoded) = match applied_ineq {
             Some((field, vec)) => self.build_bounds(equalities, Some((field, vec)), &index_keyparts)?,
             None => self.build_bounds(equalities, None, &index_keyparts)?,
         };
@@ -177,8 +234,8 @@ impl Planner {
             return Some(Plan::EmptyScan);
         }
 
-        // Remaining predicate excludes the applied OB inequality if any
-        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, equalities, applied_ineq.map(|(f, _)| f));
+        // Every term the bounds did not encode stays in the residual predicate.
+        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, &encoded);
 
         // Scan direction
         let scan_direction = if self.config.supports_desc_indexes {
@@ -245,18 +302,21 @@ impl Planner {
         // Keyparts: EQ + primary INEQ (do not append ORDER BY fields; they do not satisfy global order after a range)
         // NOTE (micro-optimization): Appending OB columns after the range could help spill comparator locality,
         // but it does not change correctness and the tests expect the simpler invariant-preserving form.
-        let mut index_keyparts: Vec<IndexKeyPart> = equalities.iter().map(|(f, v)| IndexKeyPart::asc_path(f, ValueType::of(v))).collect();
+        let mut index_keyparts: Vec<IndexKeyPart> = Vec::new();
+        for (field, value) in equalities {
+            push_keypart_once(&mut index_keyparts, IndexKeyPart::asc_path(field, ValueType::of(value)));
+        }
         let primary_value = &primary.1[0].1; // Get Value from first inequality
-        index_keyparts.push(IndexKeyPart::asc_path(primary.0, ValueType::of(primary_value))); // Use actual primary key value type
+        push_keypart_once(&mut index_keyparts, IndexKeyPart::asc_path(primary.0, ValueType::of(primary_value))); // Use actual primary key value type
 
         // Bounds: EQ + primary INEQ (most-restrictive)
-        let bounds = self.build_bounds(equalities, Some(primary), &index_keyparts)?;
+        let (bounds, encoded) = self.build_bounds(equalities, Some(primary), &index_keyparts)?;
         if self.is_empty_bounds(&bounds) {
             return Some(Plan::EmptyScan);
         }
 
-        // Remaining predicate: all inequalities except the primary one
-        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, equalities, Some(primary.0));
+        // Every term the bounds did not encode stays in the residual predicate.
+        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, &encoded);
 
         // Scan direction
         let scan_direction = if self.config.supports_desc_indexes {
@@ -369,30 +429,30 @@ impl Planner {
         // Add equality fields first
         let mut index_keyparts = Vec::new();
         for (field, value) in equalities {
-            index_keyparts.push(IndexKeyPart::asc_path(field, ValueType::of(value)));
+            push_keypart_once(&mut index_keyparts, IndexKeyPart::asc_path(field, ValueType::of(value)));
         }
 
         // Add the inequality field
         let inequality_values = inequalities.get(inequality_field)?;
         let first_inequality_value = &inequality_values[0].1; // Get Value from first inequality
-        index_keyparts.push(IndexKeyPart::asc_path(inequality_field, ValueType::of(first_inequality_value)));
+        push_keypart_once(&mut index_keyparts, IndexKeyPart::asc_path(inequality_field, ValueType::of(first_inequality_value)));
 
         // Build bounds
         let bounds = self.build_bounds(equalities, Some((inequality_field, inequality_values)), &index_keyparts);
 
         // Check for empty scan
-        let bounds = match bounds {
-            Some(bounds) => {
+        let (bounds, encoded) = match bounds {
+            Some((bounds, encoded)) => {
                 if self.is_empty_bounds(&bounds) {
                     return Some(Plan::EmptyScan);
                 }
-                bounds
+                (bounds, encoded)
             }
             None => return Some(Plan::EmptyScan),
         };
 
-        // Calculate remaining predicate (exclude this inequality field)
-        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, equalities, Some(inequality_field));
+        // Every term the bounds did not encode stays in the residual predicate.
+        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, &encoded);
 
         // Build OrderByComponents: presort (EQ + inequality) and spill (rest)
         let order_by_spill = if let Some(order_by_items) = order_by {
@@ -424,25 +484,25 @@ impl Planner {
         // Add all equality fields
         let mut index_keyparts = Vec::new();
         for (field, value) in equalities {
-            index_keyparts.push(IndexKeyPart::asc_path(field, ValueType::of(value)));
+            push_keypart_once(&mut index_keyparts, IndexKeyPart::asc_path(field, ValueType::of(value)));
         }
 
         // Build bounds (exact match on all equality values)
         let bounds = self.build_bounds(equalities, None, &index_keyparts);
 
         // Check for empty scan
-        let bounds = match bounds {
-            Some(bounds) => {
+        let (bounds, encoded) = match bounds {
+            Some((bounds, encoded)) => {
                 if self.is_empty_bounds(&bounds) {
                     return Some(Plan::EmptyScan);
                 }
-                bounds
+                (bounds, encoded)
             }
             None => return Some(Plan::EmptyScan),
         };
 
-        // Calculate remaining predicate
-        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, equalities, None);
+        // Every term the bounds did not encode stays in the residual predicate.
+        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, &encoded);
 
         let index_spec = KeySpec::new(index_keyparts);
         Some(Plan::Index {
@@ -456,20 +516,31 @@ impl Planner {
 
     // removed: specialized ORDER BY bounds builder (use unified per-strategy bounds)
 
-    /// Build bounds based on equalities and optional inequality
+    /// Build bounds based on equalities and optional inequality.
+    ///
+    /// Returns the bounds together with the terms they encode. The second half
+    /// is not bookkeeping for its own sake: it is the input the residual
+    /// predicate is computed from, so that a term this function declines to
+    /// encode is guaranteed to be re-checked per row rather than forgotten.
+    /// A column carrying several equality terms encodes at most one of them
+    /// here, and a range term is encoded only when the folded endpoint
+    /// implies it.
     fn build_bounds(
         &self,
         equalities: &[(String, Value)],
         inequality: Option<(&str, &Vec<(ComparisonOperator, Value)>)>,
         index_keyparts: &[IndexKeyPart],
-    ) -> Option<KeyBounds> {
+    ) -> Option<(KeyBounds, EncodedTerms)> {
         let mut keypart_bounds = Vec::new();
+        let mut encoded = EncodedTerms::default();
 
         // Build per-column bounds (using full_path for multi-step path support)
         for keypart in index_keyparts {
             let full_path = keypart.full_path();
 
-            // Check if this path has an equality constraint
+            // Check if this path has an equality constraint. When the column
+            // carries more than one, the first is the one the range holds; the
+            // rest are left for `calculate_remaining_predicate` to keep.
             let equality_value = equalities.iter().find(|(field, _)| field == &full_path).map(|(_, value)| value);
 
             if let Some(value) = equality_value {
@@ -479,6 +550,7 @@ impl Planner {
                     low: Endpoint::incl(value.clone()),
                     high: Endpoint::incl(value.clone()),
                 });
+                encoded.terms.push((full_path.clone(), ComparisonOperator::Equal, value.clone()));
             } else if let Some((ineq_field, inequalities)) = inequality {
                 if ineq_field == full_path {
                     // This column has inequality constraints
@@ -516,6 +588,37 @@ impl Planner {
                         }
                     }
 
+                    // Record the folded terms the final endpoints imply — equal
+                    // to the endpoint, or decisively looser. A term that lost
+                    // the fold to an incomparable value (values of different
+                    // types have no order) is implied by neither endpoint, and
+                    // recording it would drop it from the residual with nothing
+                    // left to re-check it.
+                    for (op, value) in inequalities {
+                        let enforced = match op {
+                            ComparisonOperator::GreaterThan => {
+                                let term = Endpoint::excl(value.clone());
+                                low == term || self.is_more_restrictive_lower(&low, &term)
+                            }
+                            ComparisonOperator::GreaterThanOrEqual => {
+                                let term = Endpoint::incl(value.clone());
+                                low == term || self.is_more_restrictive_lower(&low, &term)
+                            }
+                            ComparisonOperator::LessThan => {
+                                let term = Endpoint::excl(value.clone());
+                                high == term || self.is_more_restrictive_upper(&high, &term)
+                            }
+                            ComparisonOperator::LessThanOrEqual => {
+                                let term = Endpoint::incl(value.clone());
+                                high == term || self.is_more_restrictive_upper(&high, &term)
+                            }
+                            _ => false,
+                        };
+                        if enforced {
+                            encoded.terms.push((full_path.clone(), op.clone(), value.clone()));
+                        }
+                    }
+
                     keypart_bounds.push(KeyBoundComponent { column: full_path.clone(), low, high });
                     break; // Stop at first inequality column
                 } else {
@@ -528,7 +631,7 @@ impl Planner {
             }
         }
 
-        Some(KeyBounds::new(keypart_bounds))
+        Some((KeyBounds::new(keypart_bounds), encoded))
     }
 
     /// Check if candidate lower bound is more restrictive than current
@@ -629,36 +732,22 @@ impl Planner {
         false
     }
 
-    /// Calculate remaining predicate by removing consumed conjuncts
-    fn calculate_remaining_predicate(
-        &self,
-        conjuncts: &[Predicate],
-        consumed_equalities: &[(String, Value)],
-        consumed_inequality_field: Option<&str>,
-    ) -> Predicate {
+    /// Calculate the residual predicate: every conjunct the key range does not
+    /// already enforce.
+    ///
+    /// A conjunct drops out only when `encoded` says the range carries that
+    /// exact term. Matching on the column alone would be wrong, because a
+    /// column can appear in several conjuncts and the range holds at most one
+    /// of them — dropping the others would leave the scan free to return rows
+    /// they exclude.
+    fn calculate_remaining_predicate(&self, conjuncts: &[Predicate], encoded: &EncodedTerms) -> Predicate {
         let mut remaining_conjuncts = Vec::new();
 
         for conjunct in conjuncts {
-            let mut consumed = false;
-
-            // Check if this conjunct is consumed by equalities
-            if let Some((field, _, _)) = self.extract_comparison(conjunct) {
-                // Check if it's a consumed equality
-                for (eq_field, _) in consumed_equalities {
-                    if field == *eq_field {
-                        consumed = true;
-                        break;
-                    }
-                }
-
-                // Check if it's a consumed inequality
-                if !consumed
-                    && let Some(ineq_field) = consumed_inequality_field
-                    && field == ineq_field
-                {
-                    consumed = true;
-                }
-            }
+            let consumed = match self.extract_comparison(conjunct) {
+                Some((field, operator, value)) => encoded.covers(&field, &operator, &value),
+                None => false,
+            };
 
             if !consumed {
                 remaining_conjuncts.push(conjunct.clone());
@@ -2181,6 +2270,344 @@ mod tests {
                     }
                 ]
             );
+        }
+    }
+
+    // A key range can hold one term per column. Everything else a column is
+    // compared against has to stay in the residual predicate, because the scan
+    // enforces only what the range encodes. These pin that for each shape a
+    // repeated column can take.
+    mod repeated_column_tests {
+        use super::*;
+
+        /// Two equalities on one column: the range holds the first, and the
+        /// second is what makes the answer empty. Dropping it hands back the
+        /// rows the first value names — which is how a policy read scope of
+        /// `owner = <caller>` composed onto a caller's `owner = <someone else>`
+        /// used to return the other principal's row.
+        #[test]
+        fn two_equalities_on_one_column() {
+            assert_eq!(
+                plan!("__collection = 'album' AND owner = 'bob' AND owner = 'alice'"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("owner", ValueType::String)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("__collection" => ("album"..="album"), "owner" => ("bob"..="bob")),
+                        remaining_predicate: selection!("owner = 'alice'").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("__collection = 'album' AND owner = 'bob' AND owner = 'alice'").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// The same term written twice constrains nothing further, so the range
+        /// really does enforce both and the residual stays empty. This is the
+        /// shape a policy scope produces when the caller already asked for its
+        /// own rows, and it must keep the cheap no-filter path.
+        #[test]
+        fn repeated_identical_equality_needs_no_residual() {
+            assert_eq!(
+                plan!("__collection = 'album' AND owner = 'bob' AND owner = 'bob'"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("owner", ValueType::String)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("__collection" => ("album"..="album"), "owner" => ("bob"..="bob")),
+                        remaining_predicate: Predicate::True,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("__collection = 'album' AND owner = 'bob' AND owner = 'bob'").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// Three equalities on one column: the range holds the first and both
+        /// of the others survive, in the order they were written.
+        #[test]
+        fn three_equalities_on_one_column() {
+            assert_eq!(
+                plan!("owner = 'a' AND owner = 'b' AND owner = 'c'"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("owner", ValueType::String)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("owner" => ("a"..="a")),
+                        remaining_predicate: selection!("owner = 'b' AND owner = 'c'").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("owner = 'a' AND owner = 'b' AND owner = 'c'").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// An equality and a range on one column. The range endpoint is the
+        /// point bound, so the inequality is left over — including when the two
+        /// contradict, which is the case that used to answer with the equality's
+        /// rows instead of nothing.
+        #[test]
+        fn equality_and_range_on_one_column() {
+            assert_eq!(
+                plan!("age = 5 AND age > 10"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("age" => (5..=5)),
+                        remaining_predicate: selection!("age > 10").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("age = 5 AND age > 10").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// Writing the range first does not change which term the range holds,
+        /// nor that the other one survives.
+        #[test]
+        fn range_and_equality_on_one_column() {
+            assert_eq!(
+                plan!("age > 10 AND age = 5"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("age" => (5..=5)),
+                        remaining_predicate: selection!("age > 10").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("age > 10 AND age = 5").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// Two ranges on one column fold into that column's low and high
+        /// endpoints, so the range really does enforce both and nothing is left
+        /// over. This shape was always sound; it is here so a future change to
+        /// the folding cannot quietly stop encoding one side.
+        #[test]
+        fn two_ranges_on_one_column_fold_into_the_bounds() {
+            assert_eq!(
+                plan!("age > 3 AND age < 10"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds_list!(KeyBoundComponent { column: "age".to_string(), low: gt(3), high: lt(10) }),
+                        remaining_predicate: Predicate::True,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("age > 3 AND age < 10").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// Two range terms on one column whose values have no order between
+        /// them (an integer and a string). The fold keeps the first as the
+        /// endpoint and cannot compare the second against it, so the endpoint
+        /// does not imply the second term and it must survive — the residual
+        /// evaluator, not the range, decides what a cross-typed comparison
+        /// admits.
+        #[test]
+        fn incomparably_typed_ranges_on_one_column_keep_the_unfolded_term() {
+            assert_eq!(
+                plan!("age > 5 AND age > 'abc'"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds_list!(open_lower!("age" => 5..)),
+                        remaining_predicate: selection!("age > 'abc'").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("age > 5 AND age > 'abc'").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// A repeated column sitting between terms on other columns: the other
+        /// columns still make it into the key, and only the term the range
+        /// could not hold is left over.
+        #[test]
+        fn repeated_column_alongside_other_columns() {
+            assert_eq!(
+                plan!("owner = 'bob' AND status = 'open' AND owner = 'alice'"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("owner", ValueType::String), asc!("status", ValueType::String)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("owner" => ("bob"..="bob"), "status" => ("open"..="open")),
+                        remaining_predicate: selection!("owner = 'alice'").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("owner = 'bob' AND status = 'open' AND owner = 'alice'").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// `!=` never becomes a key-range endpoint, so it survives even on a
+        /// column the range already pins. It used to be dropped for naming a
+        /// column that some other term had been encoded for.
+        #[test]
+        fn not_equal_on_a_pinned_column_survives() {
+            assert_eq!(
+                plan!("age = 5 AND age != 5"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("age" => (5..=5)),
+                        remaining_predicate: selection!("age != 5").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("age = 5 AND age != 5").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// An ORDER BY naming a column the predicate already pins does not earn
+        /// that column a second position in the key, and the extra equality
+        /// still survives. The ORDER BY is satisfied either way, because the
+        /// column is constant across the rows the scan returns.
+        #[test]
+        fn repeated_equality_under_order_by() {
+            assert_eq!(
+                plan_full_support!("owner = 'bob' AND owner = 'alice' ORDER BY owner, label"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("owner", ValueType::String), asc!("label", ValueType::String)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("owner" => ("bob"..="bob")),
+                        remaining_predicate: selection!("owner = 'alice'").predicate,
+                        order_by_spill: order_by_components!(presort: [oby_asc!("owner"), oby_asc!("label")])
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("owner = 'bob' AND owner = 'alice'").predicate,
+                        order_by_spill: order_by_components!(spill: [oby_asc!("owner"), oby_asc!("label")])
+                    }
+                ]
+            );
+        }
+
+        /// The predicate a client composes and a server then composes onto
+        /// again: three terms on one column, two of them the same. The range
+        /// holds the first, the repeat of it is genuinely enforced by that same
+        /// bound, and the term that differs survives.
+        #[test]
+        fn twice_composed_repeats_on_one_column() {
+            assert_eq!(
+                plan!("owner = 'bob' AND owner = 'alice' AND owner = 'alice'"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("owner", ValueType::String)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("owner" => ("bob"..="bob")),
+                        remaining_predicate: selection!("owner = 'alice' AND owner = 'alice'").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("owner = 'bob' AND owner = 'alice' AND owner = 'alice'").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// A disjunction is never encoded into a key range, whatever else the
+        /// query says about the columns it names. This shape was always sound;
+        /// pinning it keeps a later change to what the range encodes from
+        /// taking the disjunction along.
+        #[test]
+        fn disjunction_stays_in_the_residual() {
+            assert_eq!(
+                plan!("(owner = 'a' OR reviewer = 'a') AND owner = 'b'"),
+                vec![
+                    Plan::Index {
+                        index_spec: KeySpec::new(vec![asc!("owner", ValueType::String)]),
+                        scan_direction: ScanDirection::Forward,
+                        bounds: bounds!("owner" => ("b"..="b")),
+                        remaining_predicate: selection!("owner = 'a' OR reviewer = 'a'").predicate,
+                        order_by_spill: order_by_components!()
+                    },
+                    Plan::TableScan {
+                        bounds: KeyBounds::empty(),
+                        scan_direction: ScanDirection::Forward,
+                        remaining_predicate: selection!("(owner = 'a' OR reviewer = 'a') AND owner = 'b'").predicate,
+                        order_by_spill: order_by_components!()
+                    }
+                ]
+            );
+        }
+
+        /// Every plan the planner offers for one query has to answer the same
+        /// question, so the leftover term must appear in all of them — the
+        /// caller picks a plan without re-deriving what it enforces.
+        #[test]
+        fn every_plan_for_a_repeated_column_keeps_the_leftover_term() {
+            for plans in [
+                plan!("owner = 'bob' AND owner = 'alice'"),
+                plan_full_support!("owner = 'bob' AND owner = 'alice'"),
+                plan!("age = 5 AND age > 10 ORDER BY label"),
+                plan_full_support!("age = 5 AND age > 10 ORDER BY label"),
+            ] {
+                for plan in &plans {
+                    let residual = match plan {
+                        Plan::Index { remaining_predicate, .. } | Plan::TableScan { remaining_predicate, .. } => remaining_predicate,
+                        Plan::EmptyScan => continue,
+                    };
+                    assert_ne!(*residual, Predicate::True, "a plan enforcing nothing beyond its key range: {plan:?}");
+                }
+            }
         }
     }
 

--- a/storage/common/src/planner.rs
+++ b/storage/common/src/planner.rs
@@ -21,40 +21,29 @@ impl PlannerConfig {
     pub fn full_support() -> Self { Self::new(true) }
 }
 
-/// The predicate terms an index range actually carries.
+/// The residual predicate for an index or table scan: every conjunct, joined
+/// back with AND.
 ///
-/// This exists to keep the planner honest about a soundness rule: choosing an
-/// index is an optimization, and the residual predicate is what makes the
-/// answer correct. Every term the range does not encode has to be re-checked
-/// against each row the scan returns, so a term that is neither encoded nor
-/// residual is a term nothing enforces — the scan then answers with rows the
-/// query excluded.
+/// Index selection is an optimization, and the residual is what makes the
+/// answer correct: each row the scan returns is re-checked against it by the
+/// engine's predicate evaluator. No conjunct is elided — not even one whose
+/// value became a key-range endpoint — because a key range does not enforce
+/// the comparison it was built from. The planner types each keypart from the
+/// query literal (`resolve_path` has no schema for simple paths), the key
+/// encoding casts every stored value to that type, and a cast can coalesce
+/// values the predicate distinguishes: a stored `F64(5.9)` under an
+/// `I32` keypart encodes as `5` and sits inside the point range for `= 5`,
+/// while the evaluator, casting the literal toward the stored value instead,
+/// correctly rejects it. So the range enforces "encodes like the literal",
+/// the predicate means "compares equal to the literal", and only the residual
+/// checks the latter. Bounds narrow the scan; they never stand in for a term.
 ///
-/// The planner records what it encoded rather than inferring it from column
-/// names, because one column can carry several terms. `owner = A AND owner = B`
-/// puts two terms on `owner`; a key range can encode one of them, and knowing
-/// that `owner` is "handled" says nothing about the other. The same goes for
-/// range terms: folding picks the most restrictive endpoint per side, and a
-/// term whose value the winning endpoint cannot be compared against (values of
-/// different types have no order) is folded away without being enforced, so
-/// only the terms the final endpoints imply are recorded.
-#[derive(Debug, Default)]
-struct EncodedTerms {
-    /// The exact comparisons the bounds enforce, as (column path, operator,
-    /// value). An equality appears as the point bound it became; a range term
-    /// appears only when the final folded endpoint implies it.
-    terms: Vec<(String, ComparisonOperator, Value)>,
-}
-
-impl EncodedTerms {
-    /// Does the key range already enforce this comparison, making a per-row
-    /// re-check redundant? Answer no whenever unsure: an unnecessary re-check
-    /// costs a comparison, a missing one hands back a row the query excluded.
-    fn covers(&self, field: &str, operator: &ComparisonOperator, value: &Value) -> bool {
-        // NotEqual, In and Between never become key-range endpoints, so they
-        // are never recorded and never covered.
-        self.terms.iter().any(|(column, op, encoded)| column == field && op == operator && encoded == value)
-    }
+/// The fold mirrors `build_table_scan_plan` so an index plan and the fallback
+/// answer with the same predicate.
+fn residual_predicate(conjuncts: &[Predicate]) -> Predicate {
+    conjuncts.iter().fold(Predicate::True, |acc, pred| {
+        if matches!(acc, Predicate::True) { pred.clone() } else { Predicate::And(Box::new(acc), Box::new(pred.clone())) }
+    })
 }
 
 /// Append `part` unless the key already covers that path.
@@ -63,8 +52,8 @@ impl EncodedTerms {
 /// would not: both positions read the same stored value. It is worse than
 /// useless, because the bound placed on the second position is copied from the
 /// first position's term, which makes the key look like it enforces a term it
-/// never saw. Keep the key over distinct paths and let the terms it cannot hold
-/// fall through to the residual predicate.
+/// never saw. Keep the key over distinct paths; the residual re-checks every
+/// term regardless.
 fn push_keypart_once(keyparts: &mut Vec<IndexKeyPart>, part: IndexKeyPart) {
     let path = part.full_path();
     if !keyparts.iter().any(|existing| existing.full_path() == path) {
@@ -226,7 +215,7 @@ impl Planner {
             }
         });
 
-        let (bounds, encoded) = match applied_ineq {
+        let bounds = match applied_ineq {
             Some((field, vec)) => self.build_bounds(equalities, Some((field, vec)), &index_keyparts)?,
             None => self.build_bounds(equalities, None, &index_keyparts)?,
         };
@@ -234,8 +223,8 @@ impl Planner {
             return Some(Plan::EmptyScan);
         }
 
-        // Every term the bounds did not encode stays in the residual predicate.
-        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, &encoded);
+        // Bounds only narrow the scan; every conjunct is re-checked per row.
+        let remaining_predicate = residual_predicate(conjuncts);
 
         // Scan direction
         let scan_direction = if self.config.supports_desc_indexes {
@@ -310,13 +299,13 @@ impl Planner {
         push_keypart_once(&mut index_keyparts, IndexKeyPart::asc_path(primary.0, ValueType::of(primary_value))); // Use actual primary key value type
 
         // Bounds: EQ + primary INEQ (most-restrictive)
-        let (bounds, encoded) = self.build_bounds(equalities, Some(primary), &index_keyparts)?;
+        let bounds = self.build_bounds(equalities, Some(primary), &index_keyparts)?;
         if self.is_empty_bounds(&bounds) {
             return Some(Plan::EmptyScan);
         }
 
-        // Every term the bounds did not encode stays in the residual predicate.
-        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, &encoded);
+        // Bounds only narrow the scan; every conjunct is re-checked per row.
+        let remaining_predicate = residual_predicate(conjuncts);
 
         // Scan direction
         let scan_direction = if self.config.supports_desc_indexes {
@@ -441,18 +430,18 @@ impl Planner {
         let bounds = self.build_bounds(equalities, Some((inequality_field, inequality_values)), &index_keyparts);
 
         // Check for empty scan
-        let (bounds, encoded) = match bounds {
-            Some((bounds, encoded)) => {
+        let bounds = match bounds {
+            Some(bounds) => {
                 if self.is_empty_bounds(&bounds) {
                     return Some(Plan::EmptyScan);
                 }
-                (bounds, encoded)
+                bounds
             }
             None => return Some(Plan::EmptyScan),
         };
 
-        // Every term the bounds did not encode stays in the residual predicate.
-        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, &encoded);
+        // Bounds only narrow the scan; every conjunct is re-checked per row.
+        let remaining_predicate = residual_predicate(conjuncts);
 
         // Build OrderByComponents: presort (EQ + inequality) and spill (rest)
         let order_by_spill = if let Some(order_by_items) = order_by {
@@ -487,22 +476,22 @@ impl Planner {
             push_keypart_once(&mut index_keyparts, IndexKeyPart::asc_path(field, ValueType::of(value)));
         }
 
-        // Build bounds (exact match on all equality values)
+        // Build bounds (point range on the first equality per column)
         let bounds = self.build_bounds(equalities, None, &index_keyparts);
 
         // Check for empty scan
-        let (bounds, encoded) = match bounds {
-            Some((bounds, encoded)) => {
+        let bounds = match bounds {
+            Some(bounds) => {
                 if self.is_empty_bounds(&bounds) {
                     return Some(Plan::EmptyScan);
                 }
-                (bounds, encoded)
+                bounds
             }
             None => return Some(Plan::EmptyScan),
         };
 
-        // Every term the bounds did not encode stays in the residual predicate.
-        let remaining_predicate = self.calculate_remaining_predicate(conjuncts, &encoded);
+        // Bounds only narrow the scan; every conjunct is re-checked per row.
+        let remaining_predicate = residual_predicate(conjuncts);
 
         let index_spec = KeySpec::new(index_keyparts);
         Some(Plan::Index {
@@ -518,29 +507,26 @@ impl Planner {
 
     /// Build bounds based on equalities and optional inequality.
     ///
-    /// Returns the bounds together with the terms they encode. The second half
-    /// is not bookkeeping for its own sake: it is the input the residual
-    /// predicate is computed from, so that a term this function declines to
-    /// encode is guaranteed to be re-checked per row rather than forgotten.
-    /// A column carrying several equality terms encodes at most one of them
-    /// here, and a range term is encoded only when the folded endpoint
-    /// implies it.
+    /// The bounds narrow which keys the scan visits and nothing more: the
+    /// residual predicate re-checks every conjunct against the stored values,
+    /// because index keys are stored values cast to the keypart's
+    /// literal-derived type, and that cast can coalesce values the predicate
+    /// distinguishes (see `residual_predicate`).
     fn build_bounds(
         &self,
         equalities: &[(String, Value)],
         inequality: Option<(&str, &Vec<(ComparisonOperator, Value)>)>,
         index_keyparts: &[IndexKeyPart],
-    ) -> Option<(KeyBounds, EncodedTerms)> {
+    ) -> Option<KeyBounds> {
         let mut keypart_bounds = Vec::new();
-        let mut encoded = EncodedTerms::default();
 
         // Build per-column bounds (using full_path for multi-step path support)
         for keypart in index_keyparts {
             let full_path = keypart.full_path();
 
             // Check if this path has an equality constraint. When the column
-            // carries more than one, the first is the one the range holds; the
-            // rest are left for `calculate_remaining_predicate` to keep.
+            // carries more than one, the first is the one the range narrows
+            // by; the residual re-checks all of them either way.
             let equality_value = equalities.iter().find(|(field, _)| field == &full_path).map(|(_, value)| value);
 
             if let Some(value) = equality_value {
@@ -550,7 +536,6 @@ impl Planner {
                     low: Endpoint::incl(value.clone()),
                     high: Endpoint::incl(value.clone()),
                 });
-                encoded.terms.push((full_path.clone(), ComparisonOperator::Equal, value.clone()));
             } else if let Some((ineq_field, inequalities)) = inequality {
                 if ineq_field == full_path {
                     // This column has inequality constraints
@@ -588,37 +573,6 @@ impl Planner {
                         }
                     }
 
-                    // Record the folded terms the final endpoints imply — equal
-                    // to the endpoint, or decisively looser. A term that lost
-                    // the fold to an incomparable value (values of different
-                    // types have no order) is implied by neither endpoint, and
-                    // recording it would drop it from the residual with nothing
-                    // left to re-check it.
-                    for (op, value) in inequalities {
-                        let enforced = match op {
-                            ComparisonOperator::GreaterThan => {
-                                let term = Endpoint::excl(value.clone());
-                                low == term || self.is_more_restrictive_lower(&low, &term)
-                            }
-                            ComparisonOperator::GreaterThanOrEqual => {
-                                let term = Endpoint::incl(value.clone());
-                                low == term || self.is_more_restrictive_lower(&low, &term)
-                            }
-                            ComparisonOperator::LessThan => {
-                                let term = Endpoint::excl(value.clone());
-                                high == term || self.is_more_restrictive_upper(&high, &term)
-                            }
-                            ComparisonOperator::LessThanOrEqual => {
-                                let term = Endpoint::incl(value.clone());
-                                high == term || self.is_more_restrictive_upper(&high, &term)
-                            }
-                            _ => false,
-                        };
-                        if enforced {
-                            encoded.terms.push((full_path.clone(), op.clone(), value.clone()));
-                        }
-                    }
-
                     keypart_bounds.push(KeyBoundComponent { column: full_path.clone(), low, high });
                     break; // Stop at first inequality column
                 } else {
@@ -631,7 +585,7 @@ impl Planner {
             }
         }
 
-        Some((KeyBounds::new(keypart_bounds), encoded))
+        Some(KeyBounds::new(keypart_bounds))
     }
 
     /// Check if candidate lower bound is more restrictive than current
@@ -732,43 +686,6 @@ impl Planner {
         false
     }
 
-    /// Calculate the residual predicate: every conjunct the key range does not
-    /// already enforce.
-    ///
-    /// A conjunct drops out only when `encoded` says the range carries that
-    /// exact term. Matching on the column alone would be wrong, because a
-    /// column can appear in several conjuncts and the range holds at most one
-    /// of them — dropping the others would leave the scan free to return rows
-    /// they exclude.
-    fn calculate_remaining_predicate(&self, conjuncts: &[Predicate], encoded: &EncodedTerms) -> Predicate {
-        let mut remaining_conjuncts = Vec::new();
-
-        for conjunct in conjuncts {
-            let consumed = match self.extract_comparison(conjunct) {
-                Some((field, operator, value)) => encoded.covers(&field, &operator, &value),
-                None => false,
-            };
-
-            if !consumed {
-                remaining_conjuncts.push(conjunct.clone());
-            }
-        }
-
-        // Combine remaining conjuncts with AND
-        if remaining_conjuncts.is_empty() {
-            Predicate::True
-        } else if remaining_conjuncts.len() == 1 {
-            remaining_conjuncts.into_iter().next().unwrap()
-        } else {
-            // Build AND chain
-            let mut result = remaining_conjuncts[0].clone();
-            for conjunct in remaining_conjuncts.into_iter().skip(1) {
-                result = Predicate::And(Box::new(result), Box::new(conjunct));
-            }
-            result
-        }
-    }
-
     /// Deduplicate plans based on index_spec and scan_direction
     fn deduplicate_plans(&self, plans: Vec<Plan>) -> Vec<Plan> {
         let mut unique_plans = Vec::new();
@@ -804,13 +721,7 @@ impl Planner {
         let bounds = self.extract_entity_id_range(conjuncts, primary_key);
 
         // All predicates remain (no index to satisfy any)
-        let remaining_predicate = conjuncts.iter().fold(ankql::ast::Predicate::True, |acc, pred| {
-            if matches!(acc, ankql::ast::Predicate::True) {
-                pred.clone()
-            } else {
-                ankql::ast::Predicate::And(Box::new(acc), Box::new(pred.clone()))
-            }
-        });
+        let remaining_predicate = residual_predicate(conjuncts);
 
         // Determine scan direction and ORDER BY components based on primary key ORDER BY
         let (scan_direction, order_by_spill) = if let Some(order_items) = order_by {
@@ -1205,7 +1116,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("foo"), oby_asc!("bar")])
                     },
                     Plan::TableScan {
@@ -1233,7 +1144,7 @@ mod tests {
                         // from is excl because the inequality (foo) is > 10
                         // to is incl because there is no foo < ? in the predicate
                         bounds: bounds_list!(col_range!("__collection" => "album"..="album"), open_lower!("foo" => 10..)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND foo > 10").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("foo"), oby_asc!("bar")])
                     },
                     Plan::TableScan {
@@ -1259,7 +1170,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("age" => (30..=30)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("age = 30").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("foo"), oby_asc!("bar")])
                     },
                     Plan::TableScan {
@@ -1287,7 +1198,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (30..=30)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age = 30").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("foo"), oby_asc!("bar")])
                     },
                     Plan::TableScan {
@@ -1310,7 +1221,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("name", ValueType::String)]),
                         scan_direction: ScanDirection::Reverse,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("name")])
                     },
                     Plan::TableScan {
@@ -1337,7 +1248,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Reverse,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("name"), oby_desc!("year")])
                     },
                     Plan::TableScan {
@@ -1360,7 +1271,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("name", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("name")], spill: [oby_desc!("year")])
                     },
                     Plan::TableScan {
@@ -1383,7 +1294,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("name", ValueType::String)]),
                         scan_direction: ScanDirection::Reverse,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("name")], spill: [oby_asc!("year")])
                     },
                     Plan::TableScan {
@@ -1406,7 +1317,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("a", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("a")], spill: [oby_desc!("b"), oby_desc!("c")])
                     },
                     Plan::TableScan {
@@ -1433,7 +1344,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Reverse,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("a"), oby_desc!("b")], spill: [oby_asc!("c")])
                     },
                     Plan::TableScan {
@@ -1464,7 +1375,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("a"), oby_asc!("b"), oby_asc!("c")])
                     },
                     Plan::TableScan {
@@ -1491,7 +1402,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("a"), oby_asc!("b")], spill: [oby_desc!("c")])
                     },
                     Plan::TableScan {
@@ -1514,7 +1425,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("a", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("a")], spill: [oby_desc!("b"), oby_asc!("c")])
                     },
                     Plan::TableScan {
@@ -1537,7 +1448,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("a", ValueType::String)]),
                         scan_direction: ScanDirection::Reverse,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("a")], spill: [oby_asc!("b"), oby_asc!("c")])
                     },
                     Plan::TableScan {
@@ -1560,7 +1471,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("a", ValueType::String)]),
                         scan_direction: ScanDirection::Reverse,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("a")], spill: [oby_asc!("b"), oby_desc!("c")])
                     },
                     Plan::TableScan {
@@ -1588,7 +1499,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Reverse,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("a"), oby_desc!("b"), oby_desc!("c")])
                     },
                     Plan::TableScan {
@@ -1615,7 +1526,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Reverse,
                         bounds: bounds!("__collection" => ("album"..="album"), "status" => ("active"..="active")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND status = 'active'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("name")])
                     },
                     Plan::TableScan {
@@ -1640,7 +1551,7 @@ mod tests {
                         // from is excl because the inequality (age) is > 25
                         // to is incl because there is no age < ? in the predicate
                         bounds: bounds_list!(col_range!("__collection" => "album"..="album"), open_lower!("age" => 25..)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age > 25").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("age")])
                     },
                     Plan::TableScan {
@@ -1668,7 +1579,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), desc!("name", ValueType::String),]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("name")])
                     },
                     Plan::TableScan {
@@ -1696,7 +1607,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("name"), oby_desc!("year"), oby_asc!("score")])
                     },
                     Plan::TableScan {
@@ -1723,7 +1634,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_desc!("name"), oby_desc!("year")])
                     },
                     Plan::TableScan {
@@ -1751,7 +1662,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "status" => ("active"..="active")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND status = 'active'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("name"), oby_desc!("year")])
                     },
                     Plan::TableScan {
@@ -1780,7 +1691,7 @@ mod tests {
                         // from is excl because the inequality (age) is > 25
                         // to is incl because there is no age < ? in the predicate
                         bounds: bounds_list!(col_range!("__collection" => "album"..="album"), open_lower!("age" => 25..)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age > 25").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -1804,7 +1715,7 @@ mod tests {
                         // from is excl because the inequality (age) is > 25
                         // to is excl because the inequality (age) is < 50
                         bounds: bounds_list!(col_range!("__collection" => "album"..="album"), open_lower!("age" => 25..50)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age > 25 AND age < 50").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -1830,7 +1741,7 @@ mod tests {
                         // from is excl because the inequality (age) is > 25
                         // from is incl because there is no age < ? in the predicate
                         bounds: bounds_list!(col_range!("__collection" => "album"..="album"), open_lower!("age" => 25..)),
-                        remaining_predicate: selection!("score < 100").predicate,
+                        remaining_predicate: selection!("__collection = 'album' AND age > 25 AND score < 100").predicate,
                         order_by_spill: order_by_components!()
                     },
                     // Plan 2: Uses score index, age remains in predicate
@@ -1840,7 +1751,7 @@ mod tests {
                         // from is incl because there is no score < ? in the predicate
                         // to is excl because the inequality (score) is < 100
                         bounds: bounds!("__collection" => ("album"..="album"), "score" => (..100)),
-                        remaining_predicate: selection!("age > 25").predicate,
+                        remaining_predicate: selection!("__collection = 'album' AND age > 25 AND score < 100").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -1864,7 +1775,7 @@ mod tests {
                         scan_direction: ScanDirection::Forward,
                         // from is INCLUSIVE because the inequality is >= 25
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (25..)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age >= 25").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -1888,7 +1799,7 @@ mod tests {
                         scan_direction: ScanDirection::Forward,
                         // to is EXCLUSIVE because the inequality is < 50
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (..50)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age < 50").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -1912,7 +1823,7 @@ mod tests {
                         scan_direction: ScanDirection::Forward,
                         // to is INCLUSIVE because the inequality is <= 50
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (..=50)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age <= 50").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -1936,7 +1847,7 @@ mod tests {
                         scan_direction: ScanDirection::Forward,
                         // Both bounds inclusive
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (25..=50)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age >= 25 AND age <= 50").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -1960,7 +1871,7 @@ mod tests {
                         scan_direction: ScanDirection::Forward,
                         // from inclusive (>=), to exclusive (<)
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (25..50)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age >= 25 AND age < 50").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -1984,7 +1895,7 @@ mod tests {
                         scan_direction: ScanDirection::Forward,
                         // from exclusive (>), to inclusive (<=)
                         bounds: bounds_list!(col_range!("__collection" => "album"..="album"), open_lower!("age" => 25..=50)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age > 25 AND age <= 50").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2008,7 +1919,7 @@ mod tests {
                         scan_direction: ScanDirection::Reverse,
                         // from is INCLUSIVE because the inequality is >= 25
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (25..)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age >= 25").predicate,
                         // presort contains ORDER BY columns satisfied by index scan direction
                         order_by_spill: order_by_components!(presort: [oby_desc!("age")])
                     },
@@ -2034,7 +1945,7 @@ mod tests {
                         scan_direction: ScanDirection::Reverse,
                         // to is INCLUSIVE because the inequality is <= 50
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (..=50)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age <= 50").predicate,
                         // presort contains ORDER BY columns satisfied by index scan direction
                         order_by_spill: order_by_components!(presort: [oby_desc!("age")])
                     },
@@ -2063,7 +1974,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("name", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "name" => ("Alice"..="Alice")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND name = 'Alice'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2089,7 +2000,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "name" => ("Alice"..="Alice"), "age" => (30..=30)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND name = 'Alice' AND age = 30").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2122,7 +2033,8 @@ mod tests {
                             "year" => (1975..=1975),
                             "genre" => ("Rock"..="Rock")
                         ),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND artist = 'Queen' AND year = 1975 AND genre = 'Rock'")
+                            .predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2155,7 +2067,7 @@ mod tests {
                             "artist" => ("Queen"..="Queen"),
                             "year" => (1975..=1975)
                         ),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND artist = 'Queen' AND year = 1975").predicate,
                         // ORDER BY title is satisfied by index (title is last column after eq prefix)
                         order_by_spill: order_by_components!(presort: [oby_asc!("title")])
                     },
@@ -2189,7 +2101,8 @@ mod tests {
                             col_range!("year" => 1975..=1975),
                             open_lower!("rating" => 4..)
                         ),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND artist = 'Queen' AND year = 1975 AND rating > 4")
+                            .predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2227,7 +2140,7 @@ mod tests {
                             col_range!("name" => "Alice"..="Alice"),
                             open_lower!("age" => 25..)
                         ),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND name = 'Alice' AND age > 25").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2259,7 +2172,7 @@ mod tests {
                             col_range!("age" => 30..=30),
                             open_lower!("score" => 50..)
                         ),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND score > 50 AND age = 30").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("score")])
                     },
                     Plan::TableScan {
@@ -2273,18 +2186,21 @@ mod tests {
         }
     }
 
-    // A key range can hold one term per column. Everything else a column is
-    // compared against has to stay in the residual predicate, because the scan
-    // enforces only what the range encodes. These pin that for each shape a
+    // One column carrying several terms gives the planner more terms than a
+    // key range can hold — and index keys are stored values cast to a
+    // literal-derived type, so not even the term a bound was built from is
+    // enforced by it (see `residual_predicate`). The bounds narrow the scan;
+    // the residual re-checks every term. These pin that for each shape a
     // repeated column can take.
     mod repeated_column_tests {
         use super::*;
 
-        /// Two equalities on one column: the range holds the first, and the
-        /// second is what makes the answer empty. Dropping it hands back the
-        /// rows the first value names — which is how a policy read scope of
-        /// `owner = <caller>` composed onto a caller's `owner = <someone else>`
-        /// used to return the other principal's row.
+        /// Two equalities on one column: the bounds narrow by the first, and
+        /// the residual keeps both — the second is what makes the answer
+        /// empty. Dropping it used to hand back the rows the first value
+        /// names, which is how a policy read scope of `owner = <caller>`
+        /// composed onto a caller's `owner = <someone else>` returned the
+        /// other principal's row.
         #[test]
         fn two_equalities_on_one_column() {
             assert_eq!(
@@ -2294,7 +2210,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("owner", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "owner" => ("bob"..="bob")),
-                        remaining_predicate: selection!("owner = 'alice'").predicate,
+                        remaining_predicate: selection!("__collection = 'album' AND owner = 'bob' AND owner = 'alice'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2307,12 +2223,14 @@ mod tests {
             );
         }
 
-        /// The same term written twice constrains nothing further, so the range
-        /// really does enforce both and the residual stays empty. This is the
-        /// shape a policy scope produces when the caller already asked for its
-        /// own rows, and it must keep the cheap no-filter path.
+        /// The same term written twice: the key names the column once, the
+        /// bounds narrow by it once, and the residual re-checks the query as
+        /// written. This is the shape a policy scope produces when the caller
+        /// already asked for its own rows. (A syntactically identical repeat
+        /// could be deduplicated soundly; the planner does not simplify
+        /// predicates, it narrows and re-checks.)
         #[test]
-        fn repeated_identical_equality_needs_no_residual() {
+        fn repeated_identical_equality_keeps_one_key_position() {
             assert_eq!(
                 plan!("__collection = 'album' AND owner = 'bob' AND owner = 'bob'"),
                 vec![
@@ -2320,7 +2238,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("owner", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "owner" => ("bob"..="bob")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND owner = 'bob' AND owner = 'bob'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2333,8 +2251,8 @@ mod tests {
             );
         }
 
-        /// Three equalities on one column: the range holds the first and both
-        /// of the others survive, in the order they were written.
+        /// Three equalities on one column: the bounds narrow by the first,
+        /// and the residual keeps all three in the order they were written.
         #[test]
         fn three_equalities_on_one_column() {
             assert_eq!(
@@ -2344,7 +2262,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("owner", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("owner" => ("a"..="a")),
-                        remaining_predicate: selection!("owner = 'b' AND owner = 'c'").predicate,
+                        remaining_predicate: selection!("owner = 'a' AND owner = 'b' AND owner = 'c'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2357,10 +2275,10 @@ mod tests {
             );
         }
 
-        /// An equality and a range on one column. The range endpoint is the
-        /// point bound, so the inequality is left over — including when the two
-        /// contradict, which is the case that used to answer with the equality's
-        /// rows instead of nothing.
+        /// An equality and a range on one column. The equality becomes the
+        /// point bound — the narrower prefilter — and the residual keeps both
+        /// terms, including when they contradict, which is the case that used
+        /// to answer with the equality's rows instead of nothing.
         #[test]
         fn equality_and_range_on_one_column() {
             assert_eq!(
@@ -2370,7 +2288,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("age" => (5..=5)),
-                        remaining_predicate: selection!("age > 10").predicate,
+                        remaining_predicate: selection!("age = 5 AND age > 10").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2383,8 +2301,8 @@ mod tests {
             );
         }
 
-        /// Writing the range first does not change which term the range holds,
-        /// nor that the other one survives.
+        /// Writing the range first does not change which term the bounds
+        /// narrow by, nor what the residual keeps.
         #[test]
         fn range_and_equality_on_one_column() {
             assert_eq!(
@@ -2394,7 +2312,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("age" => (5..=5)),
-                        remaining_predicate: selection!("age > 10").predicate,
+                        remaining_predicate: selection!("age > 10 AND age = 5").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2408,9 +2326,10 @@ mod tests {
         }
 
         /// Two ranges on one column fold into that column's low and high
-        /// endpoints, so the range really does enforce both and nothing is left
-        /// over. This shape was always sound; it is here so a future change to
-        /// the folding cannot quietly stop encoding one side.
+        /// endpoints — the narrowest prefilter this shape allows — and the
+        /// residual still re-checks both, because a stored value of another
+        /// type can sit inside the cast key range while failing the
+        /// comparison.
         #[test]
         fn two_ranges_on_one_column_fold_into_the_bounds() {
             assert_eq!(
@@ -2420,7 +2339,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds_list!(KeyBoundComponent { column: "age".to_string(), low: gt(3), high: lt(10) }),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("age > 3 AND age < 10").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2435,12 +2354,11 @@ mod tests {
 
         /// Two range terms on one column whose values have no order between
         /// them (an integer and a string). The fold keeps the first as the
-        /// endpoint and cannot compare the second against it, so the endpoint
-        /// does not imply the second term and it must survive — the residual
-        /// evaluator, not the range, decides what a cross-typed comparison
-        /// admits.
+        /// endpoint — it cannot rank the second against it — and the keypart
+        /// takes the first literal's type. The residual re-checks both, and
+        /// the evaluator decides what a cross-typed comparison admits.
         #[test]
-        fn incomparably_typed_ranges_on_one_column_keep_the_unfolded_term() {
+        fn incomparably_typed_ranges_on_one_column_narrow_by_the_first() {
             assert_eq!(
                 plan!("age > 5 AND age > 'abc'"),
                 vec![
@@ -2448,7 +2366,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds_list!(open_lower!("age" => 5..)),
-                        remaining_predicate: selection!("age > 'abc'").predicate,
+                        remaining_predicate: selection!("age > 5 AND age > 'abc'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2461,9 +2379,9 @@ mod tests {
             );
         }
 
-        /// A repeated column sitting between terms on other columns: the other
-        /// columns still make it into the key, and only the term the range
-        /// could not hold is left over.
+        /// A repeated column sitting between terms on other columns: the
+        /// other columns still make it into the key, and the bounds narrow by
+        /// each column's first term.
         #[test]
         fn repeated_column_alongside_other_columns() {
             assert_eq!(
@@ -2473,7 +2391,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("owner", ValueType::String), asc!("status", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("owner" => ("bob"..="bob"), "status" => ("open"..="open")),
-                        remaining_predicate: selection!("owner = 'alice'").predicate,
+                        remaining_predicate: selection!("owner = 'bob' AND status = 'open' AND owner = 'alice'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2486,9 +2404,9 @@ mod tests {
             );
         }
 
-        /// `!=` never becomes a key-range endpoint, so it survives even on a
-        /// column the range already pins. It used to be dropped for naming a
-        /// column that some other term had been encoded for.
+        /// `!=` never becomes a key-range endpoint; like every other term it
+        /// is enforced by the residual. Pinned because it used to be dropped
+        /// for naming a column another term had bounds on.
         #[test]
         fn not_equal_on_a_pinned_column_survives() {
             assert_eq!(
@@ -2498,7 +2416,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("age", ValueType::I32)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("age" => (5..=5)),
-                        remaining_predicate: selection!("age != 5").predicate,
+                        remaining_predicate: selection!("age = 5 AND age != 5").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2511,10 +2429,10 @@ mod tests {
             );
         }
 
-        /// An ORDER BY naming a column the predicate already pins does not earn
-        /// that column a second position in the key, and the extra equality
-        /// still survives. The ORDER BY is satisfied either way, because the
-        /// column is constant across the rows the scan returns.
+        /// An ORDER BY naming a column the predicate already pins does not
+        /// earn that column a second position in the key. The ORDER BY is
+        /// satisfied either way, because the column is constant across the
+        /// rows the scan returns.
         #[test]
         fn repeated_equality_under_order_by() {
             assert_eq!(
@@ -2524,7 +2442,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("owner", ValueType::String), asc!("label", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("owner" => ("bob"..="bob")),
-                        remaining_predicate: selection!("owner = 'alice'").predicate,
+                        remaining_predicate: selection!("owner = 'bob' AND owner = 'alice'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("owner"), oby_asc!("label")])
                     },
                     Plan::TableScan {
@@ -2538,9 +2456,9 @@ mod tests {
         }
 
         /// The predicate a client composes and a server then composes onto
-        /// again: three terms on one column, two of them the same. The range
-        /// holds the first, the repeat of it is genuinely enforced by that same
-        /// bound, and the term that differs survives.
+        /// again: three terms on one column, two of them the same. The bounds
+        /// narrow by the first, and the residual carries the composition
+        /// exactly as written.
         #[test]
         fn twice_composed_repeats_on_one_column() {
             assert_eq!(
@@ -2550,7 +2468,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("owner", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("owner" => ("bob"..="bob")),
-                        remaining_predicate: selection!("owner = 'alice' AND owner = 'alice'").predicate,
+                        remaining_predicate: selection!("owner = 'bob' AND owner = 'alice' AND owner = 'alice'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2563,9 +2481,9 @@ mod tests {
             );
         }
 
-        /// A disjunction is never encoded into a key range, whatever else the
-        /// query says about the columns it names. This shape was always sound;
-        /// pinning it keeps a later change to what the range encodes from
+        /// A disjunction never becomes a key-range bound, whatever else the
+        /// query says about the columns it names. This shape was always
+        /// sound; pinning it keeps a later change to bounds-building from
         /// taking the disjunction along.
         #[test]
         fn disjunction_stays_in_the_residual() {
@@ -2576,7 +2494,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("owner", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("owner" => ("b"..="b")),
-                        remaining_predicate: selection!("owner = 'a' OR reviewer = 'a'").predicate,
+                        remaining_predicate: selection!("(owner = 'a' OR reviewer = 'a') AND owner = 'b'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2589,25 +2507,34 @@ mod tests {
             );
         }
 
-        /// Every plan the planner offers for one query has to answer the same
-        /// question, so the leftover term must appear in all of them — the
-        /// caller picks a plan without re-deriving what it enforces.
+        /// Every plan the planner offers for one query — the ORDER-FIRST and
+        /// INEQ-FIRST strategies and the TableScan fallback alike, under both
+        /// capability configs — must carry the whole predicate as its
+        /// residual. The exact comparison is the point: a regressed plan
+        /// whose residual kept only the term its bounds were built from (say
+        /// `age = 5` without `age > 10`) would still pass a mere
+        /// not-`Predicate::True` check while returning rows the query
+        /// excludes.
         #[test]
-        fn every_plan_for_a_repeated_column_keeps_the_leftover_term() {
-            for plans in [
-                plan!("owner = 'bob' AND owner = 'alice'"),
-                plan_full_support!("owner = 'bob' AND owner = 'alice'"),
-                plan!("age = 5 AND age > 10 ORDER BY label"),
-                plan_full_support!("age = 5 AND age > 10 ORDER BY label"),
-            ] {
-                for plan in &plans {
+        fn every_plan_carries_the_whole_predicate_as_residual() {
+            fn assert_plans_carry(plans: &[Plan], expected: &Predicate) {
+                assert!(plans.len() >= 2, "expected at least one index strategy plus the fallback: {plans:?}");
+                for plan in plans {
                     let residual = match plan {
                         Plan::Index { remaining_predicate, .. } | Plan::TableScan { remaining_predicate, .. } => remaining_predicate,
-                        Plan::EmptyScan => continue,
+                        Plan::EmptyScan => panic!("no shape here is provably empty: {plan:?}"),
                     };
-                    assert_ne!(*residual, Predicate::True, "a plan enforcing nothing beyond its key range: {plan:?}");
+                    assert_eq!(residual, expected, "every plan re-checks the whole predicate: {plan:?}");
                 }
             }
+
+            let two_equalities = selection!("owner = 'bob' AND owner = 'alice'").predicate;
+            assert_plans_carry(&plan!("owner = 'bob' AND owner = 'alice'"), &two_equalities);
+            assert_plans_carry(&plan_full_support!("owner = 'bob' AND owner = 'alice'"), &two_equalities);
+
+            let equality_and_range = selection!("age = 5 AND age > 10").predicate;
+            assert_plans_carry(&plan!("age = 5 AND age > 10 ORDER BY label"), &equality_and_range);
+            assert_plans_carry(&plan_full_support!("age = 5 AND age > 10 ORDER BY label"), &equality_and_range);
         }
     }
 
@@ -2625,7 +2552,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album'").predicate,
                         order_by_spill: order_by_components!(),
                     },
                     Plan::TableScan {
@@ -2648,7 +2575,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: selection!("name != 'Alice'").predicate,
+                        remaining_predicate: selection!("__collection = 'album' AND name != 'Alice'").predicate,
                         order_by_spill: order_by_components!(),
                     },
                     Plan::TableScan {
@@ -2670,7 +2597,7 @@ mod tests {
                         // from is excl because the inequality (age) is > 25
                         // to is incl and the final component is omitted because there is no age < ? in the predicate
                         bounds: bounds_list!(col_range!("__collection" => "album"..="album"), open_lower!("age" => 25..)),
-                        remaining_predicate: selection!("name != 'Alice'").predicate,
+                        remaining_predicate: selection!("__collection = 'album' AND age > 25 AND name != 'Alice'").predicate,
                         order_by_spill: order_by_components!(),
                     },
                     Plan::TableScan {
@@ -2701,7 +2628,7 @@ mod tests {
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
                         // the OR-containing parenthetical is a disjunction, so it must remain in the predicate
-                        remaining_predicate: selection!("age > 25 OR name = 'Alice'").predicate,
+                        remaining_predicate: selection!("__collection = 'album' AND (age > 25 OR name = 'Alice')").predicate,
                         order_by_spill: order_by_components!(),
                     },
                     Plan::TableScan {
@@ -2725,7 +2652,8 @@ mod tests {
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "score" => (100..=100)),
                         // the OR-containing parenthetical is a disjunction, so it must remain in the predicate
-                        remaining_predicate: selection!("age > 25 OR name = 'Alice'").predicate,
+                        remaining_predicate: selection!("__collection = 'album' AND score = 100 AND (age > 25 OR name = 'Alice')")
+                            .predicate,
                         order_by_spill: order_by_components!(),
                     },
                     Plan::TableScan {
@@ -2755,7 +2683,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (30..=30)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age = 30").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("name"), oby_asc!("score")]),
                     },
                     Plan::TableScan {
@@ -2786,11 +2714,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("name", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album")),
-                        remaining_predicate: Predicate::Comparison {
-                            left: Box::new(Expr::Path(ankql::ast::PathExpr::simple("year"))),
-                            operator: ComparisonOperator::GreaterThanOrEqual,
-                            right: Box::new(Expr::Literal(ankql::ast::Literal::String("2001".to_string()))),
-                        },
+                        remaining_predicate: selection!("__collection = 'album' AND year >= '2001'").predicate,
                         order_by_spill: order_by_components!(presort: [oby_asc!("name")]),
                     },
                     // Strategy 2: Scan by year, sort by name (global sort needed since 'year' not in ORDER BY)
@@ -2798,7 +2722,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("year", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "year" => ("2001"..)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND year >= '2001'").predicate,
                         order_by_spill: order_by_components!(spill: [oby_asc!("name")]),
                     },
                     Plan::TableScan {
@@ -2825,7 +2749,7 @@ mod tests {
                         // from: is incl because the most restrictive lower bound inequality (age) is >= 25
                         // to: is incl because the upper bound inequality (age) is <= 50
                         bounds: bounds!("__collection" => ("album"..="album"), "age" => (25..=50)),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND age >= 25 AND age <= 50 AND age > 20").predicate,
                         order_by_spill: order_by_components!(),
                     },
                     Plan::TableScan {
@@ -2854,7 +2778,7 @@ mod tests {
                             col_range!("__collection" => "album"..="album"),
                             open_lower!("timestamp" => 9223372036854775807i64..)
                         ),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND timestamp > 9223372036854775807").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2877,7 +2801,7 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("name", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "name" => (""..="")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND name = ''").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -2904,7 +2828,7 @@ mod tests {
                         ]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "name" => (""..=""), "year" => ("2000"..="2000")),
-                        remaining_predicate: Predicate::True,
+                        remaining_predicate: selection!("__collection = 'album' AND name = '' AND year = '2000'").predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -3032,7 +2956,10 @@ mod tests {
                         index_spec: KeySpec::new(vec![asc!("__collection", ValueType::String), asc!("name", ValueType::String)]),
                         scan_direction: ScanDirection::Forward,
                         bounds: bounds!("__collection" => ("album"..="album"), "name" => ("Alice"..="Alice")),
-                        remaining_predicate: selection!("id > '12345678-1234-1234-1234-123456789abc'").predicate,
+                        remaining_predicate: selection!(
+                            "__collection = 'album' AND id > '12345678-1234-1234-1234-123456789abc' AND name = 'Alice'"
+                        )
+                        .predicate,
                         order_by_spill: order_by_components!()
                     },
                     Plan::TableScan {
@@ -3119,9 +3046,11 @@ mod tests {
             }
         }
 
-        /// Test that JSON path equality has no remaining predicate (fully pushed down)
+        /// A JSON path equality becomes the index bounds, and the residual
+        /// still re-checks it: bounds narrow the scan, they never stand in
+        /// for the term.
         #[test]
-        fn test_json_path_full_pushdown() {
+        fn test_json_path_equality_residual_retained() {
             let planner = Planner::new(PlannerConfig::full_support());
             let selection = selection!("context.session_id = 'sess123'");
             let plans = planner.plan(&selection, "id");
@@ -3129,14 +3058,14 @@ mod tests {
             let index_plan = plans.iter().find(|p| matches!(p, Plan::Index { .. })).expect("Should generate index plan");
 
             if let Plan::Index { remaining_predicate, .. } = index_plan {
-                // Full pushdown: remaining_predicate should be True
-                assert_eq!(*remaining_predicate, Predicate::True, "JSON path equality should be fully pushed down");
+                assert_eq!(*remaining_predicate, selection.predicate, "the residual re-checks the term the bounds narrowed by");
             } else {
                 panic!("Expected Index plan");
             }
         }
 
-        /// Test JSON path with inequality (partial pushdown for range)
+        /// Test JSON path with inequality: the range becomes the bounds, and
+        /// the residual still re-checks it.
         #[test]
         fn test_json_path_inequality() {
             let planner = Planner::new(PlannerConfig::full_support());
@@ -3151,8 +3080,7 @@ mod tests {
                 assert_eq!(keypart.column, "context");
                 assert_eq!(keypart.sub_path, Some(vec!["count".to_string()]));
 
-                // Inequality should be fully pushed to bounds, remaining_predicate is True
-                assert_eq!(*remaining_predicate, Predicate::True, "JSON path inequality should be fully pushed down");
+                assert_eq!(*remaining_predicate, selection.predicate, "the residual re-checks the term the bounds narrowed by");
             }
         }
 
@@ -3178,8 +3106,7 @@ mod tests {
                 assert_eq!(json_kp.column, "context");
                 assert_eq!(json_kp.sub_path, Some(vec!["user_id".to_string()]));
 
-                // Both should be fully pushed, remaining is True
-                assert_eq!(*remaining_predicate, Predicate::True, "Both predicates should be pushed down");
+                assert_eq!(*remaining_predicate, selection.predicate, "the residual re-checks both terms the bounds narrowed by");
             }
         }
     }

--- a/tests/tests/sled/collection_boundary.rs
+++ b/tests/tests/sled/collection_boundary.rs
@@ -42,15 +42,20 @@ async fn test_prefix_guard_toggle_effect() -> Result<(), anyhow::Error> {
     .await?;
     create_books(&ctx, vec![("Book1", "2001"), ("Book2", "2002")]).await?;
 
-    // 1) Guard enabled (default): equality prefix should constrain results to year=1969 only
+    // 1) Guard enabled (default): equality prefix constrains the scan to year=1969
     assert_eq!(names(&fetch(&ctx, "year = '1969' ORDER BY name LIMIT 100").await?), vec!["Album5"]);
 
-    // 2) Disable guard: expect overshoot beyond equality prefix (includes following names)
+    // 2) Disable guard: the index scan overshoots the equality prefix, but the
+    //    residual predicate re-checks every row, so the answer does not change.
+    //    (This used to pin the overshoot showing up in the results — that was
+    //    only observable while the planner dropped the equality term from the
+    //    residual. The guard remains a scan-narrowing optimization; the
+    //    residual is what keeps the answer right without it.)
     #[cfg(debug_assertions)]
     engine.set_prefix_guard_disabled(true);
-    assert_eq!(names(&fetch(&ctx, "year = '1969' ORDER BY name LIMIT 100").await?), vec!["Album5", "Album6"]);
+    assert_eq!(names(&fetch(&ctx, "year = '1969' ORDER BY name LIMIT 100").await?), vec!["Album5"]);
 
-    // 3) Re-enable guard: back to constrained results
+    // 3) Re-enable guard: same answer, narrower scan.
     #[cfg(debug_assertions)]
     engine.set_prefix_guard_disabled(false);
     assert_eq!(names(&fetch(&ctx, "year = '1969' ORDER BY name LIMIT 100").await?), vec!["Album5"]);

--- a/tests/tests/sled/json_property.rs
+++ b/tests/tests/sled/json_property.rs
@@ -203,11 +203,8 @@ fn test_json_path_planner_generates_sub_path() {
         assert_eq!(keypart.sub_path, Some(vec!["territory".to_string()]), "sub_path should be ['territory']");
         assert_eq!(keypart.full_path(), "licensing.territory", "full_path should be 'licensing.territory'");
 
-        // Verify full pushdown (remaining predicate should be True)
-        assert!(
-            matches!(remaining_predicate, ankql::ast::Predicate::True),
-            "JSON path equality should be fully pushed down, got: {:?}",
-            remaining_predicate
-        );
+        // The bounds narrow by the term; the residual still re-checks it
+        // (bounds are a prefilter over cast-typed keys, never an enforcement).
+        assert_eq!(*remaining_predicate, selection.predicate, "the residual re-checks the term the bounds narrowed by");
     }
 }

--- a/tests/tests/sled/main.rs
+++ b/tests/tests/sled/main.rs
@@ -9,3 +9,4 @@ mod multi_column_order_by;
 mod normalization_tests;
 mod pagination;
 mod ref_traversal;
+mod repeated_column;

--- a/tests/tests/sled/repeated_column.rs
+++ b/tests/tests/sled/repeated_column.rs
@@ -1,0 +1,224 @@
+//! What a query gets back when one column carries more than one term.
+//!
+//! An index key holds one position per column, so a query naming the same
+//! column twice gives the planner more terms than the key range can carry.
+//! Choosing an index is an optimization; the answer is only correct if every
+//! term the range does not encode is re-checked against the rows the scan
+//! returns. These run that over a real sled node, where a term the planner
+//! forgot shows up as a row the query excluded.
+//!
+//! The planner-level counterpart lives in `storage/common/src/planner.rs`
+//! (`repeated_column_tests`), which pins the plan; these pin the rows.
+
+use ankurah::property::Ref;
+use ankurah::{policy::DEFAULT_CONTEXT, Model, Node, PermissiveAgent};
+use ankurah_storage_sled::SledStorageEngine;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+// Unique names to avoid collision with the other models in this test binary.
+#[derive(Model, Debug, Serialize, Deserialize, Clone)]
+pub struct DupUser {
+    pub name: String,
+}
+
+#[derive(Model, Debug, Serialize, Deserialize, Clone)]
+pub struct DupNote {
+    #[active_type(LWW)]
+    pub title: String,
+    pub rank: i32,
+    pub owner: Ref<DupUser>,
+    pub reviewer: Ref<DupUser>,
+}
+
+async fn setup_context() -> Result<ankurah::Context> {
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), PermissiveAgent::new());
+    node.system.create().await?;
+    Ok(node.context_async(DEFAULT_CONTEXT).await)
+}
+
+fn titles(notes: &[DupNoteView]) -> Vec<String> {
+    let mut titles: Vec<String> = notes.iter().map(|n| n.title().unwrap()).collect();
+    titles.sort();
+    titles
+}
+
+/// Two owners, and one note apiece, so that a term the scan drops is visible as
+/// the other owner's note coming back.
+async fn two_owners_two_notes(ctx: &ankurah::Context) -> Result<(ankurah::EntityId, ankurah::EntityId)> {
+    let (alice, bob) = {
+        let trx = ctx.begin();
+        let alice = trx.create(&DupUser { name: "Alice".into() }).await?;
+        let bob = trx.create(&DupUser { name: "Bob".into() }).await?;
+        let ids = (alice.id(), bob.id());
+        trx.commit().await?;
+        ids
+    };
+    {
+        let trx = ctx.begin();
+        trx.create(&DupNote { title: "alice note".into(), rank: 1, owner: Ref::new(alice), reviewer: Ref::new(bob) }).await?;
+        trx.create(&DupNote { title: "bob note".into(), rank: 2, owner: Ref::new(bob), reviewer: Ref::new(alice) }).await?;
+        trx.commit().await?;
+    }
+    Ok((alice, bob))
+}
+
+/// Two equalities on one String column contradict, so the query names no row.
+#[tokio::test]
+async fn two_equalities_on_one_string_column_match_nothing() -> Result<()> {
+    let ctx = setup_context().await?;
+    two_owners_two_notes(&ctx).await?;
+
+    let rows = ctx.fetch::<DupNoteView>("title = 'alice note' AND title = 'bob note'").await?;
+    assert_eq!(titles(&rows), Vec::<String>::new(), "no note carries both titles");
+
+    // The control: one of those terms on its own does name a row, so the empty
+    // answer above is the second term doing its job rather than a broken query.
+    let rows = ctx.fetch::<DupNoteView>("title = 'alice note'").await?;
+    assert_eq!(titles(&rows), vec!["alice note"]);
+
+    Ok(())
+}
+
+/// The same term written twice still names its row. The planner is free to
+/// notice that the repeat constrains nothing further, but it must not turn the
+/// query into one that matches less.
+#[tokio::test]
+async fn repeated_identical_equality_still_matches() -> Result<()> {
+    let ctx = setup_context().await?;
+    two_owners_two_notes(&ctx).await?;
+
+    let rows = ctx.fetch::<DupNoteView>("title = 'alice note' AND title = 'alice note'").await?;
+    assert_eq!(titles(&rows), vec!["alice note"]);
+
+    Ok(())
+}
+
+/// An equality and a range on one column, contradicting: the range endpoint is
+/// the equality's point bound, so the inequality is the term that has to be
+/// re-checked.
+#[tokio::test]
+async fn equality_and_range_on_one_column_match_nothing() -> Result<()> {
+    let ctx = setup_context().await?;
+    two_owners_two_notes(&ctx).await?;
+
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank = 1 AND rank > 5").await?), Vec::<String>::new());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank > 5 AND rank = 1").await?), Vec::<String>::new());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank = 1 AND rank < 0").await?), Vec::<String>::new());
+
+    // Consistent versions of the same shape keep their row.
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank = 1 AND rank > 0").await?), vec!["alice note"]);
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank = 2 AND rank <= 2").await?), vec!["bob note"]);
+
+    Ok(())
+}
+
+/// Two ranges on one column fold into that column's low and high endpoints.
+/// This shape was already sound; it is here so that folding cannot quietly stop
+/// encoding one side without a test noticing.
+#[tokio::test]
+async fn two_ranges_on_one_column_bracket_correctly() -> Result<()> {
+    let ctx = setup_context().await?;
+    two_owners_two_notes(&ctx).await?;
+
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank > 0 AND rank < 2").await?), vec!["alice note"]);
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank >= 1 AND rank <= 2").await?), vec!["alice note", "bob note"]);
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank > 5 AND rank < 1").await?), Vec::<String>::new());
+
+    Ok(())
+}
+
+/// The repeated column sits between terms on other columns, so the key still
+/// has room for it — the leftover term is not at the end of the key and cannot
+/// be dropped by truncating it.
+#[tokio::test]
+async fn repeated_column_alongside_other_columns() -> Result<()> {
+    let ctx = setup_context().await?;
+    let (alice, bob) = two_owners_two_notes(&ctx).await?;
+
+    let query = format!("owner = '{}' AND rank = 1 AND owner = '{}'", alice.to_base64(), bob.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), Vec::<String>::new(), "no note has two owners");
+
+    let query = format!("owner = '{}' AND rank = 1 AND owner = '{}'", alice.to_base64(), alice.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), vec!["alice note"]);
+
+    Ok(())
+}
+
+/// The same shape over `Ref` columns, which collate as raw EntityId bytes
+/// rather than text. This is the column type a row-local read scope names when
+/// the scoped field is a `Ref<User>`.
+#[tokio::test]
+async fn two_equalities_on_one_ref_column_match_nothing() -> Result<()> {
+    let ctx = setup_context().await?;
+    let (alice, bob) = two_owners_two_notes(&ctx).await?;
+
+    let query = format!("owner = '{}' AND owner = '{}'", bob.to_base64(), alice.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), Vec::<String>::new(), "no note is owned by two users");
+
+    // Each half on its own names exactly one note, in both orders, so neither
+    // id is simply unmatchable.
+    let query = format!("owner = '{}'", bob.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), vec!["bob note"]);
+    let query = format!("owner = '{}'", alice.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), vec!["alice note"]);
+
+    Ok(())
+}
+
+/// A disjunction over two columns, ANDed with a term on one of them — the shape
+/// a two-armed read scope (`owner = me OR reviewer = me`) takes once a caller's
+/// own filter on `owner` is composed onto it. A disjunction is never encoded
+/// into a key range, so both halves have to be re-checked, and the answer is the
+/// rows that satisfy both.
+#[tokio::test]
+async fn or_over_two_columns_and_a_repeated_column() -> Result<()> {
+    let ctx = setup_context().await?;
+    let (alice, bob) = two_owners_two_notes(&ctx).await?;
+
+    // A third note Alice has nothing to do with, so that the disjunction has a
+    // row to exclude on its own.
+    {
+        let trx = ctx.begin();
+        trx.create(&DupNote { title: "bob solo".into(), rank: 3, owner: Ref::new(bob), reviewer: Ref::new(bob) }).await?;
+        trx.commit().await?;
+    }
+
+    let alice_touches = format!("(owner = '{}' OR reviewer = '{}')", alice.to_base64(), alice.to_base64());
+
+    // Alice reviews bob's note, so the disjunction admits it and the term on
+    // `owner` keeps it; "bob solo" fails the disjunction and "alice note"
+    // fails the term on `owner`.
+    let query = format!("{alice_touches} AND owner = '{}'", bob.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), vec!["bob note"]);
+
+    // The same disjunction with the other principal on `owner` keeps only the
+    // note Alice owns.
+    let query = format!("{alice_touches} AND owner = '{}'", alice.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), vec!["alice note"]);
+
+    // And the term on `owner` repeated with two different principals leaves
+    // nothing, disjunction or no disjunction.
+    let query = format!("{alice_touches} AND owner = '{}' AND owner = '{}'", alice.to_base64(), bob.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), Vec::<String>::new(), "no note has two owners");
+
+    Ok(())
+}
+
+/// ORDER BY naming a column the predicate already pins. The sort column and the
+/// repeated term compete for the same key position, and the answer must still
+/// be the rows both terms admit.
+#[tokio::test]
+async fn repeated_column_under_order_by() -> Result<()> {
+    let ctx = setup_context().await?;
+    let (alice, bob) = two_owners_two_notes(&ctx).await?;
+
+    let query = format!("owner = '{}' AND owner = '{}' ORDER BY owner, rank", alice.to_base64(), bob.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), Vec::<String>::new());
+
+    let query = format!("owner = '{}' AND owner = '{}' ORDER BY owner, rank", alice.to_base64(), alice.to_base64());
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>(query.as_str()).await?), vec!["alice note"]);
+
+    Ok(())
+}

--- a/tests/tests/sled/repeated_column.rs
+++ b/tests/tests/sled/repeated_column.rs
@@ -2,10 +2,11 @@
 //!
 //! An index key holds one position per column, so a query naming the same
 //! column twice gives the planner more terms than the key range can carry.
-//! Choosing an index is an optimization; the answer is only correct if every
-//! term the range does not encode is re-checked against the rows the scan
-//! returns. These run that over a real sled node, where a term the planner
-//! forgot shows up as a row the query excluded.
+//! Choosing an index is an optimization; the answer is only correct because
+//! every term is re-checked against the rows the scan returns — index bounds
+//! are a prefilter over keys built by casting stored values to literal-derived
+//! types, not an enforcement of any term. These run that over a real sled
+//! node, where a term the planner forgot shows up as a row the query excluded.
 //!
 //! The planner-level counterpart lives in `storage/common/src/planner.rs`
 //! (`repeated_column_tests`), which pins the plan; these pin the rows.
@@ -28,6 +29,7 @@ pub struct DupNote {
     #[active_type(LWW)]
     pub title: String,
     pub rank: i32,
+    pub score: f64,
     pub owner: Ref<DupUser>,
     pub reviewer: Ref<DupUser>,
 }
@@ -57,11 +59,44 @@ async fn two_owners_two_notes(ctx: &ankurah::Context) -> Result<(ankurah::Entity
     };
     {
         let trx = ctx.begin();
-        trx.create(&DupNote { title: "alice note".into(), rank: 1, owner: Ref::new(alice), reviewer: Ref::new(bob) }).await?;
-        trx.create(&DupNote { title: "bob note".into(), rank: 2, owner: Ref::new(bob), reviewer: Ref::new(alice) }).await?;
+        trx.create(&DupNote { title: "alice note".into(), rank: 1, score: 5.9, owner: Ref::new(alice), reviewer: Ref::new(bob) }).await?;
+        trx.create(&DupNote { title: "bob note".into(), rank: 2, score: 2.0, owner: Ref::new(bob), reviewer: Ref::new(alice) }).await?;
         trx.commit().await?;
     }
     Ok((alice, bob))
+}
+
+/// An integer literal against an f64 column. The planner types the index
+/// keypart from the literal (there is no schema to consult), the key encoding
+/// casts each stored value to that type, and F64 -> I32 truncates — so 5.9
+/// keys as 5 and sits inside the point range for `= 5`. The range therefore
+/// enforces "truncates to 5", not "= 5", and only the retained residual term,
+/// evaluated against the stored f64, keeps the row out. Repeating the term
+/// must not change that: an identical duplicate is exactly the shape a policy
+/// scope composes when the caller already asked for its own rows.
+#[tokio::test]
+async fn f64_column_with_integer_literal_matches_exactly() -> Result<()> {
+    let ctx = setup_context().await?;
+    two_owners_two_notes(&ctx).await?;
+
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("score = 5").await?), Vec::<String>::new(), "5.9 is not 5, whatever its index key says");
+    assert_eq!(
+        titles(&ctx.fetch::<DupNoteView>("score = 5 AND score = 5").await?),
+        Vec::<String>::new(),
+        "repeating the term must not widen it"
+    );
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("score = 5 AND score = 6").await?), Vec::<String>::new());
+
+    // Controls: an integer literal that genuinely equals a stored float
+    // (2 vs 2.0) keeps its row, as does a same-typed duplicate on the i32
+    // column — the residual re-check filters truncation artifacts without
+    // over-filtering honest matches. (An exact f64 literal is not a control
+    // available here: the query grammar has no decimal literals.)
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("score = 2").await?), vec!["bob note"]);
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("score = 2 AND score = 2").await?), vec!["bob note"]);
+    assert_eq!(titles(&ctx.fetch::<DupNoteView>("rank = 1 AND rank = 1").await?), vec!["alice note"]);
+
+    Ok(())
 }
 
 /// Two equalities on one String column contradict, so the query names no row.
@@ -181,7 +216,7 @@ async fn or_over_two_columns_and_a_repeated_column() -> Result<()> {
     // row to exclude on its own.
     {
         let trx = ctx.begin();
-        trx.create(&DupNote { title: "bob solo".into(), rank: 3, owner: Ref::new(bob), reviewer: Ref::new(bob) }).await?;
+        trx.create(&DupNote { title: "bob solo".into(), rank: 3, score: 1.0, owner: Ref::new(bob), reviewer: Ref::new(bob) }).await?;
         trx.commit().await?;
     }
 


### PR DESCRIPTION
## The defect

For a conjunction with two terms on one column — `owner = 'bob' AND owner = 'alice'` — the planner built an index key of `[owner, owner]`, bound **both** positions to the first term's value (`['bob','bob']`), and dropped **both** conjuncts from the residual predicate, because `calculate_remaining_predicate` consumed conjuncts by column name alone. The second term was neither encoded into the range nor left to re-check, so the scan answered with the first term's rows: a query whose correct answer is empty returned rows it excluded. The same by-column-name consumption lost a caller's range term when an equality on the same column took the key position (`owner >= 'bob' AND owner = 'alice'` scanned `alice..alice` and forgot the range).

## Why "the bounds enforce that term" is not a thing the planner can claim

The first commit on this branch fixed the shape above with a receipt: bounds returned the exact `(column, operator, value)` comparisons they encode, and only receipted conjuncts were elided. Review found the receipt still dishonest, one layer down, and the second commit follows that finding to its end.

The planner types each index keypart **from the query literal** — `TypeResolver::resolve_path` has no schema to consult for a simple path — and the key encoding (`encode_component_typed`) casts every **stored value** to that type when building index keys. A cast can coalesce values the predicate distinguishes: integer literals parse as `I32`, `F64 → I32` truncates, so a stored `score` of `5.9` keys as `5` and sits **inside** the point range for `score = 5`, while the predicate evaluator — which casts the literal toward the stored value's type instead — rejects it. The bounds enforce "encodes like the literal"; the predicate means "compares equal to the literal". Those differ whenever the stored type differs from the literal's, which is an everyday event (`score = 5` against an f64 column), and the planner cannot see stored types from where it sits. `score = 5 AND score = 5` returned the 5.9 row with nothing left to stop it — and so did `score = 5` alone.

## The contract now

**Bounds are a prefilter; the residual is the truth.** Every index plan carries the whole predicate as its residual — exactly what the TableScan fallback always did — and both engines already re-check it per row (sled `exec_index_scan_plan`, indexeddb `execute_plan_query`). Bounds still narrow the scan: point ranges from the first equality per column, folded low/high endpoints for ranges, `push_keypart_once` keeping a column to one key position. No conjunct is ever elided. When schema-derived keypart typing exists, elision can return with a proof; today no such proof is available to the planner, so it does not claim one.

## Shapes covered

| shape | outcome |
|---|---|
| two equalities, one column (`owner='bob' AND owner='alice'`) | fixed — bounds `bob..bob`, residual carries both terms, answer empty |
| identical duplicate (`owner='bob' AND owner='bob'`) | correct rows, one key position; residual retained (see cost note) |
| equality + range, one column (`age=5 AND age>10`, both orders) | fixed — point bound, residual carries both, answer empty |
| two ranges, one column (`age>3 AND age<10`) | bounds fold both endpoints; residual still re-checks |
| cross-typed ranges (`age>5 AND age>'abc'`) | bounds narrow by the first comparable term; residual carries both |
| integer literal vs f64 column (`score=5` and `score=5 AND score=5`, stored `5.9`) | fixed — key range admits the truncated key, residual rejects the row |
| `!=`, `IN`, `BETWEEN`, disjunctions | never bounds material; enforced by the residual as before |
| `Ref`-typed and `String`-typed columns | both covered at sled and jwt-auth layers |

## Consequence worth naming

jwt-auth composes a policy read scope onto the caller's predicate as another conjunct, so a scope of `owner = $jwt.sub` with a caller filtering `owner = <someone else>` is exactly the two-equalities shape — the scope's term was the dropped one, and a fetch returned rows outside the caller's read scope. `extensions/jwt-auth/tests/scope_column_overlap_tests.rs` pins that composition end to end (fetch and LiveQuery, `Ref` and `String` scoped columns, disjunctive two-arm scopes).

## Pins updated deliberately (they pinned the elision)

- `tests/tests/sled/collection_boundary.rs::test_prefix_guard_toggle_effect` pinned the scan **overshoot appearing in results** when the debug prefix guard is off — observable only while the planner dropped the equality residual. It now pins the answer staying right with the guard off; the guard remains a scan-narrowing optimization.
- The json-path "full pushdown" assertions (`storage/common/src/planner.rs`, `tests/tests/sled/json_property.rs`) pinned `remaining_predicate == True`; they now pin the residual re-checking the term.
- `every_plan_carries_the_whole_predicate_as_residual` asserts the **exact** residual for every plan under both configs; its predecessor accepted any non-`True` residual, which a regressed plan dropping the decisive term (residual `age = 5` without `age > 10`) would still have satisfied.

## Cost accepted

The `remaining_predicate == True` no-filter path in sled now fires only for queries with no comparison terms (e.g. unfiltered ORDER BY scans). Every indexed fetch pays a per-row materialized-values lookup plus one predicate walk over the rows the bounds admit — the work the TableScan path always did, on a bounds-narrowed row set. That is the price of answers that do not depend on the literal's type happening to match the stored value's type.

## Not addressed here (pre-existing, adjacent)

- A scan can still **miss** rows whose stored type differs from the keypart type (`F64(5.9)` under an `I32` keypart keys as `5`, so `score > 5` skips it; a `String` row under a numeric keypart fails the cast and is absent from the index). False negatives cannot be repaired by a residual; they need schema-typed or type-tagged index keys.
- `EmptyScan` still trusts a decisively contradictory same-typed fold (`x > 10 AND x < 5`), which a cross-typed stored value could satisfy under the evaluator's casts (`String("3")` compares `> "10"` and `< "5"` lexicographically).

Both predate this branch and are the remaining cast-related gaps once no term can be silently dropped.

## Evidence

- `tests/tests/sled/repeated_column.rs::f64_column_with_integer_literal_matches_exactly` fails on the first commit and on `main` (`score = 5` returns `["alice note"]`, the stored 5.9 row) and passes here; its controls pin that `score = 2` still matches a stored `2.0` (no over-filtering).
- `every_plan_carries_the_whole_predicate_as_residual` fails against the first commit's planner (partial residual `owner = 'alice'` where the whole predicate is demanded) and against `main` (residual `True`).
- The original defect-shape tests (planner unit, sled rows, jwt-auth composition) all fail on `main` as before: e.g. `two_equalities_on_one_column` observes keyparts `[__collection, owner, owner]`, both bounds `bob..bob`, `remaining_predicate: True`; sled `two_equalities_on_one_ref_column_match_nothing` gets `["bob note"]` where `[]` is demanded; `caller_equality_on_the_scoped_column_does_not_replace_the_scope` returns the other member's row.

Gates, all green: `cargo fmt --all -- --check`; `cargo test -p ankurah-core -p ankurah-jwt-auth` (the pins from #456 hold — their evaluator-semantics pins are what make the residual well-defined for cross-typed comparisons); `cargo test -p ankurah-storage-common -p ankurah-storage-sled -p ankurah-tests` (60/60 suites); `cargo check --tests`.

## Engines

The change is in the shared planner used by sled (`PlannerConfig::full_support`) and indexeddb (`PlannerConfig::indexeddb`); both engines already apply `remaining_predicate` per row. Postgres and sqlite never call this planner — they split predicates into SQL plus a residual — and are untouched.
