### PR TITLE
signals: deterministic dispatch feature, Mut::update, and wait lost-wakeup fix

### DIFF
--- a/signals/Cargo.toml
+++ b/signals/Cargo.toml
@@ -23,6 +23,9 @@ singlethread = []
 # Global observer stack - for cross-thread environments like React Native
 # Only active when singlethread is NOT enabled
 multithread = []
+# Broadcast dispatch in subscription order (BTreeMap listener map instead of HashMap)
+# For consumers that need run-to-run reproducibility, like deterministic simulators
+deterministic = []
 
 [dependencies]
 tokio          = { version = "1.40", features = ["sync"], optional = true }

--- a/signals/src/broadcast.rs
+++ b/signals/src/broadcast.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Weak};
 
@@ -35,8 +34,17 @@ pub trait IntoBroadcastListener<T> {
 #[derive(Clone)]
 pub struct Broadcast<T = ()>(Arc<Inner<T>>);
 
+// `send` dispatches by iterating this map, so the map type decides dispatch order.
+// The default HashMap iterates in arbitrary order; the `deterministic`
+// feature swaps in a BTreeMap so listeners fire in subscription-id order, which
+// is subscription order because ids are allocated monotonically.
+#[cfg(not(feature = "deterministic"))]
+type ListenerMap<T> = std::collections::HashMap<usize, BroadcastListener<T>>;
+#[cfg(feature = "deterministic")]
+type ListenerMap<T> = std::collections::BTreeMap<usize, BroadcastListener<T>>;
+
 struct Inner<T> {
-    listeners: std::sync::RwLock<HashMap<usize, BroadcastListener<T>>>,
+    listeners: std::sync::RwLock<ListenerMap<T>>,
     next_id: AtomicUsize,
 }
 
@@ -86,7 +94,7 @@ impl<T> Broadcast<T>
 where T: Clone
 {
     /// Creates a new Broadcast struct
-    pub fn new() -> Self { Self(Arc::new(Inner { listeners: std::sync::RwLock::new(HashMap::new()), next_id: AtomicUsize::new(0) })) }
+    pub fn new() -> Self { Self(Arc::new(Inner { listeners: std::sync::RwLock::new(ListenerMap::new()), next_id: AtomicUsize::new(0) })) }
 
     /// Get the unique identifier for this broadcast
     pub fn id(&self) -> BroadcastId { BroadcastId(Arc::as_ptr(&self.0) as usize) }
@@ -265,6 +273,29 @@ mod tests {
 
         // Should have been called once
         assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    #[cfg(feature = "deterministic")]
+    fn test_deterministic_dispatch_order() {
+        let sender = Broadcast::<()>::new();
+        let order = Arc::new(Mutex::new(Vec::new()));
+
+        let mut guards: Vec<_> = (0..10)
+            .map(|i| {
+                let order = order.clone();
+                sender.reference().listen(move |_| order.lock().unwrap().push(i))
+            })
+            .collect();
+
+        sender.send(());
+        assert_eq!(*order.lock().unwrap(), (0..10).collect::<Vec<_>>());
+
+        // Dropping a middle subscriber leaves the rest firing in subscription order
+        drop(guards.remove(4));
+        order.lock().unwrap().clear();
+        sender.send(());
+        assert_eq!(*order.lock().unwrap(), vec![0, 1, 2, 3, 5, 6, 7, 8, 9]);
     }
 
     #[test]

--- a/signals/src/porcelain/wait.rs
+++ b/signals/src/porcelain/wait.rs
@@ -45,9 +45,9 @@ where
 {
     async fn wait_value(&self, target_value: T)
     where T: PartialEq + Clone + Send + Sync {
-        // Check if current value already matches
-
         use std::sync::Arc;
+
+        // Fast path: return without subscribing if the value already matches
         if self.get_readcell().with(|v| *v == target_value) {
             return;
         }
@@ -59,6 +59,11 @@ where
         let _subscription = self.listen(Arc::new(move |_| {
             let _ = tx.send(());
         }));
+
+        // Re-check after subscribing
+        if self.get_readcell().with(|v| *v == target_value) {
+            return;
+        }
 
         // Loop over notifications until we find a match
         loop {
@@ -82,9 +87,9 @@ where
         R: WaitResult,
         T: Send + Sync,
     {
-        // Check current value first
-
         use std::sync::Arc;
+
+        // Fast path: return without subscribing if the predicate is already satisfied
         if let Some(result) = self.get_readcell().with(|value| predicate(value).result()) {
             return result;
         }
@@ -96,6 +101,11 @@ where
         let _subscription = self.listen(Arc::new(move |_| {
             let _ = tx.send(());
         }));
+
+        // Re-check after subscribing
+        if let Some(result) = self.get_readcell().with(|value| predicate(value).result()) {
+            return result;
+        }
 
         // Wait for notifications
         loop {

--- a/signals/src/signal/mutable.rs
+++ b/signals/src/signal/mutable.rs
@@ -27,6 +27,18 @@ impl<T: 'static> Mut<T> {
         self.broadcast.send(());
     }
 
+    /// Mutates the value in place and notifies listeners.
+    ///
+    /// The closure runs under the value's write lock, and the lock is released
+    /// before listeners are notified, so a listener that immediately re-reads
+    /// never executes under the writer's lock. Listeners are notified even if
+    /// the closure leaves the value unchanged.
+    pub fn update<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        let result = self.value.with_mut(f);
+        self.broadcast.send(());
+        result
+    }
+
     /// Calls a closure with a borrow of the current value
     /// not tracked by the current context
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R { self.value.with(f) }
@@ -83,5 +95,35 @@ where T: Clone + Send + Sync + 'static
             listener(current_value);
         }));
         SubscriptionGuard::new(subscription)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[test]
+    fn test_update_mutates_in_place_and_notifies() {
+        let signal = Mut::new(vec![1, 2]);
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_clone = seen.clone();
+        let cell = signal.get_readcell();
+        // Reading during the callback would deadlock if update still held the
+        // write lock while notifying
+        let _guard = signal.listen(Arc::new(move |_| {
+            seen_clone.lock().unwrap().push(cell.value());
+        }));
+
+        let len = signal.update(|v| {
+            v.push(3);
+            v.len()
+        });
+
+        assert_eq!(len, 3);
+        assert_eq!(signal.value(), vec![1, 2, 3]);
+        // Fired exactly once, and the listener observed the updated value
+        assert_eq!(*seen.lock().unwrap(), vec![vec![1, 2, 3]]);
     }
 }

--- a/signals/src/value.rs
+++ b/signals/src/value.rs
@@ -26,6 +26,12 @@ impl<T> ValueCell<T> {
         let guard = self.0.read().unwrap();
         f(&*guard)
     }
+    /// Calls a closure with a mutable borrow of the current value.
+    /// The write lock is held only for the duration of the closure.
+    pub fn with_mut<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        let mut guard = self.0.write().unwrap();
+        f(&mut *guard)
+    }
     #[allow(unused)]
     pub fn set_with<R>(&self, value: T, f: impl Fn(&T) -> R) -> R {
         let mut current = self.0.write().unwrap();


### PR DESCRIPTION
## What this changes

Three ankurah-signals additions for dessim (the greymatter warehouse simulator), which is adopting the crate as its reactive layer:

- An opt-in `deterministic` feature that swaps the broadcast listener map from HashMap to BTreeMap, so listeners fire in subscription order. dessim is a deterministic discrete-event simulator and cannot have simulation decisions riding on a dispatch order that varies run to run. Default builds are unchanged.
- `Mut::update(|v| ...)`: mutate in place under the write lock, then notify. The lock is released before the broadcast, so listeners can re-read safely, and it notifies even when the closure changes nothing. Turns `state.write().unwrap()` call sites into `state.update(...)` with no notify call to forget.
- `wait_value`/`wait_for` had a lost-wakeup window: they checked the value, then subscribed, so a `set()` landing in between was missed. They now fast-path the already-satisfied case, then subscribe and re-check before waiting.

Tested with and without the feature. A backport PR to release/0.9 follows.