### PR TITLE
jwt-auth, core: a read names its kind, and `get` admits by-id reads alone

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -6,7 +6,7 @@ use crate::{
     livequery::{EntityLiveQuery, LiveQuery},
     model::View,
     node::{MatchArgs, Node},
-    policy::{AccessDenied, PolicyAgent},
+    policy::{AccessDenied, PolicyAgent, ReadKind},
     storage::{StorageCollectionWrapper, StorageEngine},
     transaction::Transaction,
 };
@@ -380,7 +380,7 @@ where
             debug!("Node({}).get_entity found local entity - returning", self.node.id);
             let state = local.to_state()?;
             let entity_id = local.id();
-            self.node.policy_agent.check_read(&cdata, &entity_id, collection_id, &state)?;
+            self.node.policy_agent.check_read(&cdata, &entity_id, collection_id, &state, ReadKind::Get)?;
             return Ok(local);
         }
         debug!("{}.get_entity fetching from storage", self.node);
@@ -388,7 +388,13 @@ where
         let collection = self.node.collections.get(collection_id).await?;
         match collection.get_state(id).await {
             Ok(entity_state) => {
-                self.node.policy_agent.check_read(&cdata, &entity_state.payload.entity_id, collection_id, &entity_state.payload.state)?;
+                self.node.policy_agent.check_read(
+                    &cdata,
+                    &entity_state.payload.entity_id,
+                    collection_id,
+                    &entity_state.payload.state,
+                    ReadKind::Get,
+                )?;
                 let state_getter = crate::retrieval::LocalStateGetter::new(collection.clone());
                 let event_getter = CachedEventGetter::new(collection_id.clone(), collection, &self.node, &cdata);
                 let (_changed, entity) = self
@@ -408,7 +414,7 @@ where
         // one policy world, or a mid-operation refresh yields a
         // composite no single credential authorized.
         let cdata = self.sessions.current();
-        self.node.policy_agent.can_access_collection(&cdata, collection_id)?;
+        self.node.policy_agent.can_access_collection(&cdata, collection_id, ReadKind::Scan)?;
         // Fetch raw states from storage
 
         args.selection.predicate = self.node.policy_agent.filter_predicate(&cdata, collection_id, args.selection.predicate)?;

--- a/core/src/livequery.rs
+++ b/core/src/livequery.rs
@@ -19,7 +19,7 @@ use crate::{
     error::RetrievalError,
     model::View,
     node::{MatchArgs, NodeInner, TNodeErased},
-    policy::PolicyAgent,
+    policy::{PolicyAgent, ReadKind},
     reactor::{
         fetch_gap::{GapFetcher, QueryGapFetcher},
         ReactorSubscription, ReactorUpdate,
@@ -214,7 +214,7 @@ where
     // One credential snapshot for the whole derivation; re-derivation
     // on change arrives with https://github.com/ankurah/ankurah/pull/426.
     let cdata = sessions.current();
-    node.policy_agent.can_access_collection(&cdata, &collection_id)?;
+    node.policy_agent.can_access_collection(&cdata, &collection_id, ReadKind::Scan)?;
     args.selection.predicate = node.policy_agent.filter_predicate(&cdata, &collection_id, args.selection.predicate)?;
 
     // Resolve types in the AST (converts literals for JSON path comparisons)

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -22,7 +22,7 @@ use crate::{
     error::{MutationError, RequestError, RetrievalError},
     notice_info,
     peer_subscription::{SubscriptionHandler, SubscriptionRelay},
-    policy::{AccessDenied, PolicyAgent},
+    policy::{AccessDenied, PolicyAgent, ReadKind},
     reactor::{AbstractEntity, Reactor},
     retrieval::{LocalEventGetter, LocalStateGetter, SuspenseEvents},
     storage::StorageEngine,
@@ -472,7 +472,7 @@ where
                 }
             }
             proto::NodeRequestBody::Fetch { collection, mut selection, known_matches } => {
-                self.policy_agent.can_access_collection(cdata, &collection)?;
+                self.policy_agent.can_access_collection(cdata, &collection, ReadKind::Scan)?;
                 let storage_collection = self.collections.get(&collection).await?;
                 selection.predicate = self.policy_agent.filter_predicate(cdata, &collection, selection.predicate)?;
 
@@ -488,7 +488,11 @@ where
 
                 let mut deltas = Vec::new();
                 for state in expanded_states {
-                    if self.policy_agent.check_read(cdata, &state.payload.entity_id, &collection, &state.payload.state).is_err() {
+                    if self
+                        .policy_agent
+                        .check_read(cdata, &state.payload.entity_id, &collection, &state.payload.state, ReadKind::Scan)
+                        .is_err()
+                    {
                         continue;
                     }
 
@@ -501,13 +505,13 @@ where
                 Ok(proto::NodeResponseBody::Fetch(deltas))
             }
             proto::NodeRequestBody::Get { collection, ids } => {
-                self.policy_agent.can_access_collection(cdata, &collection)?;
+                self.policy_agent.can_access_collection(cdata, &collection, ReadKind::Get)?;
                 let storage_collection = self.collections.get(&collection).await?;
 
                 // filter out any that the policy agent says we don't have access to
                 let mut states = Vec::new();
                 for state in storage_collection.get_states(ids).await? {
-                    match self.policy_agent.check_read(cdata, &state.payload.entity_id, &collection, &state.payload.state) {
+                    match self.policy_agent.check_read(cdata, &state.payload.entity_id, &collection, &state.payload.state, ReadKind::Get) {
                         Ok(_) => states.push(state),
                         Err(AccessDenied::ByPolicy(_)) => {}
                         // TODO: we need to have a cleaner delineation between actual access denied versus processing errors
@@ -518,7 +522,10 @@ where
                 Ok(proto::NodeResponseBody::Get(states))
             }
             proto::NodeRequestBody::GetEvents { collection, event_ids } => {
-                self.policy_agent.can_access_collection(cdata, &collection)?;
+                // Scan, though the events are addressed by id: an event log
+                // carries the collection's history beyond any one presented
+                // entity id, so answering discloses what a scan discloses.
+                self.policy_agent.can_access_collection(cdata, &collection, ReadKind::Scan)?;
                 let storage_collection = self.collections.get(&collection).await?;
 
                 // filter out any that the policy agent says we don't have access to

--- a/core/src/peer_subscription/server.rs
+++ b/core/src/peer_subscription/server.rs
@@ -5,7 +5,7 @@ use crate::{
     entity::Entity,
     error::SubscriptionError,
     node::Node,
-    policy::PolicyAgent,
+    policy::{PolicyAgent, ReadKind},
     reactor::{
         fetch_gap::{GapFetcher, QueryGapFetcher},
         ReactorSubscription, ReactorUpdate,
@@ -130,7 +130,7 @@ impl<CD: ContextData> SubscriptionHandler<CD> {
         // not yet tear down a standing registration — the claw-back
         // arrives with the re-permission PR:
         // https://github.com/ankurah/ankurah/pull/426
-        node.policy_agent.can_access_collection(cdata, &collection_id)?;
+        node.policy_agent.can_access_collection(cdata, &collection_id, ReadKind::Scan)?;
         selection.predicate = node.policy_agent.filter_predicate(cdata, &collection_id, selection.predicate)?;
 
         // TODO: consider separating session updating from SubscribeQuery,
@@ -236,7 +236,8 @@ impl<CD: ContextData> SubscriptionHandler<CD> {
             // are evaluated against entity state, not just the predicate. Skip
             // unreadable entities silently (mirroring the Fetch/Get handlers) so one
             // out-of-scope entity doesn't fail the whole subscription.
-            if node.policy_agent.check_read(cdata, &state.payload.entity_id, &collection_id, &state.payload.state).is_err() {
+            if node.policy_agent.check_read(cdata, &state.payload.entity_id, &collection_id, &state.payload.state, ReadKind::Scan).is_err()
+            {
                 continue;
             }
 

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -46,6 +46,23 @@ impl AccessDenied {}
 // because it is part of this trait's surface.
 pub use crate::schema::registration::{PlannedModelPropertyMembership, PlannedUpdate, RegistrationPlan};
 
+/// How a read reaches into a collection, for policy that holds the two
+/// apart. `Get` answers with entity states the caller already named by id —
+/// a lookup. `Scan` answers with rows or history the caller could not have
+/// named: predicate matches, subscription deliveries, event backfill — an
+/// enumeration. The distinction exists for policies like "any holder of a
+/// row's id may read it, but nobody below this privilege may list the
+/// collection": id-addressed reads disclose one row per id presented, while
+/// a scan discloses membership itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadKind {
+    /// Entity states addressed by id the caller presented.
+    Get,
+    /// Rows or events selected by predicate, subscription, or event id —
+    /// anything whose answer names rows for the caller.
+    Scan,
+}
+
 /// PolicyAgents control access to resources, by:
 /// - signing requests which are sent to other nodes - this may come in the form of a bearer token, or a signature, or some other arbitrary method of authentication as defined by the PolicyAgent
 /// - checking access for requests. If approved, yield a ContextData
@@ -161,8 +178,11 @@ pub trait PolicyAgent: Clone + Send + Sync + 'static {
         state: &Attested<proto::EntityState>,
     ) -> Result<(), AccessDenied>;
 
-    // For checking if a context can access a collection
-    fn can_access_collection<C>(&self, data: &C, collection: &proto::CollectionId) -> Result<(), AccessDenied>
+    /// The collection admission gate: may this context touch this collection
+    /// at all, for a read of the given [`ReadKind`]? Every read path calls
+    /// this before doing work; `kind` lets a policy admit id-addressed
+    /// lookups at a weaker privilege than scans (see [`ReadKind`]).
+    fn can_access_collection<C>(&self, data: &C, collection: &proto::CollectionId, kind: ReadKind) -> Result<(), AccessDenied>
     where C: Iterable<Self::ContextData>;
 
     /// Filter a predicate based on the context data
@@ -170,7 +190,10 @@ pub trait PolicyAgent: Clone + Send + Sync + 'static {
     fn filter_predicate<C>(&self, data: &C, collection: &proto::CollectionId, predicate: Predicate) -> Result<Predicate, AccessDenied>
     where C: Iterable<Self::ContextData>;
 
-    /// Check if a context can read an entity
+    /// Check if a context can read an entity. `kind` carries how the read
+    /// reached this entity — by presented id or by scan — so a policy that
+    /// admits lookups at a weaker privilege applies the same tier to the
+    /// per-row vet as to the gate.
     /// If the policy agent wants to inspect the entity state, it can do so with either TemporaryEntity::new or entityset.with_state
     /// Optimization: Consider adding a common trait implemented by Entity and TemporaryEntity returned by entityset.get_evaluation_entity that
     /// returns a real entity if resident, falling back to a temporary entity if not. (as the former case would save cycles creating/populating the backends)
@@ -180,6 +203,7 @@ pub trait PolicyAgent: Clone + Send + Sync + 'static {
         id: &proto::EntityId,
         collection: &proto::CollectionId,
         state: &proto::State,
+        kind: ReadKind,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>;
@@ -292,7 +316,7 @@ impl PolicyAgent for PermissiveAgent {
         Ok(())
     }
 
-    fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId) -> Result<(), AccessDenied>
+    fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId, _kind: ReadKind) -> Result<(), AccessDenied>
     where C: Iterable<Self::ContextData> {
         // PermissiveAgent allows regardless of which credentials are supplied, including none
         Ok(())
@@ -304,6 +328,7 @@ impl PolicyAgent for PermissiveAgent {
         _id: &proto::EntityId,
         _collection: &proto::CollectionId,
         _state: &proto::State,
+        _kind: ReadKind,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,

--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -7,7 +7,7 @@ use ankurah_core::{
     error::ValidationError,
     livequery::EntityLiveQuery,
     node::{Node, NodeInner, WeakNode},
-    policy::{AccessDenied, PolicyAgent},
+    policy::{AccessDenied, PolicyAgent, ReadKind},
     selection::filter::evaluate_predicate,
     storage::StorageEngine,
     util::Iterable,
@@ -211,7 +211,7 @@ impl PolicyAgent for JwtAgent {
         Ok(())
     }
 
-    fn can_access_collection<C>(&self, data: &C, collection: &proto::CollectionId) -> Result<(), AccessDenied>
+    fn can_access_collection<C>(&self, data: &C, collection: &proto::CollectionId, kind: ReadKind) -> Result<(), AccessDenied>
     where C: Iterable<Self::ContextData> {
         if collection.as_str() == "jwtpolicy" {
             return Ok(());
@@ -223,7 +223,7 @@ impl PolicyAgent for JwtAgent {
         }
         let state = self.state.read().unwrap_or_else(|e| e.into_inner());
         for ctx in data.iterable() {
-            if state.config.can_access_collection(ctx.roles(), collection) {
+            if state.config.can_access_collection(ctx.roles(), collection, kind) {
                 return Ok(());
             }
         }
@@ -268,8 +268,10 @@ impl PolicyAgent for JwtAgent {
             // Only authorized contexts contribute, matching the collection
             // check enforce_read_scope makes before evaluating a context's
             // scope: a credential that cannot reach the collection must not
-            // widen the query on its own account.
-            if !state.config.can_access_collection(ctx.roles(), collection) {
+            // widen the query on its own account. Scan, because a composed
+            // query is one: a get-tier credential must not widen a query it
+            // could never run.
+            if !state.config.can_access_collection(ctx.roles(), collection, ReadKind::Scan) {
                 continue;
             }
 
@@ -310,11 +312,12 @@ impl PolicyAgent for JwtAgent {
         id: &proto::EntityId,
         collection: &proto::CollectionId,
         state: &proto::State,
+        kind: ReadKind,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,
     {
-        self.can_access_collection(data, collection)?;
+        self.can_access_collection(data, collection, kind)?;
 
         for ctx in data.iterable() {
             if ctx.is_privileged() {
@@ -329,7 +332,7 @@ impl PolicyAgent for JwtAgent {
 
         let entity = TemporaryEntity::new(*id, collection.clone(), state)
             .map_err(|_| AccessDenied::ByPolicy("Read scope entity state could not be evaluated"))?;
-        enforce_read_scope(&guard.config, data, &entity)
+        enforce_read_scope(&guard.config, data, &entity, kind)
     }
 
     fn check_read_event<C>(&self, data: &C, event: &Attested<proto::Event>) -> Result<(), AccessDenied>
@@ -339,7 +342,10 @@ impl PolicyAgent for JwtAgent {
                 return Ok(());
             }
         }
-        self.can_access_collection(data, &event.payload.collection)
+        // Scan: an event log carries history beyond any one presented id,
+        // so reading events discloses what a scan discloses (the same
+        // ruling the GetEvents handler applies to its gate).
+        self.can_access_collection(data, &event.payload.collection, ReadKind::Scan)
     }
 
     fn check_write(&self, cdata: &Self::ContextData, entity: &Entity, _event: Option<&proto::Event>) -> Result<(), AccessDenied> {
@@ -420,13 +426,15 @@ fn enforce_write_scope(config: &PolicyConfig, cdata: &JwtContext, entity: &Entit
     Ok(())
 }
 
-fn enforce_read_scope<C>(config: &PolicyConfig, data: &C, entity: &TemporaryEntity) -> Result<(), AccessDenied>
+fn enforce_read_scope<C>(config: &PolicyConfig, data: &C, entity: &TemporaryEntity, kind: ReadKind) -> Result<(), AccessDenied>
 where C: Iterable<JwtContext> {
     for ctx in data.iterable() {
         let JwtContext::User { claims, .. } = ctx else {
             continue;
         };
-        if !config.can_access_collection(ctx.roles(), &entity.collection) {
+        // The kind is the caller's: a credential admitted only at the get
+        // tier counts toward a by-id row vet and not toward a scan's.
+        if !config.can_access_collection(ctx.roles(), &entity.collection, kind) {
             continue;
         }
 

--- a/extensions/jwt-auth/src/config.rs
+++ b/extensions/jwt-auth/src/config.rs
@@ -1,3 +1,4 @@
+use ankurah_core::policy::ReadKind;
 use ankurah_proto::CollectionId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -61,6 +62,17 @@ pub struct CollectionRules {
     /// Privilege required to read entities in this collection (None = no access)
     pub read: Option<String>,
 
+    /// Privilege sufficient to read entities addressed by id, without being
+    /// enough to query or subscribe (None = id-addressed reads require the
+    /// `read` privilege, the pre-existing behavior). This exists for
+    /// collections whose rows are public to whoever can name them while the
+    /// roster stays private — "any holder of a user's id may load that
+    /// user, but only the signed-in may list users". Holding `read` or
+    /// `write` always suffices for an id-addressed read; `get` never
+    /// admits a scan.
+    #[serde(default)]
+    pub get: Option<String>,
+
     /// Privilege required to write (create/update) entities in this collection (None = no access)
     pub write: Option<String>,
 
@@ -70,8 +82,12 @@ pub struct CollectionRules {
 }
 
 impl PolicyConfig {
-    /// Check if any of the given roles can access a collection (read or write).
-    pub fn can_access_collection(&self, roles: &[String], collection: &CollectionId) -> bool {
+    /// Check if any of the given roles can access a collection for a read of
+    /// the given kind. `read` or `write` privilege admits every kind (a
+    /// writer may see what it writes); the `get` privilege additionally
+    /// admits [`ReadKind::Get`] alone, so a collection can hand out rows to
+    /// whoever names their ids while refusing to enumerate itself.
+    pub fn can_access_collection(&self, roles: &[String], collection: &CollectionId, kind: ReadKind) -> bool {
         for role in roles {
             if self.role_has_wildcard(role) {
                 return true;
@@ -90,6 +106,13 @@ impl PolicyConfig {
                 if let Some(ref write_priv) = rules.write {
                     if privileges.contains(&write_priv.as_str()) {
                         return true;
+                    }
+                }
+                if kind == ReadKind::Get {
+                    if let Some(ref get_priv) = rules.get {
+                        if privileges.contains(&get_priv.as_str()) {
+                            return true;
+                        }
                     }
                 }
             }

--- a/extensions/jwt-auth/tests/adversarial_rbac_tests.rs
+++ b/extensions/jwt-auth/tests/adversarial_rbac_tests.rs
@@ -2,6 +2,7 @@ mod common;
 
 use ankurah::Model;
 use ankurah::Node;
+use ankurah_core::policy::ReadKind;
 use ankurah_jwt_auth::{JwtAgent, JwtContext};
 use ankurah_proto::CollectionId;
 use ankurah_storage_sled::SledStorageEngine;
@@ -59,7 +60,7 @@ async fn test_reader_cannot_write_to_user_collection() -> anyhow::Result<()> {
     let reader_ctx = JwtContext::from_claims(reader_claims, reader_token);
 
     let user_collection = CollectionId::from("user");
-    let result = agent.can_access_collection(&reader_ctx, &user_collection);
+    let result = agent.can_access_collection(&reader_ctx, &user_collection, ReadKind::Scan);
     assert!(result.is_err(), "Reader must not be able to access the user collection");
 
     let config = load_blog_config();
@@ -68,7 +69,7 @@ async fn test_reader_cannot_write_to_user_collection() -> anyhow::Result<()> {
         "Reader role must not have write access to the user collection"
     );
     assert!(
-        !config.can_access_collection(&[String::from("Reader")], &user_collection),
+        !config.can_access_collection(&[String::from("Reader")], &user_collection, ReadKind::Scan),
         "Reader role must not have any access to the user collection"
     );
 
@@ -178,11 +179,18 @@ async fn test_nouser_can_read_jwtpolicy_but_not_other_collections() -> anyhow::R
     let nouser = JwtContext::NoUser;
 
     let jwtpolicy = CollectionId::from("jwtpolicy");
-    assert!(agent.can_access_collection(&nouser, &jwtpolicy).is_ok(), "NoUser must be able to access jwtpolicy for bootstrap");
+    assert!(
+        agent.can_access_collection(&nouser, &jwtpolicy, ReadKind::Scan).is_ok(),
+        "NoUser must be able to access jwtpolicy for bootstrap"
+    );
 
     for name in &["post", "user", "comment", "tag", "secret_stuff"] {
         let col = CollectionId::from(*name);
-        assert!(agent.can_access_collection(&nouser, &col).is_err(), "NoUser must not be able to access the {} collection", name);
+        assert!(
+            agent.can_access_collection(&nouser, &col, ReadKind::Scan).is_err(),
+            "NoUser must not be able to access the {} collection",
+            name
+        );
     }
 
     Ok(())

--- a/extensions/jwt-auth/tests/config_tests.rs
+++ b/extensions/jwt-auth/tests/config_tests.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use ankurah_core::policy::ReadKind;
 use ankurah_proto::CollectionId;
 use common::{load_blog_config, load_minimal_config};
 
@@ -42,7 +43,7 @@ fn test_load_minimal_config() {
 fn test_editor_can_access_post_collection() {
     let config = load_blog_config();
     let collection = CollectionId::from("post");
-    assert!(config.can_access_collection(&[String::from("Editor")], &collection));
+    assert!(config.can_access_collection(&[String::from("Editor")], &collection, ReadKind::Scan));
 }
 
 #[test]
@@ -56,14 +57,14 @@ fn test_editor_can_write_post_collection() {
 fn test_reader_cannot_access_post_collection() {
     let config = load_blog_config();
     let collection = CollectionId::from("post");
-    assert!(!config.can_access_collection(&[String::from("Reader")], &collection));
+    assert!(!config.can_access_collection(&[String::from("Reader")], &collection, ReadKind::Scan));
 }
 
 #[test]
 fn test_reader_can_access_comment_collection() {
     let config = load_blog_config();
     let collection = CollectionId::from("comment");
-    assert!(config.can_access_collection(&[String::from("Reader")], &collection));
+    assert!(config.can_access_collection(&[String::from("Reader")], &collection, ReadKind::Scan));
 }
 
 #[test]
@@ -77,7 +78,7 @@ fn test_reader_cannot_write_comment_collection() {
 fn test_author_can_read_but_not_write_post() {
     let config = load_blog_config();
     let collection = CollectionId::from("post");
-    assert!(config.can_access_collection(&[String::from("Author")], &collection));
+    assert!(config.can_access_collection(&[String::from("Author")], &collection, ReadKind::Scan));
     assert!(!config.can_write_collection(&[String::from("Author")], &collection));
 }
 
@@ -85,7 +86,7 @@ fn test_author_can_read_but_not_write_post() {
 fn test_unknown_role_denied() {
     let config = load_blog_config();
     let collection = CollectionId::from("post");
-    assert!(!config.can_access_collection(&[String::from("Hacker")], &collection));
+    assert!(!config.can_access_collection(&[String::from("Hacker")], &collection, ReadKind::Scan));
     assert!(!config.can_write_collection(&[String::from("Hacker")], &collection));
 }
 
@@ -93,7 +94,7 @@ fn test_unknown_role_denied() {
 fn test_unknown_collection_denied() {
     let config = load_blog_config();
     let collection = CollectionId::from("secret_stuff");
-    assert!(!config.can_access_collection(&[String::from("Editor")], &collection));
+    assert!(!config.can_access_collection(&[String::from("Editor")], &collection, ReadKind::Scan));
     assert!(!config.can_write_collection(&[String::from("Editor")], &collection));
 }
 
@@ -108,17 +109,17 @@ fn test_wildcard_privilege_grants_all_access() {
 
     let admin = [String::from("Admin")];
 
-    assert!(config.can_access_collection(&admin, &post));
+    assert!(config.can_access_collection(&admin, &post, ReadKind::Scan));
     assert!(config.can_write_collection(&admin, &post));
-    assert!(config.can_access_collection(&admin, &comment));
+    assert!(config.can_access_collection(&admin, &comment, ReadKind::Scan));
     assert!(config.can_write_collection(&admin, &comment));
-    assert!(config.can_access_collection(&admin, &user));
+    assert!(config.can_access_collection(&admin, &user, ReadKind::Scan));
     assert!(config.can_write_collection(&admin, &user));
-    assert!(config.can_access_collection(&admin, &tag));
+    assert!(config.can_access_collection(&admin, &tag, ReadKind::Scan));
     assert!(config.can_write_collection(&admin, &tag));
 
     // Wildcard also grants access to collections not explicitly defined
-    assert!(config.can_access_collection(&admin, &unknown));
+    assert!(config.can_access_collection(&admin, &unknown, ReadKind::Scan));
     assert!(config.can_write_collection(&admin, &unknown));
 }
 
@@ -126,7 +127,7 @@ fn test_wildcard_privilege_grants_all_access() {
 fn test_minimal_config_wildcard_admin() {
     let config = load_minimal_config();
     let collection = CollectionId::from("anything");
-    assert!(config.can_access_collection(&[String::from("Admin")], &collection));
+    assert!(config.can_access_collection(&[String::from("Admin")], &collection, ReadKind::Scan));
 }
 
 #[test]
@@ -143,7 +144,7 @@ fn test_multi_role_access() {
     let comment = CollectionId::from("comment");
 
     let roles = vec![String::from("Reader"), String::from("Editor")];
-    assert!(config.can_access_collection(&roles, &post));
+    assert!(config.can_access_collection(&roles, &post, ReadKind::Scan));
     assert!(config.can_write_collection(&roles, &post));
-    assert!(config.can_access_collection(&roles, &comment));
+    assert!(config.can_access_collection(&roles, &comment, ReadKind::Scan));
 }

--- a/extensions/jwt-auth/tests/context_tests.rs
+++ b/extensions/jwt-auth/tests/context_tests.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use ankurah_core::policy::ReadKind;
 use ankurah_jwt_auth::{JwtAgent, JwtClaims, JwtContext};
 use ankurah_proto::CollectionId;
 use common::blog_config_path;
@@ -203,9 +204,9 @@ fn test_nouser_can_access_jwtpolicy_collection() {
     use ankurah_core::policy::PolicyAgent;
     let ctx = JwtContext::NoUser;
     let jwtpolicy = CollectionId::from("jwtpolicy");
-    assert!(agent.can_access_collection(&ctx, &jwtpolicy).is_ok());
+    assert!(agent.can_access_collection(&ctx, &jwtpolicy, ReadKind::Scan).is_ok());
 
     // But NoUser cannot access other collections
     let post = CollectionId::from("post");
-    assert!(agent.can_access_collection(&ctx, &post).is_err());
+    assert!(agent.can_access_collection(&ctx, &post, ReadKind::Scan).is_err());
 }

--- a/extensions/jwt-auth/tests/filter_predicate_tests.rs
+++ b/extensions/jwt-auth/tests/filter_predicate_tests.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use ankql::ast::Predicate;
+use ankurah_core::policy::ReadKind;
 use ankurah_core::{
     policy::{AccessDenied, PolicyAgent},
     property::backend::{LWWBackend, PropertyBackend},
@@ -263,7 +264,7 @@ fn assert_agrees_with_check_read<C: Iterable<JwtContext>>(agent: &JwtAgent, cont
     let filtered = agent.filter_predicate(contexts, &collection, base.clone()).expect("every scenario here yields a filter");
 
     for row in rows {
-        let readable = agent.check_read(contexts, &proto::EntityId::new(), &collection, &post_state(*row)).is_ok();
+        let readable = agent.check_read(contexts, &proto::EntityId::new(), &collection, &post_state(*row), ReadKind::Scan).is_ok();
         let selected = admits(base, *row);
         assert_eq!(
             admits(&filtered, *row),
@@ -542,7 +543,7 @@ fn test_filter_predicate_all_unresolvable_refused() {
         "a lone unresolvable credential leaves nothing to read by, got: {:?}",
         filtered
     );
-    let read = agent.check_read(&lone, &proto::EntityId::new(), &collection, &row);
+    let read = agent.check_read(&lone, &proto::EntityId::new(), &collection, &row, ReadKind::Scan);
     assert!(
         matches!(read, Err(AccessDenied::ByPolicy("Read outside permitted scope"))),
         "the row-time half must deny the caller the query-time half refused, got: {:?}",
@@ -556,7 +557,7 @@ fn test_filter_predicate_all_unresolvable_refused() {
         "several unresolvable credentials are no better than one, got: {:?}",
         filtered
     );
-    let read = agent.check_read(&several, &proto::EntityId::new(), &collection, &row);
+    let read = agent.check_read(&several, &proto::EntityId::new(), &collection, &row, ReadKind::Scan);
     assert!(
         matches!(read, Err(AccessDenied::ByPolicy("Read outside permitted scope"))),
         "the row-time half must deny that caller too, got: {:?}",
@@ -584,8 +585,8 @@ fn test_filter_predicate_unresolvable_order_independent() {
     for row in [Post { author: "author-42", title: "hello" }, Post { author: "no-claim-1", title: "hello" }] {
         let state = post_state(row);
         assert_eq!(
-            agent.check_read(&broken_first, &proto::EntityId::new(), &collection, &state).is_ok(),
-            agent.check_read(&broken_last, &proto::EntityId::new(), &collection, &state).is_ok(),
+            agent.check_read(&broken_first, &proto::EntityId::new(), &collection, &state, ReadKind::Scan).is_ok(),
+            agent.check_read(&broken_last, &proto::EntityId::new(), &collection, &state, ReadKind::Scan).is_ok(),
             "post {}/{}: the row-time half must not depend on credential order either",
             row.author,
             row.title

--- a/extensions/jwt-auth/tests/fixtures/get_privilege.json
+++ b/extensions/jwt-auth/tests/fixtures/get_privilege.json
@@ -1,0 +1,21 @@
+{
+  "roles": {
+    "guest": ["view"],
+    "member": ["view", "signed_in"]
+  },
+  "collections": {
+    "user": {
+      "read": "signed_in",
+      "get": "view",
+      "write": "signed_in"
+    },
+    "modaction": {
+      "read": "signed_in",
+      "write": "signed_in"
+    },
+    "message": {
+      "read": "view",
+      "write": "signed_in"
+    }
+  }
+}

--- a/extensions/jwt-auth/tests/get_privilege_tests.rs
+++ b/extensions/jwt-auth/tests/get_privilege_tests.rs
@@ -1,0 +1,107 @@
+//! The `get` privilege: a collection can hand out rows to whoever names
+//! their ids while refusing to enumerate itself.
+//!
+//! The shape under test is community's user directory: every user row is
+//! public to anyone holding its id (message authors carry those ids), but
+//! only the signed-in may list or query users. `get` admits
+//! [`ReadKind::Get`] alone; `read` and `write` admit every kind; an absent
+//! `get` changes nothing about a policy written before it existed.
+
+mod common;
+
+use ankurah::{Model, Node};
+use ankurah_core::policy::ReadKind;
+use ankurah_jwt_auth::{JwtAgent, JwtContext, PolicyConfig};
+use ankurah_proto::CollectionId;
+use ankurah_storage_sled::SledStorageEngine;
+use common::{make_claims, sign_token};
+use std::sync::Arc;
+
+fn config_path() -> String { format!("{}/tests/fixtures/get_privilege.json", env!("CARGO_MANIFEST_DIR")) }
+
+fn load_config() -> PolicyConfig { serde_json::from_str(&std::fs::read_to_string(config_path()).unwrap()).unwrap() }
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct User {
+    pub name: String,
+}
+
+/// The split itself, at the config tier: `view` reaches a user row by id
+/// and nothing else.
+#[test]
+fn get_admits_by_id_and_never_a_scan() {
+    let config = load_config();
+    let guest = [String::from("guest")];
+    let user = CollectionId::fixed_name("user");
+
+    assert!(config.can_access_collection(&guest, &user, ReadKind::Get), "view is the get tier for user");
+    assert!(!config.can_access_collection(&guest, &user, ReadKind::Scan), "get must never admit a scan");
+}
+
+/// A collection without a `get` field behaves exactly as before the field
+/// existed: by-id reads require the read privilege.
+#[test]
+fn absent_get_falls_back_to_read() {
+    let config = load_config();
+    let guest = [String::from("guest")];
+    let modaction = CollectionId::fixed_name("modaction");
+
+    assert!(!config.can_access_collection(&guest, &modaction, ReadKind::Get), "no get field, no weakening");
+    assert!(!config.can_access_collection(&guest, &modaction, ReadKind::Scan));
+}
+
+/// `read` (and `write`) admit every kind — a role that may query needs no
+/// `get` grant to keep loading rows by id, and a collection that is fully
+/// readable gains nothing from one.
+#[test]
+fn read_privilege_admits_both_kinds() {
+    let config = load_config();
+    let member = [String::from("member")];
+    let guest = [String::from("guest")];
+    let user = CollectionId::fixed_name("user");
+    let message = CollectionId::fixed_name("message");
+
+    assert!(config.can_access_collection(&member, &user, ReadKind::Get));
+    assert!(config.can_access_collection(&member, &user, ReadKind::Scan));
+    assert!(config.can_access_collection(&guest, &message, ReadKind::Get));
+    assert!(config.can_access_collection(&guest, &message, ReadKind::Scan));
+}
+
+/// End to end through a node: the guest context loads a user it can name
+/// and is refused the roster, under the same agent and store.
+#[tokio::test]
+async fn guest_gets_a_named_user_and_cannot_list() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), config_path())?;
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent);
+    node.system.create().await?;
+
+    // A member writes the row the guest will name.
+    let member_claims = make_claims("member-1", &["member"], "member@example.com");
+    let member_token = sign_token(&keys, &member_claims);
+    let member = node.context(JwtContext::from_claims(member_claims, member_token))?;
+
+    let trx = member.begin();
+    let created = trx.create(&User { name: "Ada".into() }).await?;
+    let user_id = created.id();
+    trx.commit().await?;
+
+    let guest_claims = make_claims("guest", &["guest"], "");
+    let guest_token = sign_token(&keys, &guest_claims);
+    let guest = node.context(JwtContext::from_claims(guest_claims, guest_token))?;
+
+    // By id: admitted at the view tier.
+    let fetched = guest.get::<UserView>(user_id).await?;
+    assert_eq!(fetched.name()?, "Ada");
+
+    // By predicate: refused at the collection gate, whatever the predicate
+    // says — enumerating is what the tier withholds.
+    assert!(guest.fetch::<UserView>("true").await.is_err(), "a guest must not list users");
+    assert!(guest.fetch::<UserView>("name = 'Ada'").await.is_err(), "naming a value is still a scan");
+
+    // The member keeps the roster.
+    let listed = member.fetch::<UserView>("true").await?;
+    assert_eq!(listed.len(), 1);
+
+    Ok(())
+}

--- a/extensions/jwt-auth/tests/node_tests.rs
+++ b/extensions/jwt-auth/tests/node_tests.rs
@@ -3,6 +3,7 @@ mod common;
 use ankurah::{Model, Node, Ref};
 use ankurah_core::model::Mutable;
 use ankurah_core::policy::PolicyAgent;
+use ankurah_core::policy::ReadKind;
 use ankurah_jwt_auth::{JwtAgent, JwtClaims, JwtContext, JwtKeys, PolicyConfig};
 use ankurah_proto::{Clock, Event, OperationSet};
 use ankurah_storage_sled::SledStorageEngine;
@@ -330,7 +331,7 @@ async fn test_jwtpolicy_collection_always_accessible() -> anyhow::Result<()> {
     let ctx = JwtContext::from_claims(claims, token);
 
     use ankurah_core::policy::PolicyAgent;
-    let result = agent.can_access_collection(&ctx, &collection);
+    let result = agent.can_access_collection(&ctx, &collection, ReadKind::Scan);
     assert!(result.is_ok(), "jwtpolicy collection should always be accessible");
 
     Ok(())
@@ -348,7 +349,7 @@ async fn test_jwt_agent_collection_access_denied() -> anyhow::Result<()> {
     let ctx = JwtContext::from_claims(claims, token);
 
     use ankurah_core::policy::PolicyAgent;
-    let result = agent.can_access_collection(&ctx, &collection);
+    let result = agent.can_access_collection(&ctx, &collection, ReadKind::Scan);
     assert!(result.is_err(), "Reader should not be able to access post collection");
 
     Ok(())
@@ -386,8 +387,8 @@ async fn test_root_bypasses_collection_access() -> anyhow::Result<()> {
 
     let post = ankurah_proto::CollectionId::from("post");
     let secret = ankurah_proto::CollectionId::from("secret_stuff");
-    assert!(agent.can_access_collection(&root, &post).is_ok());
-    assert!(agent.can_access_collection(&root, &secret).is_ok());
+    assert!(agent.can_access_collection(&root, &post, ReadKind::Scan).is_ok());
+    assert!(agent.can_access_collection(&root, &secret, ReadKind::Scan).is_ok());
 
     Ok(())
 }

--- a/tests/tests/bridge_policy.rs
+++ b/tests/tests/bridge_policy.rs
@@ -9,6 +9,7 @@ use ankurah::core::{
     storage::StorageEngine,
     util::Iterable,
 };
+use ankurah::policy::ReadKind;
 use ankurah::proto::{self, Attested, EventId};
 use ankurah::{Model, Node, PermissiveAgent};
 use ankurah_connector_local_process::LocalProcessConnection;
@@ -96,7 +97,7 @@ impl PolicyAgent for BridgePolicyAgent {
         Ok(())
     }
 
-    fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId) -> Result<(), AccessDenied>
+    fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId, _kind: ReadKind) -> Result<(), AccessDenied>
     where C: Iterable<Self::ContextData> {
         Ok(())
     }
@@ -112,6 +113,7 @@ impl PolicyAgent for BridgePolicyAgent {
         _id: &proto::EntityId,
         _collection: &proto::CollectionId,
         _state: &proto::State,
+        _kind: ReadKind,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,

--- a/tests/tests/check_request_error.rs
+++ b/tests/tests/check_request_error.rs
@@ -9,7 +9,7 @@ use ankql::ast::Predicate;
 use ankurah::core::node::ContextData;
 use ankurah::core::util::Iterable;
 use ankurah::error::ValidationError;
-use ankurah::policy::{AccessDenied, PolicyAgent, DEFAULT_CONTEXT};
+use ankurah::policy::{AccessDenied, PolicyAgent, ReadKind, DEFAULT_CONTEXT};
 use ankurah::proto::{self, AuthData};
 use ankurah::storage::StorageEngine;
 use ankurah::{Node, PermissiveAgent};
@@ -92,8 +92,15 @@ impl PolicyAgent for RejectingAgent {
         Ok(())
     }
 
-    fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId) -> std::result::Result<(), AccessDenied>
-    where C: Iterable<Self::ContextData> {
+    fn can_access_collection<C>(
+        &self,
+        _data: &C,
+        _collection: &proto::CollectionId,
+        _kind: ReadKind,
+    ) -> std::result::Result<(), AccessDenied>
+    where
+        C: Iterable<Self::ContextData>,
+    {
         Ok(())
     }
 
@@ -115,6 +122,7 @@ impl PolicyAgent for RejectingAgent {
         _id: &proto::EntityId,
         _collection: &proto::CollectionId,
         _state: &proto::State,
+        _kind: ReadKind,
     ) -> std::result::Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,

--- a/tests/tests/commit_atomicity.rs
+++ b/tests/tests/commit_atomicity.rs
@@ -9,6 +9,7 @@ use ankurah::core::{
     storage::StorageEngine,
     util::Iterable,
 };
+use ankurah::policy::ReadKind;
 use ankurah::proto::{self, Attested};
 use ankurah::{Model, Mutable, Node};
 use ankurah_storage_sled::SledStorageEngine;
@@ -96,7 +97,7 @@ impl PolicyAgent for DenySecondAlbumEventAgent {
         Ok(())
     }
 
-    fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId) -> Result<(), AccessDenied>
+    fn can_access_collection<C>(&self, _data: &C, _collection: &proto::CollectionId, _kind: ReadKind) -> Result<(), AccessDenied>
     where C: Iterable<Self::ContextData> {
         Ok(())
     }
@@ -112,6 +113,7 @@ impl PolicyAgent for DenySecondAlbumEventAgent {
         _id: &proto::EntityId,
         _collection: &proto::CollectionId,
         _state: &proto::State,
+        _kind: ReadKind,
     ) -> Result<(), AccessDenied>
     where
         C: Iterable<Self::ContextData>,

--- a/tests/tests/schema_registration.rs
+++ b/tests/tests/schema_registration.rs
@@ -800,8 +800,15 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
         Ok(())
     }
 
-    fn can_access_collection<C>(&self, _data: &C, collection: &proto::CollectionId) -> Result<(), ankurah::policy::AccessDenied>
-    where C: ankurah::core::util::Iterable<Self::ContextData> {
+    fn can_access_collection<C>(
+        &self,
+        _data: &C,
+        collection: &proto::CollectionId,
+        _kind: ankurah::policy::ReadKind,
+    ) -> Result<(), ankurah::policy::AccessDenied>
+    where
+        C: ankurah::core::util::Iterable<Self::ContextData>,
+    {
         if let Some(hook) = &self.on_collection_access {
             hook(collection)?;
         }
@@ -830,6 +837,7 @@ impl ankurah::policy::PolicyAgent for ProbeAgent {
         _id: &proto::EntityId,
         _collection: &proto::CollectionId,
         _state: &proto::State,
+        _kind: ankurah::policy::ReadKind,
     ) -> Result<(), ankurah::policy::AccessDenied>
     where
         C: ankurah::core::util::Iterable<Self::ContextData>,


### PR DESCRIPTION
## Why

Community wants user rows public to whoever can name them while the roster stays signed-in-only: message authors carry user ids, so a guest rendering display names needs by-id loads and nothing else. The wire already tells the shapes apart (`Get{ids}` vs `Fetch`/`SubscribeQuery{selection}`); the policy layer could not — one collection gate admitted every read.

## What

`ReadKind::{Get, Scan}` travels with every collection gate and per-row read check. **Get** is entity state addressed by an id the caller presented; **Scan** is anything whose answer names rows for the caller — predicate matches, subscription deliveries, event backfill. `GetEvents` and `check_read_event` rule themselves Scan on those terms: an event log carries history beyond any one presented id.

The jwt-auth config grows an optional per-collection `get` privilege. `read` or `write` admit every kind, as before; `get` additionally admits Get alone; a policy without the field reads the same as before the field existed — by-id reads keep requiring `read`. In `filter_predicate` and `enforce_read_scope`, a credential counts toward an answer only at the kind it is admitted for: a get-tier credential vets by-id rows and never widens a query it could not run.

## Coverage

`extensions/jwt-auth/tests/get_privilege_tests.rs`: the split (view reaches a user row by id and never by scan), the fallback (absent `get`, no weakening), read admitting both kinds, and end to end through a node — a guest loads the row it names, is refused both `fetch("true")` and `fetch("name = 'Ada'")` (a narrowing predicate is still a scan), and the member keeps the roster.

Gates: fmt check clean; core 220, jwt-auth all suites (incl. the 4 new), storage-common 106, sled, and ankurah-tests green locally (`test_websocket_subscription_propagation` tripped once under full-suite load and passed 3/3 isolated — the known websocket timing flake family; the change adds a parameter whose value is constant per call site, and every agent in that harness is permissive).

First consumer: community's `policy.json` sets `user` to `get: view, read: signed_in`, and ankurah-chat resolves author names per-ref instead of through a roster query.