### PR TITLE
jwt-auth: the retrieve privilege — rows to whoever names them, scans to the privileged

### DIFF
--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -232,6 +232,15 @@ impl PolicyAgent for JwtAgent {
 
     fn filter_predicate<C>(&self, data: &C, collection: &proto::CollectionId, predicate: Predicate) -> Result<Predicate, AccessDenied>
     where C: Iterable<Self::ContextData> {
+        // The policy collection is granted before any credential is
+        // consulted, mirroring can_access_collection's carve-out and for the
+        // same reason: an ephemeral node bootstraps its policy through a
+        // livequery on this collection while its config is still deny-all,
+        // and a scan-privilege check here (added with the `retrieve` tier)
+        // would compose that bootstrap query to False.
+        if collection.as_str() == "jwtpolicy" {
+            return Ok(predicate);
+        }
         for ctx in data.iterable() {
             if ctx.is_privileged() {
                 return Ok(predicate);
@@ -239,8 +248,26 @@ impl PolicyAgent for JwtAgent {
         }
 
         let state = self.state.read().unwrap_or_else(|e| e.into_inner());
+
         if state.config.scope_rules_for_collection(collection.as_str()).is_empty() {
-            return Ok(predicate);
+            // An unscoped collection passes a scan-privileged caller's
+            // predicate through untouched. Any other caller the entry gate
+            // admitted — which now includes retrieval-only credentials —
+            // scans nothing: False, an empty answer rather than an error,
+            // because arriving here at the retrieval tier is a tier limit
+            // and not a fault. Every predicate is a scan here, id-shaped or
+            // not: predicate-shaped retrieval (an id-bounded pass at this
+            // tier, for fetch_one("id = …") and named-row live queries) is
+            // a deliberate follow-up, not part of this change. (Before
+            // `retrieve` existed this arm passed unconditionally, and
+            // could: the entry gate had already refused every caller
+            // without read or write.)
+            for ctx in data.iterable() {
+                if state.config.can_scan_collection(ctx.roles(), collection) {
+                    return Ok(predicate);
+                }
+            }
+            return Ok(Predicate::False);
         }
 
         // A caller holding several credentials may read what any one of them
@@ -265,11 +292,14 @@ impl PolicyAgent for JwtAgent {
             let JwtContext::User { claims, .. } = ctx else {
                 continue;
             };
-            // Only authorized contexts contribute, matching the collection
-            // check enforce_read_scope makes before evaluating a context's
-            // scope: a credential that cannot reach the collection must not
-            // widen the query on its own account.
-            if !state.config.can_access_collection(ctx.roles(), collection) {
+            // Only scan-authorized contexts contribute: a credential that
+            // cannot run this query must not widen it on its own account. A
+            // retrieval-only credential reads rows it names, never rows a
+            // scan surfaces, so it contributes no slice here.
+            // (enforce_read_scope keeps the wide check for the per-row
+            // half: a retrieval credential may satisfy a row's scope for a
+            // row it named.)
+            if !state.config.can_scan_collection(ctx.roles(), collection) {
                 continue;
             }
 

--- a/extensions/jwt-auth/src/config.rs
+++ b/extensions/jwt-auth/src/config.rs
@@ -61,6 +61,21 @@ pub struct CollectionRules {
     /// Privilege required to read entities in this collection (None = no access)
     pub read: Option<String>,
 
+    /// Privilege sufficient to RETRIEVE rows the caller can already name —
+    /// a `Ref` follow and the by-id wire path (`Get{ids}`) — without
+    /// admitting scans. Predicates are all scans for now, even id-shaped
+    /// ones; admitting id-bounded predicates at this tier is a deliberate
+    /// follow-up. None = retrieval requires `read`, the pre-existing
+    /// behavior, so a policy written before this field existed means what
+    /// it always meant. This exists for collections whose rows are public
+    /// to whoever holds their ids while the roster stays private: "any
+    /// holder of a user's id may retrieve that user; only the signed-in may
+    /// list users." `read` or `write` always suffice for a retrieval, and
+    /// row scope rules still bind per row (`check_read` is unchanged by
+    /// this field).
+    #[serde(default)]
+    pub retrieve: Option<String>,
+
     /// Privilege required to write (create/update) entities in this collection (None = no access)
     pub write: Option<String>,
 
@@ -70,8 +85,52 @@ pub struct CollectionRules {
 }
 
 impl PolicyConfig {
-    /// Check if any of the given roles can access a collection (read or write).
+    /// The collection admission gate: true when any role holds `read`,
+    /// `write`, or `retrieve` privilege. Deliberately the WIDEST read
+    /// admission — it is what admits a retrieval-tier caller's `Ref`
+    /// follow: the by-id wire path checks only this gate plus per-row
+    /// `check_read`. Scans are refused downstream in `filter_predicate`,
+    /// which composes to `False` for callers this gate admitted without
+    /// scan privilege. Use [`Self::can_scan_collection`] where only
+    /// scan-privileged credentials may count.
     pub fn can_access_collection(&self, roles: &[String], collection: &CollectionId) -> bool {
+        for role in roles {
+            if self.role_has_wildcard(role) {
+                return true;
+            }
+        }
+
+        let collection_name = collection.as_str();
+        if let Some(rules) = self.collections.get(collection_name) {
+            for role in roles {
+                let privileges = self.privileges_for_role(role);
+                if let Some(ref read_priv) = rules.read {
+                    if privileges.contains(&read_priv.as_str()) {
+                        return true;
+                    }
+                }
+                if let Some(ref write_priv) = rules.write {
+                    if privileges.contains(&write_priv.as_str()) {
+                        return true;
+                    }
+                }
+                if let Some(ref retrieve_priv) = rules.retrieve {
+                    if privileges.contains(&retrieve_priv.as_str()) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    /// True when any role may run a SCAN — a predicate query, subscription,
+    /// or listing — against the collection: `read` or `write` privilege
+    /// (exactly what [`Self::can_access_collection`] meant before
+    /// `retrieve` existed). `retrieve` deliberately does not count here:
+    /// naming rows is the whole of what it grants.
+    pub fn can_scan_collection(&self, roles: &[String], collection: &CollectionId) -> bool {
         for role in roles {
             if self.role_has_wildcard(role) {
                 return true;

--- a/extensions/jwt-auth/tests/filter_predicate_tests.rs
+++ b/extensions/jwt-auth/tests/filter_predicate_tests.rs
@@ -372,11 +372,13 @@ fn test_filter_predicate_deduplicates_equal_slices() {
     assert_eq!(result, single, "a repeated credential must not repeat its branch");
 }
 
-/// An empty credential set is refused on a scoped collection — there is no
-/// slice to union — but the no-scope early return runs before any credential
-/// is read, so an unscoped collection still returns the caller's predicate
-/// untouched. The refusal is narrower than "a caller with no authorized
-/// context is always denied".
+/// An empty credential set scans nothing anywhere. On a scoped collection it
+/// is refused — there is no slice to union — and on an unscoped collection
+/// it composes to `False`: since the `retrieve` tier widened the entry gate,
+/// the unscoped arm checks scan privilege itself instead of trusting the
+/// gate to have refused already, and an empty set holds none. (This pin
+/// previously recorded the predicate passing untouched, an artifact of that
+/// trust; the trait's empty-set guidance is fail-closed, which this now is.)
 #[test]
 fn test_filter_predicate_empty_context_set() {
     let keys = common::test_keys();
@@ -389,7 +391,7 @@ fn test_filter_predicate_empty_context_set() {
     assert!(scoped.is_err(), "post is scoped, so an empty set has no authorized slice, got: {:?}", scoped);
 
     let unscoped = agent.filter_predicate(&contexts, &CollectionId::from("comment"), predicate.clone()).unwrap();
-    assert_eq!(unscoped, predicate, "comment carries no scope rules, so the query is returned before any credential is read");
+    assert_eq!(unscoped, Predicate::False, "comment carries no scope rules, and an empty set holds no scan privilege: nothing");
 }
 
 /// An authenticated credential that cannot reach the collection contributes

--- a/extensions/jwt-auth/tests/fixtures/retrieval_privilege.json
+++ b/extensions/jwt-auth/tests/fixtures/retrieval_privilege.json
@@ -1,0 +1,22 @@
+{
+  "roles": {
+    "guest": ["view"],
+    "member": ["view", "signed_in"]
+  },
+  "collections": {
+    "user": {
+      "read": "signed_in",
+      "retrieve": "view",
+      "write": "signed_in"
+    },
+    "note": {
+      "read": "signed_in",
+      "write": "signed_in",
+      "scope": [{ "filter": "owner = $jwt.sub" }]
+    },
+    "message": {
+      "read": "view",
+      "write": "signed_in"
+    }
+  }
+}

--- a/extensions/jwt-auth/tests/retrieval_privilege_tests.rs
+++ b/extensions/jwt-auth/tests/retrieval_privilege_tests.rs
@@ -1,0 +1,176 @@
+//! The `retrieve` privilege: rows to whoever names them, scans to the
+//! privileged.
+//!
+//! The shape under test is community's user directory: message authors
+//! carry user ids (refs), so a guest rendering names needs exactly the rows
+//! it can name — never the roster. `retrieve` admits the by-id path (`Ref`
+//! follows, `get`); every predicate remains a scan for now, even id-shaped
+//! ones — admitting id-bounded predicates at this tier is a deliberate
+//! follow-up. Scans compose to `False` (empty, not an error) for a caller
+//! the gate admitted without scan privilege; row scope rules still bind
+//! by-id reads; and a policy without the field means what it always meant.
+
+mod common;
+
+use ankql::ast::Predicate;
+use ankurah::policy::PolicyAgent;
+use ankurah::{Model, Node};
+use ankurah_jwt_auth::{JwtAgent, JwtContext, PolicyConfig};
+use ankurah_proto::CollectionId;
+use ankurah_storage_sled::SledStorageEngine;
+use common::{make_claims, sign_token};
+use std::sync::Arc;
+
+fn config_path() -> String { format!("{}/tests/fixtures/retrieval_privilege.json", env!("CARGO_MANIFEST_DIR")) }
+
+fn load_config() -> PolicyConfig { serde_json::from_str(&std::fs::read_to_string(config_path()).unwrap()).unwrap() }
+
+fn parse(predicate: &str) -> Predicate { ankql::parser::parse_selection(predicate).unwrap().predicate }
+
+fn agent() -> JwtAgent { JwtAgent::new_durable(common::test_keys(), config_path()).unwrap() }
+
+fn guest_ctx() -> JwtContext {
+    let claims = make_claims("guest", &["guest"], "");
+    let token = sign_token(&common::test_keys(), &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+fn member_ctx(sub: &str) -> JwtContext {
+    let claims = make_claims(sub, &["member"], "member@example.com");
+    let token = sign_token(&common::test_keys(), &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct User {
+    pub name: String,
+}
+
+/// A row-scoped collection (`owner = $jwt.sub`), for pinning that scopes
+/// keep binding by-id reads and that an absent `retrieve` field weakens
+/// nothing.
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Note {
+    pub owner: String,
+    pub body: String,
+}
+
+/// The gate split at the config tier: the entry gate admits the retrieval
+/// tier, the scan check does not.
+#[test]
+fn gate_is_wide_and_scan_check_is_narrow() {
+    let config = load_config();
+    let guest = [String::from("guest")];
+    let member = [String::from("member")];
+    let user = CollectionId::fixed_name("user");
+    let note = CollectionId::fixed_name("note");
+
+    assert!(config.can_access_collection(&guest, &user), "retrieval admits the entry gate");
+    assert!(!config.can_scan_collection(&guest, &user), "retrieval never admits a scan");
+    assert!(config.can_access_collection(&member, &user));
+    assert!(config.can_scan_collection(&member, &user));
+
+    // No retrieve field on note: the gate means what it meant before the
+    // field existed.
+    assert!(!config.can_access_collection(&guest, &note), "absent retrieve field, no weakening");
+}
+
+/// At the retrieval tier every predicate is a scan and composes to `False`
+/// — empty, not an error — INCLUDING id-shaped ones: predicate-shaped
+/// retrieval is the deliberate follow-up, and until it lands the only
+/// retrieval surface is the by-id get path.
+#[test]
+fn retrieval_tier_scans_nothing() {
+    let agent = agent();
+    let user = CollectionId::fixed_name("user");
+    let guest = vec![guest_ctx()];
+
+    for scan in [
+        "true",
+        "name = 'Ada'",
+        "id = '5xEQjLcNhFLTKwyy2DZzHU'",
+        "id IN ('5xEQjLcNhFLTKwyy2DZzHU', '5xEQjLcNhFLTKwyy2DZzHV')",
+        "id > '5xEQjLcNhFLTKwyy2DZzHU'",
+        "id = '5xEQjLcNhFLTKwyy2DZzHU' AND name = 'Ada'",
+    ] {
+        let out = agent.filter_predicate(&guest, &user, parse(scan)).unwrap();
+        assert_eq!(out, Predicate::False, "every predicate is a scan at the retrieval tier: {scan}");
+    }
+}
+
+/// The same shapes for a scan-privileged caller are untouched — the
+/// unscoped-collection fast path is unchanged for readers.
+#[test]
+fn scan_tier_predicates_pass_untouched() {
+    let agent = agent();
+    let user = CollectionId::fixed_name("user");
+    let member = vec![member_ctx("member-1")];
+
+    for predicate in ["true", "name = 'Ada'", "id = '5xEQjLcNhFLTKwyy2DZzHU'"] {
+        let out = agent.filter_predicate(&member, &user, parse(predicate)).unwrap();
+        assert_eq!(out, parse(predicate), "read privilege scans freely: {predicate}");
+    }
+}
+
+/// On a scoped collection, a retrieval-only credential contributes no slice
+/// to scan composition — today's refusal texture for a caller with no
+/// scan-authorized credential is preserved.
+#[test]
+fn retrieval_credential_never_widens_a_scoped_scan() {
+    let agent = agent();
+    let note = CollectionId::fixed_name("note");
+
+    // The guest's only privilege is view; note grants view nothing. The
+    // scan reaches the scoped arm and no credential contributes a slice.
+    let guest = vec![guest_ctx()];
+    assert!(agent.filter_predicate(&guest, &note, parse("true")).is_err(), "no scan-authorized credential, refused as before");
+
+    // A member scans its own slice, composed as before.
+    let member = vec![member_ctx("member-1")];
+    let out = agent.filter_predicate(&member, &note, parse("true")).unwrap();
+    assert_eq!(out.to_string(), parse("true AND owner = 'member-1'").to_string(), "scope composition unchanged for scanners");
+}
+
+/// End to end through a node: the guest retrieves the user it names by the
+/// get path, is answered empty (not an error) for every predicate — even an
+/// id-shaped one — and row scopes still bind by-id reads on the scoped
+/// collection.
+#[tokio::test]
+async fn guest_retrieves_named_rows_and_scans_nothing() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), config_path())?;
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent);
+    node.system.create().await?;
+
+    let member = node.context(member_ctx("member-1"))?;
+    let trx = member.begin();
+    let ada = trx.create(&User { name: "Ada".into() }).await?;
+    let user_id = ada.id();
+    let note = trx.create(&Note { owner: "member-1".into(), body: "mine".into() }).await?;
+    let note_id = note.id();
+    trx.commit().await?;
+
+    let guest = node.context(guest_ctx())?;
+
+    // The retrieval surface: the by-id get path (what a `Ref` follow runs).
+    assert_eq!(guest.get::<UserView>(user_id).await?.name()?, "Ada");
+
+    // Every predicate answers empty — id-shaped included. Predicate-shaped
+    // retrieval (and with it, named-row liveness) is the follow-up change.
+    assert_eq!(guest.fetch::<UserView>(format!("id = '{user_id}'").as_str()).await?.len(), 0, "an id predicate is still a scan");
+    assert_eq!(guest.fetch::<UserView>("true").await?.len(), 0, "a guest's roster scan answers empty");
+    assert_eq!(guest.fetch::<UserView>("name = 'Ada'").await?.len(), 0);
+
+    // Row scopes still bind by-id reads: no retrieve field on note, so the
+    // guest dies at the gate; a different member passes the gate and dies
+    // at the scope; the owner reads its row.
+    assert!(guest.get::<NoteView>(note_id).await.is_err(), "absent retrieve field, by-id read refused as before");
+    let other = node.context(member_ctx("member-2"))?;
+    assert!(other.get::<NoteView>(note_id).await.is_err(), "a scope still binds a by-id read");
+    assert_eq!(member.get::<NoteView>(note_id).await?.body()?, "mine");
+
+    // The member's roster is intact.
+    assert_eq!(member.fetch::<UserView>("true").await?.len(), 1);
+
+    Ok(())
+}


### PR DESCRIPTION
## Why

Community's guests hold user ids (message refs carry them) and need exactly those rows to render author names; the roster stays signed-in-only. A `Ref` follow travels the by-id path — the collection gate plus per-row `check_read`; `filter_predicate` never runs on it — and the policy layer had no tier between "may scan the collection" and nothing. Supersedes #460 (same vocabulary, enforcement at the right layer, zero core changes).

## What — the minimal form, by ruling

- `CollectionRules.retrieve: Option<String>` — privilege sufficient to read rows the caller can already **name**, via the by-id path only. Absent = retrieval requires `read`; existing policies mean what they always meant. ("Retrieval" is core's own lexicon for this operation: `retrieval.rs`, `RetrievalError`.)
- `can_access_collection` (the entry gate) admits retrieve-or-better — the widest read admission, and all a `Ref` follow consults. New `can_scan_collection` carries the old read-or-write semantics.
- `filter_predicate` becomes the scan refusal point — the mandatory counterweight to widening the gate: on unscoped collections, callers without scan privilege compose to `False` (empty, not an error — a tier limit, not a fault); in scope composition, the per-credential contribution check tightens to `can_scan_collection`; the `jwtpolicy` carve-out extends here (ephemeral nodes bootstrap policy under a deny-all config).
- **Every predicate is still a scan, id-shaped or not.** Predicate-shaped retrieval (`fetch_one("id = …")`, named-row LiveQueries for guest name-liveness) is a deliberate stacked follow-up, deferred by ruling to keep this — the `release/0.9` cherry-pick candidate — the smallest semantic delta.
- `check_read` untouched: row scope rules bind by-id reads exactly as before — a non-participant naming a scoped row's id is still refused.

## Pin updated deliberately

The empty-credential-set test recorded an unscoped collection returning the predicate untouched — an artifact of that arm trusting the entry gate to have refused already. The arm now checks scan privilege itself; the pin records `False` (the trait's empty-set guidance is fail-closed, and now it is).

## Coverage

`extensions/jwt-auth/tests/retrieval_privilege_tests.rs`: the wide-gate/narrow-scan split; every predicate shape composing to `False` at the retrieval tier (id-shaped included — pinned loudly); scan-tier pass-through unchanged; a retrieval credential contributing no slice to a scoped scan; end to end — the guest retrieves the named user by `get`, every predicate answers empty, the scoped row refuses the guest at the gate (absent `retrieve`), refuses the wrong member at the scope, and answers its owner. Full jwt-auth suite (17 binaries) green; fmt clean.

## First consumer

community adds one line — `user.retrieve: "view"` — and ankurah-chat resolves authors per-ref (`get_cached` snapshots for now; liveness arrives with the stacked PR). Cherry-pick PR to `release/0.9` after review.