### PR TITLE
core: backport Value correctness fixes

### DIFF
--- a/core/src/collation.rs
+++ b/core/src/collation.rs
@@ -51,8 +51,8 @@ impl Collatable for ast::Literal {
     fn to_bytes(&self) -> Vec<u8> {
         match self {
             ast::Literal::String(s) => s.as_bytes().to_vec(),
-            ast::Literal::I16(i) => i.to_be_bytes().to_vec(),
-            ast::Literal::I32(i) => i.to_be_bytes().to_vec(),
+            ast::Literal::I16(i) => (*i as i64).to_be_bytes().to_vec(),
+            ast::Literal::I32(i) => (*i as i64).to_be_bytes().to_vec(),
             ast::Literal::I64(i) => i.to_be_bytes().to_vec(),
             ast::Literal::F64(f) => {
                 let bits = if f.is_nan() {
@@ -95,14 +95,14 @@ impl Collatable for ast::Literal {
                 if *i == i16::MAX {
                     None
                 } else {
-                    Some((i + 1).to_be_bytes().to_vec())
+                    Some(((*i as i64) + 1).to_be_bytes().to_vec())
                 }
             }
             ast::Literal::I32(i) => {
                 if *i == i32::MAX {
                     None
                 } else {
-                    Some((i + 1).to_be_bytes().to_vec())
+                    Some(((*i as i64) + 1).to_be_bytes().to_vec())
                 }
             }
             ast::Literal::I64(i) => {
@@ -122,7 +122,7 @@ impl Collatable for ast::Literal {
                 }
             }
             ast::Literal::Bool(b) => {
-                if !b {
+                if *b {
                     None
                 } else {
                     Some(vec![1])
@@ -179,14 +179,14 @@ impl Collatable for ast::Literal {
                 if *i == i16::MIN {
                     None
                 } else {
-                    Some((i - 1).to_be_bytes().to_vec())
+                    Some(((*i as i64) - 1).to_be_bytes().to_vec())
                 }
             }
             ast::Literal::I32(i) => {
                 if *i == i32::MIN {
                     None
                 } else {
-                    Some((i - 1).to_be_bytes().to_vec())
+                    Some(((*i as i64) - 1).to_be_bytes().to_vec())
                 }
             }
             ast::Literal::I64(i) => {

--- a/core/src/reactor/comparison_index.rs
+++ b/core/src/reactor/comparison_index.rs
@@ -177,4 +177,29 @@ mod tests {
         assert_eq!(index.find_matching(Value::I64(8)).collect::<Vec<_>>(), vec![]);
         assert_eq!(index.find_matching(Value::I64(9)).collect::<Vec<_>>(), vec![sub0]);
     }
+
+    #[test]
+    fn test_narrow_integer_literals_match_values() {
+        let mut i16_index = ComparisonIndex::<proto::QueryId>::new();
+        let mut i32_index = ComparisonIndex::<proto::QueryId>::new();
+        let i16_sub = proto::QueryId::test(0);
+        let i32_sub = proto::QueryId::test(1);
+
+        i16_index.add(ast::Literal::I16(8), ast::ComparisonOperator::Equal, i16_sub);
+        i32_index.add(ast::Literal::I32(8), ast::ComparisonOperator::Equal, i32_sub);
+
+        assert_eq!(i16_index.find_matching(Value::I16(8)).collect::<Vec<_>>(), vec![i16_sub]);
+        assert_eq!(i32_index.find_matching(Value::I32(8)).collect::<Vec<_>>(), vec![i32_sub]);
+    }
+
+    #[test]
+    fn test_less_than_or_equal_false_matches_false() {
+        let mut index = ComparisonIndex::<proto::QueryId>::new();
+        let sub = proto::QueryId::test(0);
+
+        index.add(ast::Literal::Bool(false), ast::ComparisonOperator::LessThanOrEqual, sub);
+
+        assert_eq!(index.find_matching(Value::Bool(false)).collect::<Vec<_>>(), vec![sub]);
+        assert_eq!(index.find_matching(Value::Bool(true)).collect::<Vec<_>>(), vec![]);
+    }
 }

--- a/core/src/value/cast.rs
+++ b/core/src/value/cast.rs
@@ -102,7 +102,7 @@ impl Value {
                 }
             }
             (Value::F64(n), ValueType::I64) => {
-                if n.is_finite() && *n >= i64::MIN as f64 && *n <= i64::MAX as f64 {
+                if n.is_finite() && *n >= i64::MIN as f64 && *n < i64::MAX as f64 {
                     Ok(Value::I64(*n as i64))
                 } else {
                     Err(CastError::NumericOverflow { value: n.to_string(), target_type: ValueType::I64 })
@@ -262,6 +262,13 @@ mod tests {
 
         let large_value = Value::I32(100000);
         assert!(matches!(large_value.cast_to(ValueType::I16), Err(CastError::NumericOverflow { .. })));
+    }
+
+    #[test]
+    fn test_f64_at_two_pow_63_overflows_i64() {
+        let two_pow_63 = 9_223_372_036_854_775_808.0_f64;
+
+        assert!(matches!(Value::F64(two_pow_63).cast_to(ValueType::I64), Err(CastError::NumericOverflow { .. })));
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

Backports the Value correctness fixes from #470 to `release/0.9` without bringing the value-unification refactor onto the release branch.

AnkQL narrow-integer literals now use the same full-width comparison-index keys as property values, `<= false` registers the correct watcher bound, and casting the floating-point value `2^63` to `i64` reports numeric overflow instead of saturating to `i64::MAX`.
