### PR TITLE
0.9.2: backport the retrieve privilege, bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "ankql"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah-connector-local-process",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-connector-local-process"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah-derive",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-derive"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "maplit",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-model"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "getrandom 0.3.4",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "ankurah-doc-example-model",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-doc-example-wasm-bindings"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "ankurah-doc-example-model",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-example-server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "ankurah-storage-sled",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-jwt-auth"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-proto"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "anyhow",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-signals"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "js-sys",
  "reactive_graph",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-common"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah-core",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-indexeddb-wasm"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-postgres"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-sled"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-storage-sqlite"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankql",
  "ankurah",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-tests-wasm-bindings"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "ankurah-signals",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-client-wasm"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "ankurah-core",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "ankurah-websocket-server"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah-core",
  "ankurah-proto",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "example-model"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "chrono",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "example-wasm-bindings"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ankurah",
  "ankurah-signals",

--- a/RELEASES
+++ b/RELEASES
@@ -1,3 +1,4 @@
+0.9.2   jwt-auth retrieve privilege: optional per-collection tier admitting by-id reads (Ref follows, wire Get) below read; scans compose to False (empty, not error) for callers without scan privilege; jwtpolicy carve-out extended to filter_predicate
 0.9.1   Add portable ankurah-cli ak dump/load tooling for PostgreSQL, SQLite, and Sled with versioned checksummed logical dumps and rematerializing restores; harden release-branch-only publishing
 0.9.0   Concurrent updates: event-DAG causal comparison and layered per-property merge; LWW state buffers gain a one-byte version header (unversioned pre-0.9 buffers load via a legacy fallback and rewrite to the new format on next save); contributor internals documentation
 0.8.1   Fix ankurah-core wasm feature to enable ankql/wasm (0.8.0 publish verification failed for wasm storage/connector crates); add ankurah-jwt-auth to the publish list

--- a/ankql/Cargo.toml
+++ b/ankql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankql"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah Query Language - Aspirational query language for Ankurah in the style of Open Cypher and GQL (ISO/IEC 39075:2024)"
 license       = "MIT OR Apache-2.0"

--- a/ankurah/Cargo.toml
+++ b/ankurah/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Observable, event-driven state management for native and web"
 license       = "MIT OR Apache-2.0"
@@ -38,11 +38,11 @@ instrument = ["ankurah-core/instrument"]
 test-helpers = ["ankurah-core/test-helpers"]
 
 [dependencies]
-ankurah-core    = { path = "../core", version = "=0.9.1" }
-ankurah-proto   = { path = "../proto", version = "=0.9.1" }
-ankurah-derive  = { path = "../derive", version = "=0.9.1", optional = true }
-ankurah-signals = { path = "../signals", version = "=0.9.1" }
-ankql           = { path = "../ankql", version = "=0.9.1" }
+ankurah-core    = { path = "../core", version = "=0.9.2" }
+ankurah-proto   = { path = "../proto", version = "=0.9.2" }
+ankurah-derive  = { path = "../derive", version = "=0.9.2", optional = true }
+ankurah-signals = { path = "../signals", version = "=0.9.2" }
+ankql           = { path = "../ankql", version = "=0.9.2" }
 serde_json      = { version = "1.0" }
 serde           = { version = "1.0" }
 tracing         = { version = "0.1.40" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-cli"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Command-line tools for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -14,11 +14,11 @@ name = "ak"
 path = "src/main.rs"
 
 [dependencies]
-ankurah-core                 = { path = "../core", version = "=0.9.1" }
-ankurah-proto                = { path = "../proto", version = "=0.9.1" }
-ankurah-storage-postgres-0-9 = { package = "ankurah-storage-postgres", path = "../storage/postgres", version = "=0.9.1" }
-ankurah-storage-sled-0-9     = { package = "ankurah-storage-sled", path = "../storage/sled", version = "=0.9.1" }
-ankurah-storage-sqlite-0-9   = { package = "ankurah-storage-sqlite", path = "../storage/sqlite", version = "=0.9.1" }
+ankurah-core                 = { path = "../core", version = "=0.9.2" }
+ankurah-proto                = { path = "../proto", version = "=0.9.2" }
+ankurah-storage-postgres-0-9 = { package = "ankurah-storage-postgres", path = "../storage/postgres", version = "=0.9.2" }
+ankurah-storage-sled-0-9     = { package = "ankurah-storage-sled", path = "../storage/sled", version = "=0.9.2" }
+ankurah-storage-sqlite-0-9   = { package = "ankurah-storage-sqlite", path = "../storage/sqlite", version = "=0.9.2" }
 anyhow                       = "1.0"
 base64                       = "0.22"
 clap                         = { version = "4.5", features = ["derive", "env"] }
@@ -31,8 +31,8 @@ thiserror                    = "2.0"
 tokio                        = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]
-ankurah                = { path = "../ankurah", version = "=0.9.1", features = ["derive"] }
-ankql                  = { path = "../ankql", version = "=0.9.1" }
+ankurah                = { path = "../ankurah", version = "=0.9.2", features = ["derive"] }
+ankql                  = { path = "../ankql", version = "=0.9.2" }
 serde                  = { version = "1.0", features = ["derive"] }
 testcontainers         = { version = "0.23", features = ["reusable-containers"] }
 testcontainers-modules = { version = "0.11.4", features = ["postgres"] }

--- a/connectors/local-process/Cargo.toml
+++ b/connectors/local-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-connector-local-process"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah connector for local processes"
 license       = "MIT OR Apache-2.0"
@@ -9,8 +9,8 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core  = { path = "../../core", version = "=0.9.1" }
-ankurah-proto = { path = "../../proto", version = "=0.9.1" }
+ankurah-core  = { path = "../../core", version = "=0.9.2" }
+ankurah-proto = { path = "../../proto", version = "=0.9.2" }
 
 tokio       = { version = "1.40", features = ["full"] }
 async-trait = "0.1"

--- a/connectors/websocket-client-wasm/Cargo.toml
+++ b/connectors/websocket-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client-wasm"
-version       = "0.9.1"
+version       = "0.9.2"
 authors       = ["Daniel Norman <daniel@danielnorman.net>"]
 edition       = "2021"
 description   = "Ankurah WebSocket Client - A WebSocket client for Ankurah"
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.9.1" }
-ankurah-core       = { path = "../../core", version = "=0.9.1" }
-ankurah-proto      = { path = "../../proto", version = "=0.9.1", features = ["wasm"] }
-ankurah-derive     = { path = "../../derive", version = "=0.9.1" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.9.2" }
+ankurah-core       = { path = "../../core", version = "=0.9.2" }
+ankurah-proto      = { path = "../../proto", version = "=0.9.2", features = ["wasm"] }
+ankurah-derive     = { path = "../../derive", version = "=0.9.2" }
 serde              = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 

--- a/connectors/websocket-client/Cargo.toml
+++ b/connectors/websocket-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-client"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah WebSocket Client - Native WebSocket client for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -9,9 +9,9 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-core    = { path = "../../core", version = "=0.9.1" }
-ankurah-proto   = { path = "../../proto", version = "=0.9.1" }
-ankurah-signals = { path = "../../signals", version = "=0.9.1" }
+ankurah-core    = { path = "../../core", version = "=0.9.2" }
+ankurah-proto   = { path = "../../proto", version = "=0.9.2" }
+ankurah-signals = { path = "../../signals", version = "=0.9.2" }
 
 # WebSocket implementation
 tokio-tungstenite = { version = "0.27", features = ["native-tls"] }
@@ -33,6 +33,6 @@ url       = "2.0"
 strum     = { version = "0.27", features = ["derive"] }
 
 [dev-dependencies]
-ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.9.1" }
-ankurah-websocket-server = { path = "../websocket-server", version = "=0.9.1" }
-ankurah                  = { path = "../../ankurah", version = "=0.9.1", features = ["derive"] }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.9.2" }
+ankurah-websocket-server = { path = "../websocket-server", version = "=0.9.2" }
+ankurah                  = { path = "../../ankurah", version = "=0.9.2", features = ["derive"] }

--- a/connectors/websocket-server/Cargo.toml
+++ b/connectors/websocket-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-websocket-server"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah WebSocket Server - A WebSocket server for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ instrument = []
 [dependencies]
 
 # Base dependencies
-ankurah-proto          = { path = "../../proto", version = "=0.9.1" }
-ankurah-core           = { path = "../../core", version = "=0.9.1" }
+ankurah-proto          = { path = "../../proto", version = "=0.9.2" }
+ankurah-core           = { path = "../../core", version = "=0.9.2" }
 anyhow                 = "1.0"
 bincode                = "1.3"
 serde                  = { version = "1.0.203", features = ["derive", "serde_derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-core"
 description   = "Core state management functionality for Ankurah"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-core"
@@ -28,10 +28,10 @@ test-helpers = []
 
 [dependencies]
 # Internal dependencies
-ankurah-derive  = { path = "../derive", optional = true, version = "=0.9.1" }
-ankql           = { path = "../ankql", version = "=0.9.1" }
-ankurah-proto   = { path = "../proto", version = "=0.9.1" }
-ankurah-signals = { path = "../signals", version = "=0.9.1" }
+ankurah-derive  = { path = "../derive", optional = true, version = "=0.9.2" }
+ankql           = { path = "../ankql", version = "=0.9.2" }
+ankurah-proto   = { path = "../proto", version = "=0.9.2" }
+ankurah-signals = { path = "../signals", version = "=0.9.2" }
 
 rand                 = "0.8"
 anyhow               = "1.0"
@@ -64,4 +64,4 @@ uniffi               = { version = "0.29", optional = true }
 
 [dev-dependencies]
 maplit         = "1.0"
-ankurah-derive = { path = "../derive", version = "=0.9.1" }
+ankurah-derive = { path = "../derive", version = "=0.9.2" }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-derive"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah Derive - Derive macros for Ankurah"
 license       = "MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ syn = { version = "2.0", default-features = false, features = [
     "extra-traits",
 ] }
 serde_derive_internals = "0.29"
-ankql = { path = "../ankql", version = "=0.9.1" }
+ankql = { path = "../ankql", version = "=0.9.2" }
 regex = "1.0"
 ron = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/example/model/Cargo.toml
+++ b/docs/example/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-model"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [features]

--- a/docs/example/server/Cargo.toml
+++ b/docs/example/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-server"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]

--- a/docs/example/wasm-bindings/Cargo.toml
+++ b/docs/example/wasm-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-doc-example-wasm-bindings"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/examples/model/Cargo.toml
+++ b/examples/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "example-model"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 publish = false
 
@@ -9,7 +9,7 @@ default = []
 wasm    = ["dep:wasm-bindgen", "ankurah/wasm", "ankurah/react"]
 
 [dependencies]
-ankurah      = { path = "../../ankurah", features = ["derive"], version = "=0.9.1" }
+ankurah      = { path = "../../ankurah", features = ["derive"], version = "=0.9.2" }
 serde        = { version = "1.0", features = ["derive"] }
 serde_json   = "1.0"
 wasm-bindgen = { version = "0.2", optional = true }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name    = "ankurah-example-server"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 publish = false
 
 [dependencies]
-ankurah                  = { path = "../../ankurah", version = "=0.9.1" }
-ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "=0.9.1" }
-ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.9.1" }
+ankurah                  = { path = "../../ankurah", version = "=0.9.2" }
+ankurah-websocket-server = { path = "../../connectors/websocket-server", version = "=0.9.2" }
+ankurah-storage-sled     = { path = "../../storage/sled", version = "=0.9.2" }
 example-model            = { path = "../model" }
 tracing                  = "0.1"
 tracing-subscriber       = "0.3"

--- a/examples/wasm-bindings/Cargo.toml
+++ b/examples/wasm-bindings/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name    = "example-wasm-bindings"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.9.1" }
-ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "=0.9.1" }
-ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "=0.9.1" }
-ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "=0.9.1" }
-example-model                  = { path = "../model", features = ["wasm"], version = "=0.9.1" }
+ankurah                        = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.9.2" }
+ankurah-signals                = { path = "../../signals", features = ["wasm"], version = "=0.9.2" }
+ankurah-websocket-client-wasm  = { path = "../../connectors/websocket-client-wasm", version = "=0.9.2" }
+ankurah-storage-indexeddb-wasm = { path = "../../storage/indexeddb-wasm", version = "=0.9.2" }
+example-model                  = { path = "../model", features = ["wasm"], version = "=0.9.2" }
 wasm-bindgen                   = "0.2.84"
 wasm-bindgen-futures           = "0.4.42"
 wasm-logger                    = "0.2.0"

--- a/extensions/jwt-auth/Cargo.toml
+++ b/extensions/jwt-auth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "ankurah-jwt-auth"
 description = "JWT-based PolicyAgent for Ankurah"
-version     = "0.9.1"
+version     = "0.9.2"
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 homepage    = "https://github.com/ankurah/ankurah"
@@ -15,10 +15,10 @@ uniffi  = ["dep:uniffi"]
 
 [dependencies]
 # Internal dependencies
-ankurah       = { path = "../../ankurah", features = ["derive"], version = "=0.9.1" }
-ankurah-core  = { path = "../../core", version = "=0.9.1" }
-ankurah-proto = { path = "../../proto", version = "=0.9.1" }
-ankql         = { path = "../../ankql", version = "=0.9.1" }
+ankurah       = { path = "../../ankurah", features = ["derive"], version = "=0.9.2" }
+ankurah-core  = { path = "../../core", version = "=0.9.2" }
+ankurah-proto = { path = "../../proto", version = "=0.9.2" }
+ankql         = { path = "../../ankql", version = "=0.9.2" }
 
 # JWT
 jwt-simple = { version = "0.12", default-features = false, features = ["pure-rust"] }
@@ -46,6 +46,6 @@ tokio        = { version = "1", default-features = false, features = ["rt"] }
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
-ankurah-storage-sled            = { path = "../../storage/sled", version = "=0.9.1" }
-ankurah-connector-local-process = { path = "../../connectors/local-process", version = "=0.9.1" }
+ankurah-storage-sled            = { path = "../../storage/sled", version = "=0.9.2" }
+ankurah-connector-local-process = { path = "../../connectors/local-process", version = "=0.9.2" }
 tokio                           = { version = "1", features = ["full"] }

--- a/extensions/jwt-auth/src/agent.rs
+++ b/extensions/jwt-auth/src/agent.rs
@@ -214,6 +214,15 @@ impl PolicyAgent for JwtAgent {
 
     fn filter_predicate<C>(&self, data: &C, collection: &proto::CollectionId, predicate: Predicate) -> Result<Predicate, AccessDenied>
     where C: Iterable<Self::ContextData> {
+        // The policy collection is granted before any credential is
+        // consulted, mirroring can_access_collection's carve-out and for the
+        // same reason: an ephemeral node bootstraps its policy through a
+        // livequery on this collection while its config is still deny-all,
+        // and a scan-privilege check here (added with the `retrieve` tier)
+        // would compose that bootstrap query to False.
+        if collection.as_str() == "jwtpolicy" {
+            return Ok(predicate);
+        }
         for ctx in data.iterable() {
             if ctx.is_privileged() {
                 return Ok(predicate);
@@ -221,14 +230,40 @@ impl PolicyAgent for JwtAgent {
         }
 
         let state = self.state.read().unwrap_or_else(|e| e.into_inner());
+
         if state.config.scope_rules_for_collection(collection.as_str()).is_empty() {
-            return Ok(predicate);
+            // An unscoped collection passes a scan-privileged caller's
+            // predicate through untouched. Any other caller the entry gate
+            // admitted — which now includes retrieval-only credentials —
+            // scans nothing: False, an empty answer rather than an error,
+            // because arriving here at the retrieval tier is a tier limit
+            // and not a fault. Every predicate is a scan here, id-shaped or
+            // not: predicate-shaped retrieval (an id-bounded pass at this
+            // tier, for fetch_one("id = …") and named-row live queries) is
+            // a deliberate follow-up, not part of this change. (Before
+            // `retrieve` existed this arm passed unconditionally, and
+            // could: the entry gate had already refused every caller
+            // without read or write.)
+            for ctx in data.iterable() {
+                if state.config.can_scan_collection(ctx.roles(), collection) {
+                    return Ok(predicate);
+                }
+            }
+            return Ok(Predicate::False);
         }
 
+        // Only a scan-authorized credential may stand for the caller here:
+        // a retrieval-only credential reads rows it names, never rows a
+        // scan surfaces, so its scope must not be composed into a query it
+        // could never run (the entry gate now admits it; this arm must
+        // not). Backport note: main composes the union of every authorized
+        // credential's scope here; this branch keeps its single-credential
+        // shape, so the check rides the same find_map that picks the
+        // credential.
         let claims = data
             .iterable()
             .find_map(|ctx| match ctx {
-                JwtContext::User { claims, .. } => Some(claims),
+                JwtContext::User { claims, .. } if state.config.can_scan_collection(ctx.roles(), collection) => Some(claims),
                 _ => None,
             })
             .ok_or(AccessDenied::ByPolicy("No authenticated context for row filtering"))?;

--- a/extensions/jwt-auth/src/config.rs
+++ b/extensions/jwt-auth/src/config.rs
@@ -61,6 +61,21 @@ pub struct CollectionRules {
     /// Privilege required to read entities in this collection (None = no access)
     pub read: Option<String>,
 
+    /// Privilege sufficient to RETRIEVE rows the caller can already name —
+    /// a `Ref` follow and the by-id wire path (`Get{ids}`) — without
+    /// admitting scans. Predicates are all scans for now, even id-shaped
+    /// ones; admitting id-bounded predicates at this tier is a deliberate
+    /// follow-up. None = retrieval requires `read`, the pre-existing
+    /// behavior, so a policy written before this field existed means what
+    /// it always meant. This exists for collections whose rows are public
+    /// to whoever holds their ids while the roster stays private: "any
+    /// holder of a user's id may retrieve that user; only the signed-in may
+    /// list users." `read` or `write` always suffice for a retrieval, and
+    /// row scope rules still bind per row (`check_read` is unchanged by
+    /// this field).
+    #[serde(default)]
+    pub retrieve: Option<String>,
+
     /// Privilege required to write (create/update) entities in this collection (None = no access)
     pub write: Option<String>,
 
@@ -70,8 +85,52 @@ pub struct CollectionRules {
 }
 
 impl PolicyConfig {
-    /// Check if any of the given roles can access a collection (read or write).
+    /// The collection admission gate: true when any role holds `read`,
+    /// `write`, or `retrieve` privilege. Deliberately the WIDEST read
+    /// admission — it is what admits a retrieval-tier caller's `Ref`
+    /// follow: the by-id wire path checks only this gate plus per-row
+    /// `check_read`. Scans are refused downstream in `filter_predicate`,
+    /// which composes to `False` for callers this gate admitted without
+    /// scan privilege. Use [`Self::can_scan_collection`] where only
+    /// scan-privileged credentials may count.
     pub fn can_access_collection(&self, roles: &[String], collection: &CollectionId) -> bool {
+        for role in roles {
+            if self.role_has_wildcard(role) {
+                return true;
+            }
+        }
+
+        let collection_name = collection.as_str();
+        if let Some(rules) = self.collections.get(collection_name) {
+            for role in roles {
+                let privileges = self.privileges_for_role(role);
+                if let Some(ref read_priv) = rules.read {
+                    if privileges.contains(&read_priv.as_str()) {
+                        return true;
+                    }
+                }
+                if let Some(ref write_priv) = rules.write {
+                    if privileges.contains(&write_priv.as_str()) {
+                        return true;
+                    }
+                }
+                if let Some(ref retrieve_priv) = rules.retrieve {
+                    if privileges.contains(&retrieve_priv.as_str()) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    /// True when any role may run a SCAN — a predicate query, subscription,
+    /// or listing — against the collection: `read` or `write` privilege
+    /// (exactly what [`Self::can_access_collection`] meant before
+    /// `retrieve` existed). `retrieve` deliberately does not count here:
+    /// naming rows is the whole of what it grants.
+    pub fn can_scan_collection(&self, roles: &[String], collection: &CollectionId) -> bool {
         for role in roles {
             if self.role_has_wildcard(role) {
                 return true;

--- a/extensions/jwt-auth/tests/fixtures/retrieval_privilege.json
+++ b/extensions/jwt-auth/tests/fixtures/retrieval_privilege.json
@@ -1,0 +1,22 @@
+{
+  "roles": {
+    "guest": ["view"],
+    "member": ["view", "signed_in"]
+  },
+  "collections": {
+    "user": {
+      "read": "signed_in",
+      "retrieve": "view",
+      "write": "signed_in"
+    },
+    "note": {
+      "read": "signed_in",
+      "write": "signed_in",
+      "scope": [{ "filter": "owner = $jwt.sub" }]
+    },
+    "message": {
+      "read": "view",
+      "write": "signed_in"
+    }
+  }
+}

--- a/extensions/jwt-auth/tests/retrieval_privilege_tests.rs
+++ b/extensions/jwt-auth/tests/retrieval_privilege_tests.rs
@@ -1,0 +1,192 @@
+//! The `retrieve` privilege: rows to whoever names them, scans to the
+//! privileged.
+//!
+//! The shape under test is community's user directory: message authors
+//! carry user ids (refs), so a guest rendering names needs exactly the rows
+//! it can name — never the roster. `retrieve` admits the by-id path (`Ref`
+//! follows, `get`); every predicate remains a scan for now, even id-shaped
+//! ones — admitting id-bounded predicates at this tier is a deliberate
+//! follow-up. Scans compose to `False` (empty, not an error) for a caller
+//! the gate admitted without scan privilege; row scope rules still bind
+//! by-id reads; and a policy without the field means what it always meant.
+
+mod common;
+
+use ankql::ast::Predicate;
+use ankurah::policy::PolicyAgent;
+use ankurah::{Model, Node};
+use ankurah_jwt_auth::{JwtAgent, JwtContext, PolicyConfig};
+use ankurah_proto::CollectionId;
+use ankurah_storage_sled::SledStorageEngine;
+use common::{make_claims, sign_token};
+use std::sync::Arc;
+
+fn config_path() -> String { format!("{}/tests/fixtures/retrieval_privilege.json", env!("CARGO_MANIFEST_DIR")) }
+
+fn load_config() -> PolicyConfig { serde_json::from_str(&std::fs::read_to_string(config_path()).unwrap()).unwrap() }
+
+fn parse(predicate: &str) -> Predicate { ankql::parser::parse_selection(predicate).unwrap().predicate }
+
+fn agent() -> JwtAgent { JwtAgent::new_durable(common::test_keys(), config_path()).unwrap() }
+
+fn guest_ctx() -> JwtContext {
+    let claims = make_claims("guest", &["guest"], "");
+    let token = sign_token(&common::test_keys(), &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+fn member_ctx(sub: &str) -> JwtContext {
+    let claims = make_claims(sub, &["member"], "member@example.com");
+    let token = sign_token(&common::test_keys(), &claims);
+    JwtContext::from_claims(claims, token)
+}
+
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct User {
+    pub name: String,
+}
+
+/// A row-scoped collection (`owner = $jwt.sub`), for pinning that scopes
+/// keep binding by-id reads and that an absent `retrieve` field weakens
+/// nothing.
+#[derive(Model, Debug, serde::Serialize, serde::Deserialize)]
+pub struct Note {
+    pub owner: String,
+    pub body: String,
+}
+
+/// The gate split at the config tier: the entry gate admits the retrieval
+/// tier, the scan check does not.
+#[test]
+fn gate_is_wide_and_scan_check_is_narrow() {
+    let config = load_config();
+    let guest = [String::from("guest")];
+    let member = [String::from("member")];
+    let user = CollectionId::fixed_name("user");
+    let note = CollectionId::fixed_name("note");
+
+    assert!(config.can_access_collection(&guest, &user), "retrieval admits the entry gate");
+    assert!(!config.can_scan_collection(&guest, &user), "retrieval never admits a scan");
+    assert!(config.can_access_collection(&member, &user));
+    assert!(config.can_scan_collection(&member, &user));
+
+    // No retrieve field on note: the gate means what it meant before the
+    // field existed.
+    assert!(!config.can_access_collection(&guest, &note), "absent retrieve field, no weakening");
+}
+
+/// At the retrieval tier every predicate is a scan and composes to `False`
+/// — empty, not an error — INCLUDING id-shaped ones: predicate-shaped
+/// retrieval is the deliberate follow-up, and until it lands the only
+/// retrieval surface is the by-id get path.
+#[test]
+fn retrieval_tier_scans_nothing() {
+    let agent = agent();
+    let user = CollectionId::fixed_name("user");
+    let guest = vec![guest_ctx()];
+
+    for scan in [
+        "true",
+        "name = 'Ada'",
+        "id = '5xEQjLcNhFLTKwyy2DZzHU'",
+        "id IN ('5xEQjLcNhFLTKwyy2DZzHU', '5xEQjLcNhFLTKwyy2DZzHV')",
+        "id > '5xEQjLcNhFLTKwyy2DZzHU'",
+        "id = '5xEQjLcNhFLTKwyy2DZzHU' AND name = 'Ada'",
+    ] {
+        let out = agent.filter_predicate(&guest, &user, parse(scan)).unwrap();
+        assert_eq!(out, Predicate::False, "every predicate is a scan at the retrieval tier: {scan}");
+    }
+}
+
+/// An empty credential set scans nothing on an unscoped collection: the
+/// unscoped arm checks scan privilege itself now, instead of trusting the
+/// entry gate to have refused already, and an empty set holds none. (This
+/// pin lives in the main branch's filter_predicate_tests; that file's
+/// multi-credential suite is not on this branch, so the backport pins the
+/// changed arm here.)
+#[test]
+fn empty_credential_set_scans_nothing_unscoped() {
+    let agent = agent();
+    let user = CollectionId::fixed_name("user");
+    let nobody: Vec<JwtContext> = Vec::new();
+
+    let out = agent.filter_predicate(&nobody, &user, parse("true")).unwrap();
+    assert_eq!(out, Predicate::False, "an empty set holds no scan privilege: nothing");
+}
+
+/// The same shapes for a scan-privileged caller are untouched — the
+/// unscoped-collection fast path is unchanged for readers.
+#[test]
+fn scan_tier_predicates_pass_untouched() {
+    let agent = agent();
+    let user = CollectionId::fixed_name("user");
+    let member = vec![member_ctx("member-1")];
+
+    for predicate in ["true", "name = 'Ada'", "id = '5xEQjLcNhFLTKwyy2DZzHU'"] {
+        let out = agent.filter_predicate(&member, &user, parse(predicate)).unwrap();
+        assert_eq!(out, parse(predicate), "read privilege scans freely: {predicate}");
+    }
+}
+
+/// On a scoped collection, a retrieval-only credential contributes no slice
+/// to scan composition — today's refusal texture for a caller with no
+/// scan-authorized credential is preserved.
+#[test]
+fn retrieval_credential_never_widens_a_scoped_scan() {
+    let agent = agent();
+    let note = CollectionId::fixed_name("note");
+
+    // The guest's only privilege is view; note grants view nothing. The
+    // scan reaches the scoped arm and no credential contributes a slice.
+    let guest = vec![guest_ctx()];
+    assert!(agent.filter_predicate(&guest, &note, parse("true")).is_err(), "no scan-authorized credential, refused as before");
+
+    // A member scans its own slice, composed as before.
+    let member = vec![member_ctx("member-1")];
+    let out = agent.filter_predicate(&member, &note, parse("true")).unwrap();
+    assert_eq!(out.to_string(), parse("true AND owner = 'member-1'").to_string(), "scope composition unchanged for scanners");
+}
+
+/// End to end through a node: the guest retrieves the user it names by the
+/// get path, is answered empty (not an error) for every predicate — even an
+/// id-shaped one — and row scopes still bind by-id reads on the scoped
+/// collection.
+#[tokio::test]
+async fn guest_retrieves_named_rows_and_scans_nothing() -> anyhow::Result<()> {
+    let keys = common::test_keys();
+    let agent = JwtAgent::new_durable(keys.clone(), config_path())?;
+    let node = Node::new_durable(Arc::new(SledStorageEngine::new_test()?), agent);
+    node.system.create().await?;
+
+    let member = node.context(member_ctx("member-1"))?;
+    let trx = member.begin();
+    let ada = trx.create(&User { name: "Ada".into() }).await?;
+    let user_id = ada.id();
+    let note = trx.create(&Note { owner: "member-1".into(), body: "mine".into() }).await?;
+    let note_id = note.id();
+    trx.commit().await?;
+
+    let guest = node.context(guest_ctx())?;
+
+    // The retrieval surface: the by-id get path (what a `Ref` follow runs).
+    assert_eq!(guest.get::<UserView>(user_id).await?.name()?, "Ada");
+
+    // Every predicate answers empty — id-shaped included. Predicate-shaped
+    // retrieval (and with it, named-row liveness) is the follow-up change.
+    assert_eq!(guest.fetch::<UserView>(format!("id = '{user_id}'").as_str()).await?.len(), 0, "an id predicate is still a scan");
+    assert_eq!(guest.fetch::<UserView>("true").await?.len(), 0, "a guest's roster scan answers empty");
+    assert_eq!(guest.fetch::<UserView>("name = 'Ada'").await?.len(), 0);
+
+    // Row scopes still bind by-id reads: no retrieve field on note, so the
+    // guest dies at the gate; a different member passes the gate and dies
+    // at the scope; the owner reads its row.
+    assert!(guest.get::<NoteView>(note_id).await.is_err(), "absent retrieve field, by-id read refused as before");
+    let other = node.context(member_ctx("member-2"))?;
+    assert!(other.get::<NoteView>(note_id).await.is_err(), "a scope still binds a by-id read");
+    assert_eq!(member.get::<NoteView>(note_id).await?.body()?, "mine");
+
+    // The member's roster is intact.
+    assert_eq!(member.fetch::<UserView>("true").await?.len(), 1);
+
+    Ok(())
+}

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "ankurah-proto"
 description   = "Inter-node communication protocol for Ankurah"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 license       = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/ankurah-proto"
@@ -23,7 +23,7 @@ serde              = { version = "1.0.204", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 ulid               = { version = "1.1.3", features = ["serde"] }
 base64             = { version = "0.22" }
-ankql              = { path = "../ankql", version = "=0.9.1" }
+ankql              = { path = "../ankql", version = "=0.9.2" }
 sha2               = "0.10.8"
 postgres-types     = { version = "0.2", optional = true }
 postgres-protocol  = { version = "0.6", optional = true }

--- a/signals/Cargo.toml
+++ b/signals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-signals"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2024"
 description   = "Ankurah Signals"
 license       = "MIT OR Apache-2.0"

--- a/storage/common/Cargo.toml
+++ b/storage/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-common"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2024"
 description   = "Ankurah storage engine common libraries"
 license       = "MIT OR Apache-2.0"
@@ -9,13 +9,13 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankql         = { path = "../../ankql", version = "=0.9.1" }
-ankurah-core  = { path = "../../core", version = "=0.9.1" }
-ankurah-proto = { path = "../../proto", version = "=0.9.1" }
+ankql         = { path = "../../ankql", version = "=0.9.2" }
+ankurah-core  = { path = "../../core", version = "=0.9.2" }
+ankurah-proto = { path = "../../proto", version = "=0.9.2" }
 futures       = "0.3"
 indexmap      = "2.0"
 serde         = { version = "1.0", features = ["derive"] }
 tracing       = { version = "0.1.40" }
 
 [dev-dependencies]
-ankurah-derive = { path = "../../derive", version = "=0.9.1" }
+ankurah-derive = { path = "../../derive", version = "=0.9.2" }

--- a/storage/indexeddb-wasm/Cargo.toml
+++ b/storage/indexeddb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-indexeddb-wasm"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah storage engine using IndexedDB in the browser"
 license       = "MIT OR Apache-2.0"
@@ -15,11 +15,11 @@ crate-type = ["cdylib", "rlib"]
 default = []
 
 [dependencies]
-ankurah-core           = { path = "../../core", version = "=0.9.1", features = ["wasm"] }
-ankurah-proto          = { path = "../../proto", version = "=0.9.1", features = ["wasm"] }
-ankql                  = { path = "../../ankql", version = "=0.9.1" }
-ankurah-derive         = { path = "../../derive", version = "=0.9.1", features = ["wasm"] }
-ankurah-storage-common = { path = "../common", version = "=0.9.1" }
+ankurah-core           = { path = "../../core", version = "=0.9.2", features = ["wasm"] }
+ankurah-proto          = { path = "../../proto", version = "=0.9.2", features = ["wasm"] }
+ankql                  = { path = "../../ankql", version = "=0.9.2" }
+ankurah-derive         = { path = "../../derive", version = "=0.9.2", features = ["wasm"] }
+ankurah-storage-common = { path = "../common", version = "=0.9.2" }
 serde                  = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen     = "0.6"
 tokio                  = { version = "1.39", features = ["sync"] }
@@ -80,7 +80,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 #[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 [dev-dependencies]
 wasm-bindgen-test  = "0.3"
-ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.9.1" }
+ankurah            = { path = "../../ankurah", features = ["derive", "wasm"], version = "=0.9.2" }
 tracing-subscriber = "0.3"
 
     [package.metadata.wasm-pack.profile.dev.wasm-bindgen]

--- a/storage/postgres/Cargo.toml
+++ b/storage/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-postgres"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah storage engine using Postgres"
 license       = "MIT OR Apache-2.0"
@@ -19,16 +19,16 @@ anyhow         = "1.0"
 thiserror      = "2.0"
 tokio          = { version = "1.36", features = ["full"] }
 
-ankql         = { path = "../../ankql", version = "=0.9.1" }
-ankurah-core  = { path = "../../core", version = "=0.9.1" }
-ankurah-proto = { path = "../../proto", version = "=0.9.1", features = ["postgres"] }
+ankql         = { path = "../../ankql", version = "=0.9.2" }
+ankurah-core  = { path = "../../core", version = "=0.9.2" }
+ankurah-proto = { path = "../../proto", version = "=0.9.2", features = ["postgres"] }
 tracing       = "0.1"
 async-trait   = "0.1"
 futures-util  = "0.3"
 bytes         = "1.5"
 
 [dev-dependencies]
-ankurah                = { path = "../../ankurah", version = "=0.9.1", features = ["derive"] }
+ankurah                = { path = "../../ankurah", version = "=0.9.2", features = ["derive"] }
 tokio                  = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber     = "0.3"
 ctor                   = "0.2"

--- a/storage/sled/Cargo.toml
+++ b/storage/sled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-sled"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah storage engine using Sled"
 license       = "MIT OR Apache-2.0"
@@ -9,10 +9,10 @@ homepage      = "https://github.com/ankurah/ankurah"
 repository    = "https://github.com/ankurah/ankurah"
 
 [dependencies]
-ankurah-proto          = { path = "../../proto", version = "=0.9.1" }
-ankurah-core           = { path = "../../core", version = "=0.9.1" }
-ankql                  = { path = "../../ankql", version = "=0.9.1" }
-ankurah-storage-common = { path = "../common", version = "=0.9.1" }
+ankurah-proto          = { path = "../../proto", version = "=0.9.2" }
+ankurah-core           = { path = "../../core", version = "=0.9.2" }
+ankql                  = { path = "../../ankql", version = "=0.9.2" }
+ankurah-storage-common = { path = "../common", version = "=0.9.2" }
 anyhow                 = "1.0"
 async-trait            = "0.1"
 futures                = "0.3"
@@ -28,6 +28,6 @@ tracing                = "0.1"
 thiserror              = "2.0"
 
 [dev-dependencies]
-ankurah            = { path = "../../ankurah", version = "=0.9.1", features = ["derive"] }
+ankurah            = { path = "../../ankurah", version = "=0.9.2", features = ["derive"] }
 ctor               = "0.5"
 tracing-subscriber = "0.3"

--- a/storage/sqlite/Cargo.toml
+++ b/storage/sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ankurah-storage-sqlite"
-version       = "0.9.1"
+version       = "0.9.2"
 edition       = "2021"
 description   = "Ankurah storage engine using SQLite"
 license       = "MIT OR Apache-2.0"
@@ -30,13 +30,13 @@ serde        = { version = "1.0", features = ["derive"] }
 serde_json   = "1"
 
 # Ankurah workspace dependencies
-ankql                  = { path = "../../ankql", version = "=0.9.1" }
-ankurah-core           = { path = "../../core", version = "=0.9.1" }
-ankurah-proto          = { path = "../../proto", version = "=0.9.1" }
-ankurah-storage-common = { path = "../common", version = "=0.9.1" }
+ankql                  = { path = "../../ankql", version = "=0.9.2" }
+ankurah-core           = { path = "../../core", version = "=0.9.2" }
+ankurah-proto          = { path = "../../proto", version = "=0.9.2" }
+ankurah-storage-common = { path = "../common", version = "=0.9.2" }
 
 [dev-dependencies]
 tokio              = { version = "1", features = ["rt-multi-thread", "macros"] }
-ankurah            = { path = "../../ankurah", version = "=0.9.1", features = ["derive"] }
+ankurah            = { path = "../../ankurah", version = "=0.9.2", features = ["derive"] }
 tracing-subscriber = "0.3"
 ctor               = "0.2"

--- a/tests-wasm/bindings/Cargo.toml
+++ b/tests-wasm/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ankurah-tests-wasm-bindings"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name    = "ankurah-tests"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 publish = false
 
 [dependencies]
 anyhow = "1.0"
 tracing = "0.1"
-ankql = { path = "../ankql", version = "=0.9.1" }
+ankql = { path = "../ankql", version = "=0.9.2" }
 ankurah = { path = "../ankurah", features = [
     "derive",
     "instrument",
     "test-helpers",
-], version = "=0.9.1" }
-ankurah-storage-sled = { path = "../storage/sled", version = "=0.9.1" }
-ankurah-connector-local-process = { path = "../connectors/local-process", version = "=0.9.1" }
-ankurah-websocket-client = { path = "../connectors/websocket-client", version = "=0.9.1" }
-ankurah-websocket-server = { path = "../connectors/websocket-server", version = "=0.9.1" }
-ankurah-storage-common = { path = "../storage/common", version = "=0.9.1" }
+], version = "=0.9.2" }
+ankurah-storage-sled = { path = "../storage/sled", version = "=0.9.2" }
+ankurah-connector-local-process = { path = "../connectors/local-process", version = "=0.9.2" }
+ankurah-websocket-client = { path = "../connectors/websocket-client", version = "=0.9.2" }
+ankurah-websocket-server = { path = "../connectors/websocket-server", version = "=0.9.2" }
+ankurah-storage-common = { path = "../storage/common", version = "=0.9.2" }
 tokio = { version = "1.40", features = ["full"] }
 tracing-subscriber = "0.3"
 ctor = "0.2"


### PR DESCRIPTION
Backport of #462 (main 161114d5) to `release/0.9`, plus the lockstep 0.9.2 bump — the release community's server consumes for guest author names.

## The backport, adapted where the branches diverge

- `release/0.9` keeps the pre-union **single-credential** `filter_predicate` (main's union-of-credential-scopes rewrite never shipped here), so the new scan-privilege check rides the existing `find_map` that selects the credential: a retrieval-only credential is no longer eligible to stand for the caller in scope composition. Same semantics as main's per-credential check, expressed in this branch's shape; the divergence is recorded in the commit message and a code comment.
- Main's empty-credential-set pin update targets a test that only exists in main's multi-credential suite; the backport pins the changed behavior (unscoped + empty set → `False`) in `retrieval_privilege_tests.rs` instead.
- Everything else applied clean: the `retrieve` field, the widened gate + `can_scan_collection`, the `jwtpolicy` carve-out in `filter_predicate`, the fixture, and the test suite.

## Release 0.9.2

27 manifests 0.9.1 → 0.9.2 (lockstep, mirroring the 0.9.1 release commit), `Cargo.lock` regenerated, `RELEASES` line added.

## Gates

Full jwt-auth suite green on this branch (16 binaries, including the 6 retrieval pins with the relocated empty-set pin); `cargo check` and `cargo fmt --check` clean post-bump.

First consumer after publish: community pins `=0.9.2` and adds `user.retrieve: "view"` to policy.json.